### PR TITLE
small fixes

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,6 +75,7 @@ jobs:
         pip install -r requirements-testing.txt
         pip install -r requirements-optional.txt
 
+
     - name: Test with pytest
       env:
         CONTINUOUS_INTEGRATION: True

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,7 +75,6 @@ jobs:
         pip install -r requirements-testing.txt
         pip install -r requirements-optional.txt
 
-
     - name: Test with pytest
       env:
         CONTINUOUS_INTEGRATION: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ numpy==1.18.1
 pynng==0.5.0
 dnspython==1.16.0
 uvicorn==0.11.3
+sshtunnel==0.1.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,3 +67,6 @@ ignore_missing_imports = True
 
 [mypy-monty.json.*]
 ignore_missing_imports = True
+
+[mypy-sshtunnel.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "fastapi>=0.42.0",
         "pynng>=0.5.0",
         "dnspython>=1.16.0",
+        "sshtunnel>=0.1.5",
     ],
     extras_require={"vault": ["hvac>=0.9.5"], "S3": ["boto3==1.12.11"]},
     classifiers=[

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -60,7 +60,7 @@ class S3Store(Store):
         self.s3 = None  # type: Any
         self.s3_bucket = None  # type: Any
         # Force the key to be the same as the index
-        kwargs["key"] = index.key
+        kwargs["key"] = str(index.key)
         super(S3Store, self).__init__(**kwargs)
 
     def name(self) -> str:
@@ -267,7 +267,7 @@ class S3Store(Store):
                 data = zlib.compress(data)
 
             self.s3_bucket.put_object(
-                Key=self.sub_dir + d[self.key], Body=data, Metadata=search_doc
+                Key=self.sub_dir + str(d[self.key]), Body=data, Metadata=search_doc
             )
             search_docs.append(search_doc)
 

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -356,7 +356,7 @@ class MongoURIStore(MongoStore):
         Connect to the source data
         """
         if ssh_tunnel is not None:
-            warnings.warn(f"SSH Tunnel not needed for {self.__name__}")
+            warnings.warn(f"SSH Tunnel not needed for {self.__class__.__name__}")
         if not self._collection or force_reset:
             conn = MongoClient(self.uri)
             db = conn[self.database]
@@ -385,7 +385,7 @@ class MemoryStore(MongoStore):
         Connect to the source data
         """
         if ssh_tunnel is not None:
-            warnings.warn(f"SSH Tunnel not needed for {self.__name__}")
+            warnings.warn(f"SSH Tunnel not needed for {self.__class__.__name__}")
         if not self._collection or force_reset:
             self._collection = mongomock.MongoClient().db[self.name]
 

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -26,7 +26,7 @@ from monty.dev import deprecated
 from maggma.utils import confirm_field_index
 
 from maggma.core import Store, Sort, StoreError
-from sshtunnel import SSHTunnelForwarder  # type: ignore
+from sshtunnel import SSHTunnelForwarder
 
 
 class MongoStore(Store):

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -214,6 +214,15 @@ def test_memory_store_connect():
     memorystore.connect()
     assert isinstance(memorystore._collection, mongomock.collection.Collection)
 
+    with pytest.warns(UserWarning, match="SSH Tunnel not needed for MemoryStore"):
+
+        class fake_pipe:
+            remote_bind_address = ("localhost", 27017)
+            local_bind_address = ("localhost", 37017)
+
+        server = fake_pipe()
+        memorystore.connect(ssh_tunnel=server)
+
 
 def test_groupby(memorystore):
     memorystore.update(
@@ -278,3 +287,11 @@ def test_mongo_uri():
     is_name = store.name is uri
     # This is try and keep the secret safe
     assert is_name
+    with pytest.warns(UserWarning, match="SSH Tunnel not needed for MongoURIStore"):
+
+        class fake_pipe:
+            remote_bind_address = ("localhost", 27017)
+            local_bind_address = ("localhost", 37017)
+
+        server = fake_pipe()
+        store.connect(ssh_tunnel=server)

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from maggma.core import StoreError
 from maggma.stores import MongoStore, MemoryStore, JSONStore, MongoURIStore
 from maggma.validators import JSONSchemaValidator
+from sshtunnel import open_tunnel
 
 
 @pytest.fixture
@@ -37,6 +38,18 @@ def test_mongostore_connect():
     mongostore = MongoStore("maggma_test", "test")
     assert mongostore._collection is None
     mongostore.connect()
+    assert isinstance(mongostore._collection, pymongo.collection.Collection)
+
+
+def test_mongostore_connect_via_ssh():
+    mongostore = MongoStore("maggma_test", "test")
+
+    class fake_pipe:
+        remote_bind_address = ("localhost", 27017)
+        local_bind_address = ("localhost", 37017)
+
+    server = fake_pipe()
+    mongostore.connect(ssh_tunnel=server)
     assert isinstance(mongostore._collection, pymongo.collection.Collection)
 
 

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from maggma.core import StoreError
 from maggma.stores import MongoStore, MemoryStore, JSONStore, MongoURIStore
 from maggma.validators import JSONSchemaValidator
-from sshtunnel import open_tunnel
 
 
 @pytest.fixture


### PR DESCRIPTION
enforced s3 key to be a string.
allows sshtunnel to be passed to `MongoStore.connect`
