### PR TITLE
Mongolike mixin

### DIFF
--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -118,18 +118,23 @@ class Mongolike(object):
         return self.collection.find(filter=criteria, projection=properties,
                                     **kwargs)
 
-    def distinct(self, key, criteria=None, **kwargs):
+    def distinct(self, key, criteria=None, all_exist=False, **kwargs):
         """
-        Function get to get
+        Function get to get all distinct values of a certain key in
+        a mongolike store.  May take a single key or a list of keys
+
         Args:
             key (mongolike key or list of mongolike keys): key or keys
                 for which to find distinct values or sets of values.
-            criteria (filter criteria): criteria for filter 
+            criteria (filter criteria): criteria for filter
+            all_exist (bool): whether to ensure all keys in list exist
+                in each document
             **kwargs (kwargs): kwargs corresponding to collection.distinct
         """
         if isinstance(key, list):
             agg_pipeline = [{"$match": criteria}] if criteria else []
-
+            if all_exist:
+                agg_pipeline=[{"$match": {k: {"$exists": True} for k in key}}]
             # use string ints as keys and replace later to avoid bug where periods
             # can't be in group keys, then reconstruct after
             group_op = {"$group": {"_id": {str(n): "${}".format(k) for n, k in enumerate(key)}}}

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -39,6 +39,7 @@ class TestMongoStore(unittest.TestCase):
         self.assertTrue(len(ad_distinct), 3)
         self.assertTrue({"a": 4, "d": 6} in ad_distinct)
         self.assertTrue({"a": 1} in ad_distinct)
+        self.assertEqual(len(self.mongostore.distinct(["a", "f"])), 2)
 
         self.mongostore.update([{"e": 6, "d": 4}],key="e")
         self.assertEqual(self.mongostore.query(

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -40,6 +40,7 @@ class TestMongoStore(unittest.TestCase):
         self.assertTrue({"a": 4, "d": 6} in ad_distinct)
         self.assertTrue({"a": 1} in ad_distinct)
         self.assertEqual(len(self.mongostore.distinct(["a", "f"])), 2)
+        self.mongostore.distinct(["d", "e"], {"a": 4})
 
         self.mongostore.update([{"e": 6, "d": 4}],key="e")
         self.assertEqual(self.mongostore.query(

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -32,6 +32,13 @@ class TestMongoStore(unittest.TestCase):
 
         self.mongostore.collection.insert({"a": 4, "d": 5, "e": 6})
         self.assertEqual(self.mongostore.distinct("a"), [1, 4])
+        # Test list distinct functionality
+        self.mongostore.collection.insert({"a": 4, "d": 6, "e": 7})
+        self.mongostore.collection.insert({"a": 4, "d": 6})
+        ad_distinct = self.mongostore.distinct(["a", "d"])
+        self.assertTrue(len(ad_distinct), 3)
+        self.assertTrue({"a": 4, "d": 6} in ad_distinct)
+        self.assertTrue({"a": 1} in ad_distinct)
 
         self.mongostore.update([{"e": 6, "d": 4}],key="e")
         self.assertEqual(self.mongostore.query(

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -47,7 +47,8 @@ class TestMongoStore(unittest.TestCase):
         self.assertTrue({"a": 1} in ad_distinct)
         self.assertEqual(len(self.mongostore.distinct(["a", "f"])), 3)
         self.assertEqual(len(self.mongostore.distinct(["d", "e"], {"a": 4})), 2)
-
+        all_exist = self.mongostore.distinct(["a", "b"], all_exist=True)
+        self.assertEqual(len(all_exist), 1)
 
     def test_from_db_file(self):
         ms = MongoStore.from_db_file(os.path.join(db_dir, "db.json"))


### PR DESCRIPTION
A couple of things contained here.  Wanted to do a PR to inform and get any feedback, but this should be completely backwards-compatible.

* Mongolike mixin class that attempts to mitigate code duplication between MongoStore and MemoryStore.  Shared methods that are identical (e. g. query, distinct, ensure_index) are moved here.
* Distinct can now take list arguments, which returns a list of documents with unique combinations of key-value _sets_.  For example, distinct(["spacegroup.number", "formula_pretty"]) would return a list of dictionaries that each look like {"spacegroup.number": SG_NUM, "formula_pretty": FORMULA}.  Can also provide an "all_exists" boolean to ensure that all keys exist.  I've defaulted all_exists to False, but it might be better off True if that's the more common use case.
* bunch of updated docstrings