### PR TITLE
Make GridFSStore query check files store first.

### DIFF
--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -268,9 +268,10 @@ class S3Store(Store):
 
             search_docs.append(search_doc.copy())
 
-            search_doc[self.last_updated_field] = str(
-                to_isoformat_ceil_ms(search_doc[self.last_updated_field])
-            )
+            if self.last_updated_field in search_doc:
+                search_doc[self.last_updated_field] = str(
+                    to_isoformat_ceil_ms(search_doc[self.last_updated_field])
+                )
 
             self.s3_bucket.put_object(
                 Key=self.sub_dir + str(d[self.key]), Body=data, Metadata=search_doc

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -12,7 +12,7 @@ from monty.json import jsanitize
 from monty.dev import deprecated
 
 from maggma.core import Store, Sort
-from maggma.utils import grouper
+from maggma.utils import grouper, to_isoformat_ceil_ms
 
 try:
     import botocore
@@ -269,7 +269,7 @@ class S3Store(Store):
             search_docs.append(search_doc.copy())
 
             search_doc[self.last_updated_field] = str(
-                search_doc[self.last_updated_field]
+                to_isoformat_ceil_ms(search_doc[self.last_updated_field])
             )
 
             self.s3_bucket.put_object(

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -266,10 +266,15 @@ class S3Store(Store):
                 search_doc["compression"] = "zlib"
                 data = zlib.compress(data)
 
+            search_docs.append(search_doc.copy())
+
+            search_doc[self.last_updated_field] = str(
+                search_doc[self.last_updated_field]
+            )
+
             self.s3_bucket.put_object(
                 Key=self.sub_dir + str(d[self.key]), Body=data, Metadata=search_doc
             )
-            search_docs.append(search_doc)
 
         # Use store's update to remove key clashes
         self.index.update(search_docs)

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -155,10 +155,9 @@ class GridFSStore(Store):
         limit: int = 0,
     ) -> Iterator[Dict]:
         """
-        Queries the GridFS Store for a set of documents
-        Currently ignores properties
-
-        TODO: If properties wholy in metadata, just query that
+        Queries the GridFS Store for a set of documents.
+        Will check to see if data can be returned from 
+        files store first.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -170,20 +169,38 @@ class GridFSStore(Store):
         if isinstance(criteria, dict):
             criteria = self.transform_criteria(criteria)
 
-        for f in self._collection.find(
-            filter=criteria, skip=skip, limit=limit, sort=sort
+        prop_keys = set()
+        if isinstance(properties, dict):
+            prop_keys = set(properties.keys())
+        elif isinstance(properties, list):
+            prop_keys = set(properties)
+
+        for doc in self._files_store.query(
+            criteria=criteria, sort=sort, limit=limit, skip=skip
         ):
-            data = f.read()
+            if properties is not None and prop_keys.issubset(set(doc.keys())):
+                yield {p: doc[p] for p in properties if p in doc}
+            else:
+                data = self._collection.find_one(
+                    filter={
+                        "metadata.{}".format(self._files_store.key): doc["metadata"][
+                            self._files_store.key
+                        ]
+                    },
+                    skip=skip,
+                    limit=limit,
+                    sort=sort,
+                ).read()
 
-            metadata = f.metadata
-            if metadata.get("compression", "") == "zlib":
-                data = zlib.decompress(data).decode("UTF-8")
+                metadata = doc["metadata"]
+                if metadata.get("compression", "") == "zlib":
+                    data = zlib.decompress(data).decode("UTF-8")
 
-            try:
-                data = json.loads(data)
-            except Exception:
-                pass
-            yield data
+                try:
+                    data = json.loads(data)
+                except Exception:
+                    pass
+                yield data
 
     def distinct(
         self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -156,7 +156,7 @@ class GridFSStore(Store):
     ) -> Iterator[Dict]:
         """
         Queries the GridFS Store for a set of documents.
-        Will check to see if data can be returned from 
+        Will check to see if data can be returned from
         files store first.
 
         Args:


### PR DESCRIPTION
This PR makes the query method in the GridFSStore first try and pull data from its mongo `files_store` using the list of `properties` input by the user. 

Also, proper datetime object accommodation is enabled in the S3 index store.