### PR TITLE
GridFS Store update: use metadata field, update removes old file(s)

### DIFF
--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -526,7 +526,7 @@ class GridFSStore(Store):
         "_id", "length", "chunkSize", "uploadDate", "md5", "filename",
         "contentType", "aliases", "metadata")
 
-    def __init__(self, database, collection_name, host="localhost", port=27017, username="", password="", **kwargs):
+    def __init__(self, database, collection_name, host="localhost", port=27017, username="", password="",compression=False,**kwargs):
 
         self.database = database
         self.collection_name = collection_name
@@ -535,8 +535,10 @@ class GridFSStore(Store):
         self.username = username
         self.password = password
         self._collection = None
+        self.compression = compression
         self.kwargs = kwargs
         self.meta_keys = set()
+
 
         if "key" not in kwargs:
             kwargs["key"] = "_oid"
@@ -697,7 +699,7 @@ class GridFSStore(Store):
             self.meta_keys |= key
             return self._files_collection.create_index("metadata.{}".format(key), unique=unique, background=True)
 
-    def update(self, docs, update_lu=True, key=None, compression=False):
+    def update(self, docs, update_lu=True, key=None):
         """
         Function to update associated MongoStore collection.
 
@@ -723,7 +725,7 @@ class GridFSStore(Store):
             metadata.update(search_doc)
 
             data = json.dumps(jsanitize(d)).encode("UTF-8")
-            if compression:
+            if self.compression:
                 data = zlib.compress(data)
                 metadata["compression"] = "zlib"
 

--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -559,6 +559,11 @@ class GridFSStore(Store):
 
     @classmethod
     def transform_criteria(cls, criteria):
+        """
+        Allow client to not need to prepend 'metadata.' to query fields.
+        Args:
+            criteria (dict): Query criteria
+        """
         for field in criteria:
             if (field not in cls.files_collection_fields
                     and not field.startswith('metadata.')):

--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -705,7 +705,7 @@ class GridFSStore(Store):
         Args:
             docs ([dict]): list of documents
             update_lu (bool) : Updat the last_updated field or not
-            key (list or str): list or str of important parameters  
+            key (list or str): list or str of important parameters
         """
         if isinstance(key, str):
             key = [key]

--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -535,6 +535,7 @@ class GridFSStore(Store):
         self.password = password
         self._collection = None
         self.kwargs = kwargs
+        self.meta_keys = set()
 
         if "key" not in kwargs:
             kwargs["key"] = "_oid"
@@ -677,7 +678,12 @@ class GridFSStore(Store):
         """
         Wrapper for pymongo.Collection.ensure_index for the files collection
         """
-        return self._files_collection.create_index(key, unique=unique, background=True)
+        if key in self.files_collection_fields:
+            return self._files_collection.create_index(key, unique=unique, background=True)
+        else:
+            # Store this key to put into metadata collection
+            self.meta_keys |= key
+            return self._files_collection.create_index("metadata.{}".format(key), unique=unique, background=True)
 
     def update(self, docs, update_lu=True, key=None):
         """

--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -586,12 +586,16 @@ class GridFSStore(Store):
             self.transform_criteria(criteria)
         for f in self.collection.find(filter=criteria, **kwargs):
             data = f.read()
-            metadata = f.metadata
+            
+            metadata = f.metadata 
+            if metadata.get("compression","") == "zlib":
+                data = zlib.decompress(data).decode("UTF-8")
+
             try:
                 data = json.loads(data)
             except:
                 pass
-            yield dict(data=data, metadata=metadata)
+            yield data
 
     def query_one(self, properties=None, criteria=None, **kwargs):
         """

--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -30,7 +30,7 @@ class Store(MSONable, metaclass=ABCMeta):
     Defines the interface for all data going in and out of a Builder
     """
 
-    def __init__(self, key="task_id", lu_field='last_updated', lu_type="datetime", validator = None):
+    def __init__(self, key="task_id", lu_field='last_updated', lu_type="datetime", validator=None):
         """
         Args:
             key (str): master key to index on
@@ -526,7 +526,7 @@ class GridFSStore(Store):
         "_id", "length", "chunkSize", "uploadDate", "md5", "filename",
         "contentType", "aliases", "metadata")
 
-    def __init__(self, database, collection_name, host="localhost", port=27017, username="", password="",compression=False,**kwargs):
+    def __init__(self, database, collection_name, host="localhost", port=27017, username="", password="", compression=False, **kwargs):
 
         self.database = database
         self.collection_name = collection_name
@@ -538,7 +538,6 @@ class GridFSStore(Store):
         self.compression = compression
         self.kwargs = kwargs
         self.meta_keys = set()
