### PR TITLE
MapBuilder retry_failed Fix

### DIFF
--- a/src/maggma/builders/map_builder.py
+++ b/src/maggma/builders/map_builder.py
@@ -109,9 +109,11 @@ class MapBuilder(Builder, metaclass=ABCMeta):
 
         keys = self.target.newer_in(self.source, criteria=self.query, exhaustive=True)
         if self.retry_failed:
-            failed_keys = self.target.distinct(
-                self.target.key, criteria={"state": "failed"}
-            )
+            if isinstance(self.query, (dict)):
+                failed_query = {"$and": [self.query, {"state": "failed"}]}
+            else:
+                failed_query = {"state": "failed"}
+            failed_keys = self.target.distinct(self.target.key, criteria=failed_query)
             keys = list(set(keys + failed_keys))
 
         self.logger.info("Processing {} items".format(len(keys)))


### PR DESCRIPTION
Before the retry_failed input of MapBuilder worked independently of the query input. For example, if retry_failed=True and the user provided a query, get_items() would grab all failed items (including those that did not match query) and any items matching query. With this fix, now only failed items that also match query will be grabbed. If a query is provided, docs from the source store that do not match this query will not be processed.

test_get_items for MapBuilder has been expanded to check for:
1. retry_failed = False, query = None (default)
2. retry_failed = True, query = None
3. retry_failed = False, query provided
4. retry_failed = True, query provided