### PR TITLE
Add count to maggma store

### DIFF
--- a/src/maggma/core/store.py
+++ b/src/maggma/core/store.py
@@ -97,6 +97,15 @@ class Store(MSONable, metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def count(self, criteria: Optional[Dict] = None) -> int:
+        """
+        Counts the number of documents matching the query criteria
+
+        Args:
+            criteria: PyMongo filter for documents to count in
+        """
+
+    @abstractmethod
     def query(
         self,
         criteria: Optional[Dict] = None,

--- a/src/maggma/stores/advanced_stores.py
+++ b/src/maggma/stores/advanced_stores.py
@@ -219,6 +219,17 @@ class AliasingStore(Store):
         """
         return self.store.name
 
+    def count(self, criteria: Optional[Dict] = None) -> int:
+        """
+        Counts the number of documents matching the query criteria
+
+        Args:
+            criteria: PyMongo filter for documents to count in
+        """
+        criteria = criteria if criteria else {}
+        lazy_substitute(criteria, self.reverse_aliases)
+        return self.store.count(criteria)
+
     def query(
         self,
         criteria: Optional[Dict] = None,
@@ -412,6 +423,18 @@ class SandboxStore(Store):
             return {
                 "$or": [{"sbxn": {"$in": [self.sandbox]}}, {"sbxn": {"$exists": False}}]
             }
+
+    def count(self, criteria: Optional[Dict] = None) -> int:
+        """
+        Counts the number of documents matching the query criteria
+
+        Args:
+            criteria: PyMongo filter for documents to count in
+        """
+        criteria = (
+            dict(**criteria, **self.sbx_criteria) if criteria else self.sbx_criteria
+        )
+        return self.store.count(criteria=criteria)
 
     def query(
         self,

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -88,6 +88,16 @@ class AmazonS3Store(Store):
         # For now returns the index collection since that is what we would "search" on
         return self.index
 
+    def count(self, criteria: Optional[Dict] = None) -> int:
+        """
+        Counts the number of documents matching the query criteria
+
+        Args:
+            criteria: PyMongo filter for documents to count in
+        """
+
+        return self.index.count(criteria)
+
     def query(
         self,
         criteria: Optional[Dict] = None,

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -134,6 +134,18 @@ class GridFSStore(Store):
 
         return new_criteria
 
+    def count(self, criteria: Optional[Dict] = None) -> int:
+        """
+        Counts the number of documents matching the query criteria
+
+        Args:
+            criteria: PyMongo filter for documents to count in
+        """
+        if isinstance(criteria, dict):
+            criteria = self.transform_criteria(criteria)
+
+        return self._files_store.count(criteria)
+
     def query(
         self,
         criteria: Optional[Dict] = None,

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -171,6 +171,17 @@ class MongoStore(Store):
             raise StoreError("Must connect Mongo-like store before attemping to use it")
         return self._collection
 
+    def count(self, criteria: Optional[Dict] = None) -> int:
+        """
+        Counts the number of documents matching the query criteria
+
+        Args:
+            criteria: PyMongo filter for documents to count in
+        """
+
+        criteria = criteria if criteria else {}
+        return self._collection.count_documents(filter=criteria)
+
     def query(
         self,
         criteria: Optional[Dict] = None,

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -12,6 +12,7 @@ def mongostore():
     store = MongoStore("maggma_test", "test")
     store.connect()
     yield store
+    store.remove_docs({})
     store._collection.drop()
 
 
@@ -20,6 +21,7 @@ def reporting_store():
     store = MongoStore("maggma_test", "reporting")
     store.connect()
     yield store
+    store.remove_docs({})
     store._collection.drop()
 
 

--- a/tests/stores/test_advanced_stores.py
+++ b/tests/stores/test_advanced_stores.py
@@ -213,6 +213,13 @@ def alias_store():
     return alias_store
 
 
+def test_alias_count(alias_store):
+
+    d = [{"b": 1}, {"e": 2}, {"g": {"h": 3}}]
+    alias_store.store._collection.insert_many(d)
+    assert alias_store.count({"a": 1}) == 1
+
+
 def test_aliasing_query(alias_store):
 
     d = [{"b": 1}, {"e": 2}, {"g": {"h": 3}}]
@@ -298,6 +305,14 @@ def sandbox_store():
     store = SandboxStore(memstore, sandbox="test")
     store.connect()
     return store
+
+
+def test_sandbox_count(sandbox_store):
+    sandbox_store.collection.insert_one({"a": 1, "b": 2, "c": 3})
+    assert sandbox_store.count({"a": 1}) == 1
+
+    sandbox_store.collection.insert_one({"a": 1, "b": 3, "sbxn": ["test"]})
+    assert sandbox_store.count({"a": 1}) == 2
 
 
 def test_sandbox_query(sandbox_store):

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -39,6 +39,11 @@ def s3store():
         yield store
 
 
+def test_count(s3store):
+    assert s3store.count() == 2
+    assert s3store.count({"task_id": "mp-3"}) == 1
+
+
 def test_qeuery(s3store):
     assert s3store.query_one(criteria={"task_id": "mp-2"}) is None
     assert s3store.query_one(criteria={"task_id": "mp-1"})["data"] == "asd"

--- a/tests/stores/test_compound_stores.py
+++ b/tests/stores/test_compound_stores.py
@@ -62,6 +62,11 @@ def jointstore(jointstore_test1, jointstore_test2):
     return store
 
 
+def test_joint_store_count(jointstore):
+    assert jointstore.count() == 10
+    assert jointstore.count({"test2.category2": {"$exists": 1}}) == 5
+
+
 def test_joint_store_query(jointstore):
     # Test query all
     docs = list(jointstore.query())
@@ -191,6 +196,12 @@ def test_concat_store_distinct(concat_store):
 def test_concat_store_groupby(concat_store):
     assert len(list(concat_store.groupby("index"))) == 4
     assert len(list(concat_store.groupby("task_id"))) == 40
+
+
+def test_concat_store_count(concat_store):
+
+    assert concat_store.count() == 40
+    assert concat_store.count({"prop": "3"}) == 4
 
 
 def test_concat_store_query(concat_store):

--- a/tests/stores/test_gridfs.py
+++ b/tests/stores/test_gridfs.py
@@ -77,6 +77,24 @@ def test_remove(gridfsstore):
     assert gridfsstore.query_one(criteria={"task_id": "mp-2"})
 
 
+def test_count(gridfsstore):
+    data1 = np.random.rand(256)
+    data2 = np.random.rand(256)
+    tic = datetime(2018, 4, 12, 16)
+    gridfsstore.update(
+        [{"task_id": "mp-1", "data": data1, gridfsstore.last_updated_field: tic}]
+    )
+
+    assert gridfsstore.count() == 1
+
+    gridfsstore.update(
+        [{"task_id": "mp-2", "data": data2, gridfsstore.last_updated_field: tic}]
+    )
+
+    assert gridfsstore.count() == 2
+    assert gridfsstore.count({"task_id": "mp-2"}) == 1
+
+
 def test_query(gridfsstore):
     data1 = np.random.rand(256)
     data2 = np.random.rand(256)

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -47,6 +47,14 @@ def test_mongostore_query(mongostore):
     assert mongostore.query_one(properties=["c"])["c"] == 3
 
 
+def test_mongostore_count(mongostore):
+    mongostore._collection.insert_one({"a": 1, "b": 2, "c": 3})
+    assert mongostore.count() == 1
+    mongostore._collection.insert_one({"aa": 1, "b": 2, "c": 3})
+    assert mongostore.count() == 2
+    assert mongostore.count({"a": 1}) == 1
+
+
 def test_mongostore_distinct(mongostore):
     mongostore._collection.insert_one({"a": 1, "b": 2, "c": 3})
     mongostore._collection.insert_one({"a": 4, "d": 5, "e": 6, "g": {"h": 1}})


### PR DESCRIPTION
Adds the ability to count the number of documents matching a query to the `Store` interface and implements this for all existing stores. 