### PR TITLE
Rename Schema to Validator

### DIFF
--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -32,7 +32,7 @@ class Store(MSONable, metaclass=ABCMeta):
         self.lu_field = lu_field
         self.lu_type = lu_type
         self.lu_func = LU_KEY_ISOFORMAT if lu_type == "isoformat" else (identity, identity)
-        self.schema = None
+        self.validator = None
 
     @property
     @abstractmethod

--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -206,6 +206,9 @@ class Mongolike(object):
 
         bulk = self.collection.initialize_ordered_bulk_op()
 
+        # filter out None values
+        docs = [doc for doc in docs if doc]
+
         for d in docs:
 
             d = jsanitize(d, allow_bson=True)

--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -212,10 +212,10 @@ class Mongolike(object):
 
             # document-level validation is optional
             validates = True
-            if self.schema:
-                validates = self.schema.is_valid(d)
+            if self.validator:
+                validates = self.validator.is_valid(d)
                 if not validates:
-                    if self.schema.strict:
+                    if self.validator.strict:
                         raise ValueError('Document failed to validate: {}'.format(d))
                     else:
                         self.logger.error('Document failed to validate: {}'.format(d))

--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -206,9 +206,6 @@ class Mongolike(object):
 
         bulk = self.collection.initialize_ordered_bulk_op()
 
-        # filter out None values
-        docs = [doc for doc in docs if doc]
-
         for d in docs:
 
             d = jsanitize(d, allow_bson=True)

--- a/maggma/tests/test_validator.py
+++ b/maggma/tests/test_validator.py
@@ -3,14 +3,26 @@ from maggma.validator import StandardValidator
 from monty.json import MSONable
 
 class ValidatorTests(unittest.TestCase):
+    """
+    Tests for Validators.
+    """
 
     def test_standardvalidator(self):
+        """
+        Test the StandardValidator class.
+        """
 
         class LatticeMock(MSONable):
+            """
+            A sample MSONable object, just for testing.
+            """
             def __init__(self, a):
                 self.a = a
 
         class SampleValidator(StandardValidator):
+            """
+            A sample validator, just for testing.
+            """
 
             @property
             def schema(self):

--- a/maggma/tests/test_validator.py
+++ b/maggma/tests/test_validator.py
@@ -1,10 +1,10 @@
 import unittest
-from maggma.schema import StandardSchema
+from maggma.validator import StandardValidator
 from monty.json import MSONable
 
-class SchemaTests(unittest.TestCase):
+class ValidatorTests(unittest.TestCase):
 
-    def test_standardschema(self):
+    def test_standardvalidator(self):
 
         class LatticeMock(MSONable):
             def __init__(self, a):

--- a/maggma/tests/test_validator.py
+++ b/maggma/tests/test_validator.py
@@ -10,7 +10,7 @@ class ValidatorTests(unittest.TestCase):
             def __init__(self, a):
                 self.a = a
 
-        class SampleSchema(StandardSchema):
+        class SampleValidator(StandardValidator):
             @property
             def schema(self):
                 return {
@@ -26,7 +26,7 @@ class ValidatorTests(unittest.TestCase):
             def msonable_keypaths(self):
                 return {"lattice": LatticeMock}
 
-        schema = SampleSchema()
+        schema = SampleValidator()
 
         lattice = LatticeMock(5)
 

--- a/maggma/tests/test_validator.py
+++ b/maggma/tests/test_validator.py
@@ -11,6 +11,7 @@ class ValidatorTests(unittest.TestCase):
                 self.a = a
 
         class SampleValidator(StandardValidator):
+
             @property
             def schema(self):
                 return {
@@ -22,11 +23,12 @@ class ValidatorTests(unittest.TestCase):
                         },
                     "required": ["task_id", "successful"]
                 }
+
             @property
             def msonable_keypaths(self):
                 return {"lattice": LatticeMock}
 
-        schema = SampleValidator()
+        validator = SampleValidator()
 
         lattice = LatticeMock(5)
 
@@ -53,7 +55,7 @@ class ValidatorTests(unittest.TestCase):
             'lattice': lattice.as_dict()
         }
 
-        self.assertTrue(schema.is_valid(valid_doc))
-        self.assertFalse(schema.is_valid(invalid_doc_msonable))
-        self.assertFalse(schema.is_valid(invalid_doc_missing_key))
-        self.assertFalse(schema.is_valid(invalid_doc_wrong_type))
+        self.assertTrue(validator.is_valid(valid_doc))
+        self.assertFalse(validator.is_valid(invalid_doc_msonable))
+        self.assertFalse(validator.is_valid(invalid_doc_missing_key))
+        self.assertFalse(validator.is_valid(invalid_doc_wrong_type))

--- a/maggma/validator.py
+++ b/maggma/validator.py
@@ -1,12 +1,12 @@
-from abc import ABC, abstractmethod
-from jsonschema import validate, ValidationError
-import pydash
-
 """
 Validator class for document-level validation on Stores. Attach an instance
 of a Validator subclass to a Store .schema variable to enable validation on
 that Store.
 """
+
+from abc import ABC, abstractmethod
+from jsonschema import validate, ValidationError
+import pydash
 
 class Validator(ABC):
     """

--- a/maggma/validator.py
+++ b/maggma/validator.py
@@ -3,22 +3,22 @@ from jsonschema import validate, ValidationError
 import pydash
 
 """
-Schema class for document-level validation on Stores. Attach an instance
-of a Schema subclass to a Store .schema variable to enable validation on
+Validator class for document-level validation on Stores. Attach an instance
+of a Validator subclass to a Store .schema variable to enable validation on
 that Store.
 """
 
-class Schema(ABC):
+class Validator(ABC):
     """
     A generic class to perform document-level validation on Stores.
-    Attach a Schema to a Store during initialization, any all documents
+    Attach a Validator to a Store during initialization, any all documents
     added to the Store will call .validate_doc() before being added.
     """
 
     def init(self, strict=False):
         """
         Args:
-            strict (bool): Informs Store how to treat Schema: if
+            strict (bool): Informs Store how to treat Validator: if
             True, will cause build to fail if invalid document
             is found and raise a ValueError, if False will continue
             build but log an error message. In both cases, invalid
@@ -35,10 +35,10 @@ class Schema(ABC):
         return NotImplementedError
 
 
-class StandardSchema(Schema):
+class StandardValidator(Validator):
     """
-    A standard Schema, which allows document validation against a
-    JSON schema, and also can check that specified keys, if present,
+    A standard Validator, which allows document validation against a
+    provided JSON schema, and also can check that specified keys, if present,
     are MSONable (that is, a Python object can be reconstructed).
 
     To use, subclass StandardSchema and with your own `schema`


### PR DESCRIPTION
Reasons:

1) 'Validator' is a more accurate description of what it does.
2) Schemas sound scary.
3) You can write a valid validator without writing a schema (though a formal schema is encouraged for the StandardValidator).