### PR TITLE
Update distinct to be more like mongo distinct

### DIFF
--- a/src/maggma/core/store.py
+++ b/src/maggma/core/store.py
@@ -205,33 +205,21 @@ class Store(MSONable, metaclass=ABCMeta):
         )
 
     def distinct(
-        self,
-        field: Union[List[str], str],
-        criteria: Optional[Dict] = None,
-        all_exist: bool = False,
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
     ) -> List:
         """
-        Get all distinct values for a field(s)
-        For a single field, this returns a list of values
-        For multiple fields, this return a list of of dictionaries for each unique combination
+        Get all distinct values for a field
 
         Args:
             field: the field(s) to get distinct values for
             criteria: PyMongo filter for documents to search in
-            all_exist: ensure all fields exist for the distinct set
         """
-        field = field if isinstance(field, list) else [field]
-
         criteria = criteria or {}
 
-        if all_exist:
-            criteria.update({f: {"$exists": 1} for f in field if f not in criteria})
         results = [
             key for key, _ in self.groupby(field, properties=field, criteria=criteria)
         ]
-        # Flatten out results if searching for a single field
-        if len(field) == 1:
-            results = [get(r, field[0]) for r in results]
+        results = [get(r, field) for r in results]
         return results
 
     @property

--- a/src/maggma/core/store.py
+++ b/src/maggma/core/store.py
@@ -217,7 +217,7 @@ class Store(MSONable, metaclass=ABCMeta):
         criteria = criteria or {}
 
         results = [
-            key for key, _ in self.groupby(field, properties=field, criteria=criteria)
+            key for key, _ in self.groupby(field, properties=[field], criteria=criteria)
         ]
         results = [get(r, field) for r in results]
         return results

--- a/src/maggma/stores/advanced_stores.py
+++ b/src/maggma/stores/advanced_stores.py
@@ -76,6 +76,10 @@ class MongograntStore(MongoStore):
             db = client.db(self.mongogrant_spec)
             self._collection = db[self.collection_name]
 
