### PR TITLE
Change update_targets log level from debug to exception

### DIFF
--- a/maggma/runner.py
+++ b/maggma/runner.py
@@ -258,7 +258,7 @@ class MPIProcessor(BaseProcessor):
                     self.update_pbar.update(len(self.data))
                     self.data.clear()
                 except Exception as e:
-                    self.logger.debug("Problem in updating targets in builder run: {}".format(e))
+                    self.logger.exception("Problem in updating targets in builder run: {}".format(e))
 
 
 class MultiprocProcessor(BaseProcessor):

--- a/maggma/runner.py
+++ b/maggma/runner.py
@@ -392,7 +392,7 @@ class MultiprocProcessor(BaseProcessor):
                         self.update_pbar.update(len(self.data))
                         self.data.clear()
                 except Exception as e:
-                    self.logger.debug("Problem in updating targets in builder run: {}".format(e))
+                    self.logger.exception("Problem in updating targets in builder run: {}".format(e))
 
 
 class Runner(MSONable):


### PR DESCRIPTION
(imo) maggma uses logger.debug slightly too liberally, many times I've had exceptions caught silently, leaving builders in a state where they hang indefinitely