### PR TITLE
Minor bug fixes to S3Store

### DIFF
--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -186,7 +186,7 @@ class S3Store(Store):
                 # msgpack.unpackb goes as deep as possible during reconstruction
                 # MontyDecoder().process_decode only goes until it finds a from_dict
                 # as such, we cannot just use msgpack.unpackb(data, object_hook=monty_object_hook, raw=False)
-                yield MontyDecoder().process_decode(unpacked_data_)
+                yield MontyDecoder().process_decoded(unpacked_data_)
 
     def distinct(
         self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -16,7 +16,6 @@ from maggma.utils import grouper, to_isoformat_ceil_ms
 from monty.dev import deprecated
 from monty.json import MontyDecoder
 from monty.msgpack import default as monty_default
-from monty.msgpack import object_hook as monty_object_hook
 
 try:
     import botocore


### PR DESCRIPTION
## Fix for unpacking issue
Reconstructing data from msgpack is not compatible with how monty wants to reconstruct objects.
msgpack wants to go as deep as possible first, but monty wants to stop when it finds a from_dict

So now we use `MontyDecoder().process_decoded` and issue should be resolved.

Doing this also allows us to bypass string conversion (json.dumps) which gives us up to 5x speedup when processing CHGCARs and 1.5x on bandstructures.

## Fixed mismatched between documentation and functionality of `update` function

Now allows for a single document to be updated 


