### PR TITLE
fix GridFSStore

### DIFF
--- a/maggma/stores.py
+++ b/maggma/stores.py
@@ -811,7 +811,7 @@ class GridFSStore(Store):
 
         return self.collection.aggregate(pipeline, allowDiskUse=allow_disk_use)
 
-    def ensure_index(self, key, unique=False):
+    def ensure_index(self, key, unique=False, **kwargs):
         """
         Wrapper for pymongo.Collection.ensure_index for the files collection
         """
@@ -822,11 +822,11 @@ class GridFSStore(Store):
         if "background" not in kwargs:
             kwargs["background"] = True
 
-        if confirm_field_index(self.collection, key):
+        if confirm_field_index(self._files_collection, key):
             return True
         else:
             try:
-                self.collection.create_index(key, unique=unique, **kwargs)
+                self._files_collection.create_index(key, unique=unique, **kwargs)
                 return True
             except:
                 return False

--- a/maggma/tests/test_stores.py
+++ b/maggma/tests/test_stores.py
@@ -112,7 +112,7 @@ class TestMongoStore(unittest.TestCase):
 
     def test_last_updated(self):
         self.assertEqual(self.mongostore.last_updated, datetime.min)
-        tic = datetime.now()
+        tic = datetime.utcnow()
         self.mongostore.collection.insert_one({self.mongostore.key: 1, "a": 1})
         with self.assertRaises(StoreError) as cm:
             self.mongostore.last_updated


### PR DESCRIPTION
A few bugfix

* In the `ensure_index` method of the `GridFSStore` kwargs is used but not defined.
* In `GridFSStore` the default collection does not support indexes. It is possible to put them on the files collection
* in one of the tests the `tic` is time-zone dependent. It fails locally for me. Replacing `now` with `utcnow` as used in the `Store`