### PR TITLE
Can update pyyaml req?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pymongo==3.7.2
 mongomock==3.13.0
 monty==1.0.3
 smoqe==0.1.3
-PyYAML==3.12
+pyyaml>=4.2b1
 pydash==4.7.3
 jsonschema==2.6.0
 hvac==0.3.0


### PR DESCRIPTION
As per https://github.com/materialsproject/maggma/network/alert/requirements.txt/pyyaml/open.

Where do we use pyyaml? Can we remove the req?