### PR TITLE
groupby change for memory/jsonstore

### DIFF
--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -346,6 +346,12 @@ class MemoryStore(Mongolike, Store):
 
     def groupby(self, keys, properties=None, criteria=None,
                 allow_disk_use=True):
+        """
+        This is a placeholder for groupby for memorystores,
+        current version of mongomock do not allow for standard
+        aggregation methods, so this method currently raises
+        a NotImplementedError
+        """
         raise NotImplementedError("groupby not available for {}"
                                   "due to mongomock incompatibility".format(
             self.__class__))

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -101,6 +101,9 @@ class TestMemoryStore(unittest.TestCase):
         self.assertIsInstance(self.memstore.collection,
                               mongomock.collection.Collection)
 
+    def test_groupby(self):
+        self.assertRaises( NotImplementedError, self.memstore.groupby, "a")
+
 
 class TestJsonStore(unittest.TestCase):
 


### PR DESCRIPTION
mongomock doesn't appear to cleanly support aggregation, so this moves groupby into MongoStore, rather than Mongolike, and adds a notImplementedError into the groupby functions on MemoryStore (and JSONStore).