-
 
         if "key" not in kwargs:
             kwargs["key"] = "_oid"
@@ -590,9 +589,9 @@ class GridFSStore(Store):
             self.transform_criteria(criteria)
         for f in self.collection.find(filter=criteria, **kwargs):
             data = f.read()
-            
-            metadata = f.metadata 
-            if metadata.get("compression","") == "zlib":
+
+            metadata = f.metadata
+            if metadata.get("compression", "") == "zlib":
                 data = zlib.decompress(data).decode("UTF-8")
 
             try:
@@ -708,7 +707,7 @@ class GridFSStore(Store):
             update_lu (bool) : Updat the last_updated field or not
             key (list or str): list or str of important parameters  
         """
-        if isinstance(key,str):
+        if isinstance(key, str):
             key = [key]
         elif not key:
             key = [self.key]
@@ -734,7 +733,7 @@ class GridFSStore(Store):
 
             # Cleans up old gridfs entries
             for fdoc in (self._files_collection.find(search_doc, ["_id"])
-                    .sort("uploadDate", -1).skip(1)):
+                         .sort("uploadDate", -1).skip(1)):
                 self.collection.delete(fdoc["_id"])
 
     def close(self):

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -17,6 +17,7 @@ test_dir = os.path.abspath(os.path.join(module_dir, "..", "..", "test_files", "t
 
 
 class TestMongoStore(unittest.TestCase):
+
     def setUp(self):
         self.mongostore = MongoStore("maggma_test", "test")
         self.mongostore.connect()
@@ -110,6 +111,7 @@ class TestMongoStore(unittest.TestCase):
 
 
 class TestMemoryStore(unittest.TestCase):
+
     def setUp(self):
         self.memstore = MemoryStore()
 
@@ -151,6 +153,7 @@ class TestMemoryStore(unittest.TestCase):
 
 
 class TestJsonStore(unittest.TestCase):
+
     def test(self):
         files = []
         for f in ["a.json", "b.json"]:
@@ -166,6 +169,7 @@ class TestJsonStore(unittest.TestCase):
 
 
 class TestGridFSStore(unittest.TestCase):
+
     def setUp(self):
         self.gStore = GridFSStore("maggma_test", "test", key="task_id")
         self.gStore.connect()
@@ -184,7 +188,7 @@ class TestGridFSStore(unittest.TestCase):
         nptu.assert_almost_equal(self.gStore.query_one({"task_id": "mp-1"})["data"], data2, 7)
 
         # Test storing compressed data
-        self.gStore = GridFSStore("maggma_test", "test", key="task_id",compression=True)
+        self.gStore = GridFSStore("maggma_test", "test", key="task_id", compression=True)
         self.gStore.connect()
         self.gStore.update([{"task_id": "mp-1", "data": data1}])
         self.assertTrue(self.gStore._files_collection.find_one({"metadata.compression": "zlib"}))

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -176,11 +176,16 @@ class TestGridFSStore(unittest.TestCase):
 
     def test_update(self):
         data1 = np.random.rand(256)
+        data2 = np.random.rand(256)
         self.gStore.update([{"task_id": "mp-1", "data": data1}])
         self.assertTrue(self.gStore._files_collection.find_one(
             {"metadata.task_id": "mp-1"}))
         self.assertTrue(self.gStore.lu_field
                         in self.gStore.query_one()["metadata"])
+        self.gStore.update([{"task_id": "mp-1", "data": data2}])
+        self.assertEqual(len(list(self.gStore.query({"task_id": "mp-1"}))), 1)
+        nptu.assert_almost_equal(
+            self.gStore.query_one({"task_id": "mp-1"})["data"], data2, 7)
 
     def test_query(self):
         data1 = np.random.rand(256)

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -184,7 +184,9 @@ class TestGridFSStore(unittest.TestCase):
         nptu.assert_almost_equal(self.gStore.query_one({"task_id": "mp-1"})["data"], data2, 7)
 
         # Test storing compressed data
-        self.gStore.update([{"task_id": "mp-1", "data": data1}], compression=True)
+        self.gStore = GridFSStore("maggma_test", "test", key="task_id",compression=True)
+        self.gStore.connect()
+        self.gStore.update([{"task_id": "mp-1", "data": data1}])
         self.assertTrue(self.gStore._files_collection.find_one({"metadata.compression": "zlib"}))
         nptu.assert_almost_equal(self.gStore.query_one({"task_id": "mp-1"})["data"], data1, 7)
 


### PR DESCRIPTION
* Change GridFS store to use "metadata" field as per official spec
* Remove old files matching GridFS store key on update