### PR TITLE
Fix issues with last_updated in MapBuilder

### DIFF
--- a/src/docs/getting_started/map_builder.md
+++ b/src/docs/getting_started/map_builder.md
@@ -34,7 +34,7 @@ Just like before we define a new class, but this time it should inherit from `Ma
                          projection=["a"],
                          delete_orphans=False,
                          timeout=10,
-                         store_process_timeout=True,
+                         store_process_time=True,
                          retry_failed=True,
                          **kwargs)
 ```
@@ -52,7 +52,7 @@ Finally let's get to the hard part which is running our function. We do this by 
 ``` python
 
     def unary_function(self,item):
-        return {"a": item["a"] * self.mulitplier}
+        return {"a": item["a"] * self.multiplier}
 
 ```
 

--- a/src/docs/getting_started/map_builder.md
+++ b/src/docs/getting_started/map_builder.md
@@ -29,6 +29,8 @@ Just like before we define a new class, but this time it should inherit from `Ma
         self.multiplier = multiplier
         self.kwargs = kwargs
 
+        kwargs = {k,v in kwargs.items() if k not in ["projection","delete_orphans","timeout","store_process_time","retry_failed"]}
+
         super().__init__(source=source,
                          target=target,
                          projection=["a"],

--- a/src/maggma/builders/map_builder.py
+++ b/src/maggma/builders/map_builder.py
@@ -163,7 +163,7 @@ class MapBuilder(Builder, metaclass=ABCMeta):
         out = {
             self.target.key: item[key],
             self.target.last_updated_field: self.source._lu_func[0](
-                item[last_updated_field]
+                item.get(last_updated_field, datetime.utcnow())
             ),
         }
 

--- a/src/maggma/core/store.py
+++ b/src/maggma/core/store.py
@@ -269,14 +269,18 @@ class Store(MSONable, metaclass=ABCMeta):
             # Get our current last_updated dates for each key value
             props = {self.key: 1, self.last_updated_field: 1, "_id": 0}
             dates = {
-                d[self.key]: self._lu_func[0](d[self.last_updated_field])
+                d[self.key]: self._lu_func[0](
+                    d.get(self.last_updated_field, datetime.max)
+                )
                 for d in self.query(properties=props)
             }
 
             # Get the last_updated for the store we're comparing with
             props = {target.key: 1, target.last_updated_field: 1, "_id": 0}
             target_dates = {
-                d[target.key]: target._lu_func[0](d[target.last_updated_field])
+                d[target.key]: target._lu_func[0](
+                    d.get(target.last_updated_field, datetime.min)
+                )
                 for d in target.query(criteria=criteria, properties=props)
             }
 


### PR DESCRIPTION
This PR fixes some issues with the treatment of `last_updated` in the core store and `MapBuilder`

- make `newer_in` more resilient to lack of `last_updated` fields
- fix typos in `MultiplyBuilder` example