+    @property
+    def name(self):
+        return f"mgrant://{self.mongogrant_spec}/{self.collection_name}"
+
     def __hash__(self):
         return hash(
             (self.mongogrant_spec, self.collection_name, self.last_updated_field)

--- a/src/maggma/stores/advanced_stores.py
+++ b/src/maggma/stores/advanced_stores.py
@@ -262,25 +262,20 @@ class AliasingStore(Store):
             yield d
 
     def distinct(
-        self,
-        field: Union[List[str], str],
-        criteria: Optional[Dict] = None,
-        all_exist: bool = False,
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
     ) -> List:
         """
-        Get all distinct values for a key
+        Get all distinct values for a field
 
         Args:
             field: the field(s) to get distinct values for
             criteria: PyMongo filter for documents to search in
-            all_exist: ensure all fields exist for the distinct set
         """
         criteria = criteria if criteria else {}
         lazy_substitute(criteria, self.reverse_aliases)
-        field = field if isinstance(field, list) else [field]
+
         # substitute forward
-        field = [self.aliases[f] for f in field]
-        return self.store.distinct(field, criteria=criteria)
+        return self.store.distinct(self.aliases[field], criteria=criteria)
 
     def groupby(
         self,

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -139,23 +139,17 @@ class AmazonS3Store(Store):
             yield json.loads(data)
 
     def distinct(
-        self,
-        field: Union[List[str], str],
-        criteria: Optional[Dict] = None,
-        all_exist: bool = False,
-    ) -> Union[List[Dict], List]:
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+    ) -> List:
         """
-        Get all distinct values for a field(s)
-        For a single field, this returns a list of values
-        For multiple fields, this return a list of of dictionaries for each unique combination
+        Get all distinct values for a field
 
         Args:
             field: the field(s) to get distinct values for
             criteria: PyMongo filter for documents to search in
-            all_exist: ensure all fields exist for the distinct set
         """
         # Index is a store so it should have its own distinct function
-        return self.index.distinct(field, criteria=criteria, all_exist=all_exist)
+        return self.index.distinct(field, criteria=criteria)
 
     def groupby(
         self,

--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -386,31 +386,20 @@ class ConcatStore(Store):
         raise NotImplementedError("No update method for ConcatStore")
 
     def distinct(
-        self,
-        field: Union[List[str], str],
-        criteria: Optional[Dict] = None,
-        all_exist: bool = False,
-    ) -> Union[List[Dict], List]:
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+    ) -> List:
         """
-        Get all distinct values for a field(s)
-        For a single field, this returns a list of values
-        For multiple fields, this return a list of of dictionaries for each unique combination
+        Get all distinct values for a field
 
         Args:
             field: the field(s) to get distinct values for
             criteria: PyMongo filter for documents to search in
-            all_exist: ensure all fields exist for the distinct set
         """
         distincts = []
         for store in self.stores:
-            distincts.extend(
-                store.distinct(field=field, criteria=criteria, all_exist=all_exist)
-            )
+            distincts.extend(store.distinct(field=field, criteria=criteria))
 
-        if isinstance(field, str):
-            return list(set(distincts))
-        else:
-            return [dict(s) for s in set(frozenset(d.items()) for d in distincts)]
+        return list(set(distincts))
 
     def ensure_index(self, key: str, unique: bool = False) -> bool:
         """

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -186,38 +186,29 @@ class GridFSStore(Store):
             yield data
 
     def distinct(
-        self,
-        field: Union[List[str], str],
-        criteria: Optional[Dict] = None,
-        all_exist: bool = False,
-    ) -> Union[List[Dict], List]:
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+    ) -> List:
         """
-        Function get to get all distinct values of a certain key in
-        a GridFs store.
-
+        Get all distinct values for a field
 
         Args:
-            field: key or keys
-                for which to find distinct values or sets of values.
-            criteria: criteria for filter
-            all_exist: whether to ensure all keys in list exist
-                in each document, defaults to False
+            field: the field(s) to get distinct values for
+            criteria: PyMongo filter for documents to search in
         """
         criteria = (
             self.transform_criteria(criteria)
             if isinstance(criteria, dict)
             else criteria
         )
-        field = [field] if not isinstance(field, list) else field
-        field = [
-            f"metadata.{k}"
-            if k not in self.files_collection_fields and not k.startswith("metadata.")
-            else k
-            for k in field
-        ]
-        return self._files_store.distinct(
-            field=field, criteria=criteria, all_exist=all_exist
+
+        field = (
+            f"metadata.{field}"
+            if field not in self.files_collection_fields
+            and not field.startswith("metadata.")
+            else field
         )
+
+        return self._files_store.distinct(field=field, criteria=criteria)
 
     def groupby(
         self,

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -96,6 +96,19 @@ class MongoStore(Store):
         kwargs.pop("aliases", None)
         return cls(**kwargs)
 
+    def distinct(
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+    ) -> List:
+        """
+        Get all distinct values for a field
+
+        Args:
+            field: the field(s) to get distinct values for
+            criteria: PyMongo filter for documents to search in
+        """
+        criteria = criteria or {}
+        return self._collection.distinct(field, criteria)
+
     def groupby(
         self,
         keys: Union[List[str], str],

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -63,22 +63,10 @@ def test_mongostore_distinct(mongostore):
     # Test list distinct functionality
     mongostore._collection.insert_one({"a": 4, "d": 6, "e": 7})
     mongostore._collection.insert_one({"a": 4, "d": 6, "g": {"h": 2}})
-    ad_distinct = mongostore.distinct(["a", "d"])
-    assert len(ad_distinct) == 3
-    assert {"a": 4, "d": 6} in ad_distinct
-    assert {"a": 1} in ad_distinct
-    assert len(mongostore.distinct(["d", "e"], {"a": 4})) == 3
-    all_exist = mongostore.distinct(["a", "b"], all_exist=True)
-    assert len(all_exist) == 1
-    all_exist2 = mongostore.distinct(["a", "e"], all_exist=True, criteria={"d": 6})
-    assert len(all_exist2) == 1
 
     # Test distinct subdocument functionality
     ghs = mongostore.distinct("g.h")
-    assert set(ghs) == {1, 2, None}
-    ghs_ds = mongostore.distinct(["d", "g.h"], all_exist=True)
-    assert {s["g"]["h"] for s in ghs_ds} == {1, 2}
-    assert {s["d"] for s in ghs_ds}, {5, 6}
+    assert set(ghs) == {1, 2}
 
 
 def test_mongostore_update(mongostore):


### PR DESCRIPTION
This PR updates `distinct` to be more like mongo's `distinct`. It primarily removes the multi-field distinct.