### PR TITLE
Add custom source loading

### DIFF
--- a/docs/getting_started/running_builders.md
+++ b/docs/getting_started/running_builders.md
@@ -70,6 +70,46 @@ There are progress bars for each of the three steps, which lets you understand w
 The `url` argument takes a fully qualified url including protocol. `tcp` is recommended:
 Example: `tcp://127.0.0.1:8080`
 
+
+## Running Scripts
+
+`mrun` has the ability to run Builders defined in python scripts or in jupyter-notebooks.
+
+The only requirements are:
+
+1. The builder file has to be in a sub-directory from where `mrun` is called.
+2. The builders you want to run are in a variable called `__builder__` or `__builders__`
+
+`mrun` will run the whole python/jupyter file, grab the builders in these variables and adds these builders to the builder queue.
+
+Assuming you have a builder in a python file: `my_builder.py`
+``` python
+class MultiplyBuilder(Builder):
+    """
+    Simple builder that multiplies the "a" sub-document by pre-set value
+    """
+
+    ...
+
+__builder__ = MultiplyBuilder(source_store,target_store,multiplier=3)
+```
+
+You can use `mrun` to run this builder and parallelize for you:
+``` shell
+mrun -n 2 -v my_builder.py
+```
+
+
+## Running multiple builders
+
+`mrun` can run multiple builders. You can have multiple builders in a single file: `json`, `python`, or `jupyter-notebook`. Or you can chain multiple files in the order you want to run them:
+``` shell
+mrun -n 32 -vv my_first_builder.json builder_2_and_3.py last_builder.ipynb
+```
+
+`mrun` will then execute the builders in these files in order.
+
+
 ## Reporting Build State
 
 `mrun` has the ability to report the status of the build pipeline to a user-provided `Store`. To do this, you first have to save the `Store` as a JSON or YAML file. Then you can use the `-r` option to give this to `mrun`. It will then periodicially add documents to the `Store` for one of 3 different events:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,8 @@ nav:
   - Getting Started:
     - Using Stores: getting_started/stores.md
     - Writing a Builder: getting_started/simple_builder.md
-    - Advanced Builders: getting_started/advanced_builder.md
     - Running a Builder Pipeline: getting_started/running_builders.md
+    - Advanced Builders: getting_started/advanced_builder.md
     - Working with MapBuilder: getting_started/map_builder.md
     - Working with GroupBuilder: getting_started/group_builder.md
     - Writing a Drone: getting_started/simple_drone.md

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,3 +3,4 @@ boto3==1.14.60
 hvac==0.10.5
 IPython==7.16.1
 nbformat==5.0.7
+regex==2020.6.8

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,3 +1,4 @@
 uvicorn==0.11.8
 boto3==1.14.56
 hvac==0.10.5
+IPython==7.16.1

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,3 +2,4 @@ uvicorn==0.11.8
 boto3==1.14.56
 hvac==0.10.5
 IPython==7.16.1
+nbformat==5.0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,3 +73,12 @@ ignore_missing_imports = True
 
 [mypy-sshtunnel.*]
 ignore_missing_imports = True
+
+[mypy-IPython.*]
+ignore_missing_imports = True
+
+[mypy-nbformat.*]
+ignore_missing_imports = True
+
+[mypy-regex.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,11 @@ setup(
         "sshtunnel>=0.1.5",
         "msgpack-python>=0.5.6",
     ],
-    extras_require={"vault": ["hvac>=0.9.5"], "S3": ["boto3==1.14.56"]},
+    extras_require={
+        "vault": ["hvac>=0.9.5"],
+        "S3": ["boto3==1.14.56"],
+        "notebook_runner": ["IPython>=7.16", "nbformat>=5.0"],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     extras_require={
         "vault": ["hvac>=0.9.5"],
         "S3": ["boto3>=1.14.56"],
-        "notebook_runner": ["IPython>=7.16", "nbformat>=5.0"],
+        "notebook_runner": ["IPython>=7.16", "nbformat>=5.0", "regex>=2020.6"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import sys
 from itertools import chain
 
 import click
@@ -12,7 +13,10 @@ from monty.serialization import loadfn
 from maggma.cli.distributed import master, worker
 from maggma.cli.multiprocessing import multi
 from maggma.cli.serial import serial
+from maggma.cli.source_loader import ScriptFinder, load_builder_from_source
 from maggma.utils import ReportingHandler, TqdmLoggingHandler
+
+sys.meta_path.append(ScriptFinder)
 
 
 @click.command()
@@ -56,9 +60,16 @@ def run(builders, verbosity, reporting_store, num_workers, url, num_chunks):
     ch.setFormatter(formatter)
     root.addHandler(ch)
 
-    builders = [loadfn(b) for b in builders]
-    builders = [b if isinstance(b, list) else [b] for b in builders]
-    builders = list(chain.from_iterable(builders))
+    builder_objects = []
+
+    for b in builders:
+        if str(b).endswith(".py") or str(b).endswith(".ipynb"):
+            builder_objects.append(load_builder_from_source(b))
+        else:
+            builder_objects.append(loadfn(b))
+
+    builder_objects = [b if isinstance(b, list) else [b] for b in builder_objects]
+    builder_objects = list(chain.from_iterable(builder_objects))
 
     if reporting_store:
         reporting_store = loadfn(reporting_store)
@@ -67,14 +78,14 @@ def run(builders, verbosity, reporting_store, num_workers, url, num_chunks):
     if url:
         if num_chunks > 0:
             # Master
-            asyncio.run(master(url, builders, num_chunks))
+            asyncio.run(master(url, builder_objects, num_chunks))
         else:
             # worker
             asyncio.run(worker(url, num_workers))
     else:
         if num_workers == 1:
-            for builder in builders:
+            for builder in builder_objects:
                 serial(builder)
         else:
-            for builder in builders:
+            for builder in builder_objects:
                 asyncio.run(multi(builder, num_workers))

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -16,7 +16,7 @@ from maggma.cli.serial import serial
 from maggma.cli.source_loader import ScriptFinder, load_builder_from_source
 from maggma.utils import ReportingHandler, TqdmLoggingHandler
 
-sys.meta_path.append(ScriptFinder)
+sys.meta_path.append(ScriptFinder())
 
 
 @click.command()

--- a/src/maggma/cli/multiprocessing.py
+++ b/src/maggma/cli/multiprocessing.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding utf-8
 
+import multiprocessing
 from asyncio import (
     FIRST_COMPLETED,
     BoundedSemaphore,
@@ -157,7 +158,9 @@ async def multi(builder, num_workers):
 
     builder.connect()
     cursor = builder.get_items()
-    executor = ProcessPoolExecutor(num_workers)
+    executor = ProcessPoolExecutor(
+        num_workers, mp_context=multiprocessing.get_context("spawn")
+    )
 
     # Gets the total number of items to process by priming
     # the cursor

--- a/src/maggma/cli/source_loader.py
+++ b/src/maggma/cli/source_loader.py
@@ -1,0 +1,173 @@
+import importlib
+import pickle
+import sys
+import types
+from glob import glob
+from importlib.abc import Loader, MetaPathFinder
+from importlib.machinery import ModuleSpec, SourceFileLoader
+from pathlib import Path
+from typing import List
+
+from IPython import get_ipython
+from IPython.core.interactiveshell import InteractiveShell
+from nbformat import read
+from regex import match
+
+from maggma.core import Builder
+
+_BASENAME = "maggma.cli.sources"
+
+
+class ScriptFinder(MetaPathFinder):
+    """
+    Special Finder designed to find custom script builders
+    """
+
+    @classmethod
+    def find_spec(cls, fullname, path, target=None):
+        if not (str(fullname).startswith(f"{_BASENAME}.")):
+            return None
+
+        # The last module is what we want to find the path for
+        sub_path = str(fullname).split(".")[-1]
+        segments = sub_path.split("_")
+
+        file_path = next(find_matching_file(segments))
+
+        if file_path is None:
+            return None
+
+        return spec_from_source(file_path)
+
+
+class NotebookLoader(Loader):
+    """Module Loader for Jupyter Notebooks or Source Files"""
+
+    def __init__(self, name=None, path=None):
+        self.shell = InteractiveShell.instance()
+        self.name = name
+        self.path = path
+
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        path = self.path
+
+        module.__dict__["get_ipython"] = get_ipython
+        module.__path__ = path
+
+        # load the notebook object
+        with open(path, "r", encoding="utf-8") as f:
+            nb = read(f, 4)
+
+        # extra work to ensure that magics that would affect the user_ns
+        # actually affect the notebook module's ns
+        save_user_ns = self.shell.user_ns
+        self.shell.user_ns = module.__dict__
+
+        try:
+            for cell in nb.cells:
+                if cell.cell_type == "code":
+                    # transform the input to executable Python
+                    code = self.shell.input_transformer_manager.transform_cell(
+                        cell.source
+                    )
+                    # run the code in themodule
+                    exec(code, module.__dict__)
+        finally:
+            self.shell.user_ns = save_user_ns
+        return module
+
+
+def spec_from_source(file_path: str) -> ModuleSpec:
+    """
+    Returns a ModuleSpec from a filepath for importlib loading
+    Specialized for loading python source files and notebooks into
+    a temporary maggma cli package to run as a builder
+    """
+    file_path = Path(file_path).resolve().relative_to(Path(".").resolve())
+    file_path_str = str(file_path)
+
+    if file_path.parts[-1][-3:] == ".py":
+        # Gets module name from the filename without the .py extension
+        module_name = "_".join(file_path.parts).replace(" ", "_").replace(".py", "")
+
+        spec = ModuleSpec(
+            name=f"{_BASENAME}.{module_name}",
+            loader=SourceFileLoader(
+                fullname=f"{_BASENAME}.{module_name}", path=file_path_str
+            ),
+            origin=file_path_str,
+        )
+        # spec._set_fileattr = True
+    elif file_path.parts[-1][-6:] == ".ipynb":
+        # Gets module name from the filename without the .ipnb extension
+        module_name = "_".join(file_path.parts).replace(" ", "_").replace(".ipynb", "")
+
+        spec = ModuleSpec(
+            name=f"{_BASENAME}.{module_name}",
+            loader=NotebookLoader(
+                name=f"{_BASENAME}.{module_name}", path=file_path_str
+            ),
+            origin=file_path_str,
+        )
+        # spec._set_fileattr = True
+    else:
+        raise Exception(
+            "Can't load {file_path}. Must provide a python source file such as a .py or .ipynb file"
+        )
+
+    return spec
+
+
+def load_builder_from_source(file_path: str) -> List[Builder]:
+    """
+    Loads Maggma Builders from a Python source file
+    """
+    file_path = str(Path(file_path).resolve())
+    spec = spec_from_source(file_path)
+    module_object = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module_object)
+
+    sys.modules[spec.name] = module_object
+
+    if hasattr(module_object, "__builders__"):
+        return module_object.__builders__
+    elif hasattr(module_object, "__builder__"):
+        return module_object.__builder__
+    else:
+        raise Exception(
+            f"No __builders__ or __builder__ attribute found in {file_path}"
+        )
+
+
+def find_matching_file(segments, curr_path="./"):
+    """
+    Finds file that has the right sequence of segments
+    in the path relative to the current path
+    Requires all segments match the file path
+    """
+
+    # If we've gotten to the end of the segment match check to see if a file exists
+    if len(segments) == 0:
+        if Path(curr_path + ".py").exists():
+            yield curr_path + ".py"
+        if Path(curr_path + ".ipynb").exists():
+            yield curr_path + ".ipynb"
+    else:
+        # Recurse down the segment tree some more
+        current_segment = segments[0]
+        remainder = segments[1:]
+
+        re = fr"({curr_path}[\s_]*{current_segment})"
+        pos_matches = [match(re, pos_path) for pos_path in glob(curr_path + "*")]
+        pos_matches = {pmatch.group(1) for pmatch in pos_matches if pmatch}
+        for new_path in pos_matches:
+            if Path(new_path).exists() and Path(new_path).is_dir:
+                for sub_match in find_matching_file(
+                    remainder, curr_path=new_path + "/"
+                ):
+                    yield sub_match
+            for sub_match in find_matching_file(remainder, curr_path=new_path):
+                yield sub_match

--- a/src/maggma/cli/source_loader.py
+++ b/src/maggma/cli/source_loader.py
@@ -1,13 +1,11 @@
 import importlib.util
 import sys
-import types
 from glob import glob
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec, SourceFileLoader
 from pathlib import Path
 from typing import List
-from nbformat import read
-from regex import match
+
 
 from maggma.core import Builder
 
@@ -15,6 +13,7 @@ try:
     import nbformat
     from IPython import get_ipython
     from IPython.core.interactiveshell import InteractiveShell
+    from regex import match
 except ModuleNotFoundError:
     pass
 

--- a/src/maggma/cli/source_loader.py
+++ b/src/maggma/cli/source_loader.py
@@ -6,11 +6,17 @@ from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec, SourceFileLoader
 from pathlib import Path
 from typing import List
-
 from nbformat import read
 from regex import match
 
 from maggma.core import Builder
+
+try:
+    import nbformat
+    from IPython import get_ipython
+    from IPython.core.interactiveshell import InteractiveShell
+except ModuleNotFoundError:
+    pass
 
 _BASENAME = "maggma.cli.sources"
 
@@ -42,8 +48,6 @@ class NotebookLoader(Loader):
 
     def __init__(self, name=None, path=None):
 
-        from IPython.core.interactiveshell import InteractiveShell
-
         self.shell = InteractiveShell.instance()
 
         self.name = name
@@ -53,14 +57,13 @@ class NotebookLoader(Loader):
         return None
 
     def exec_module(self, module):
-        from IPython import get_ipython
 
         module.__dict__["get_ipython"] = get_ipython
         module.__path__ = self.path
 
         # load the notebook object
         with open(self.path, "r", encoding="utf-8") as f:
-            nb = read(f, 4)
+            nb = nbformat.read(f, 4)
 
         # extra work to ensure that magics that would affect the user_ns
         # actually affect the notebook module's ns

--- a/src/maggma/cli/source_loader.py
+++ b/src/maggma/cli/source_loader.py
@@ -8,8 +8,6 @@ from importlib.machinery import ModuleSpec, SourceFileLoader
 from pathlib import Path
 from typing import List
 
-from IPython import get_ipython
-from IPython.core.interactiveshell import InteractiveShell
 from nbformat import read
 from regex import match
 
@@ -44,7 +42,11 @@ class NotebookLoader(Loader):
     """Module Loader for Jupyter Notebooks or Source Files"""
 
     def __init__(self, name=None, path=None):
+
+        from IPython.core.interactiveshell import InteractiveShell
+
         self.shell = InteractiveShell.instance()
+
         self.name = name
         self.path = path
 
@@ -52,13 +54,13 @@ class NotebookLoader(Loader):
         return None
 
     def exec_module(self, module):
-        path = self.path
+        from IPython import get_ipython
 
         module.__dict__["get_ipython"] = get_ipython
-        module.__path__ = path
+        module.__path__ = self.path
 
         # load the notebook object
-        with open(path, "r", encoding="utf-8") as f:
+        with open(self.path, "r", encoding="utf-8") as f:
             nb = read(f, 4)
 
         # extra work to ensure that magics that would affect the user_ns

--- a/src/maggma/cli/sources/__init__.py
+++ b/src/maggma/cli/sources/__init__.py
@@ -1,0 +1,1 @@
+""" Dummy module to allow for loading dynamic source files """

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -4,10 +4,10 @@ Advanced Stores for connecting to AWS data
 """
 
 import threading
+import warnings
 import zlib
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-import warnings
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import msgpack  # type: ignore

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -21,7 +21,6 @@ from pymongo import MongoClient
 from maggma.core import Sort, Store
 from maggma.stores.mongolike import MongoStore
 
-
 # https://github.com/mongodb/specifications/
 #   blob/master/source/gridfs/gridfs-spec.rst#terms
 #   (Under "Files collection document")

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -10,7 +10,7 @@ import copy
 import json
 import zlib
 from datetime import datetime
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import gridfs
 from monty.dev import deprecated

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -230,8 +230,14 @@ class MongoStore(Store):
         if isinstance(properties, list):
             properties = {p: 1 for p in properties}
 
-        sort_list = [(k, Sort(v).value) if isinstance(v, int) else (k, v.value)
-                     for k, v in sort.items()] if sort else None
+        sort_list = (
+            [
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in sort.items()
+            ]
+            if sort
+            else None
+        )
 
         for d in self._collection.find(
             filter=criteria,

--- a/tests/cli/builder_for_test.py
+++ b/tests/cli/builder_for_test.py
@@ -1,7 +1,7 @@
 from maggma.core import Builder
 
 
-class TestBuilder(Builder):
+class DummyBuilder(Builder):
     def __init__(self, total=10):
         self.get_called = 0
         self.process_called = 0
@@ -22,4 +22,4 @@ class TestBuilder(Builder):
         self.update_called += 1
 
 
-__builder__ = TestBuilder()
+__builder__ = DummyBuilder()

--- a/tests/cli/builder_for_test.py
+++ b/tests/cli/builder_for_test.py
@@ -1,0 +1,25 @@
+from maggma.core import Builder
+
+
+class TestBuilder(Builder):
+    def __init__(self, total=10):
+        self.get_called = 0
+        self.process_called = 0
+        self.update_called = 0
+        super().__init__(sources=[], targets=[])
+        self.total = total
+
+    def get_items(self):
+        for i in range(self.total):
+            self.get_called += 1
+            yield self.get_called
+
+    def process_item(self, item):
+        self.process_called += 1
+        return item
+
+    def update_targets(self, items):
+        self.update_called += 1
+
+
+__builder__ = TestBuilder()

--- a/tests/cli/builder_notebook_for_test.ipynb
+++ b/tests/cli/builder_notebook_for_test.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class TestBuilder(Builder):\n",
+    "class DummyBuilder(Builder):\n",
     "    def __init__(self, total=10):\n",
     "        self.get_called = 0\n",
     "        self.process_called = 0\n",
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "__builders__ = [TestBuilder()]"
+    "__builders__ = [DummyBuilder()]"
    ]
   }
  ],

--- a/tests/cli/builder_notebook_for_test.ipynb
+++ b/tests/cli/builder_notebook_for_test.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# This is a markdown test just to mess up the test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/shyamd/Dropbox/Codes/maggma/src/maggma/utils.py:20: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "from maggma.core import Builder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TestBuilder(Builder):\n",
+    "    def __init__(self, total=10):\n",
+    "        self.get_called = 0\n",
+    "        self.process_called = 0\n",
+    "        self.update_called = 0\n",
+    "        super().__init__(sources=[], targets=[])\n",
+    "        self.total = total\n",
+    "\n",
+    "    def get_items(self):\n",
+    "        for i in range(self.total):\n",
+    "            self.get_called += 1\n",
+    "            yield self.get_called\n",
+    "\n",
+    "    def process_item(self, item):\n",
+    "        self.process_called += 1\n",
+    "        return item\n",
+    "\n",
+    "    def update_targets(self, items):\n",
+    "        self.update_called += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "__builders__ = [TestBuilder()]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/cli/test_distributed.py
+++ b/tests/cli/test_distributed.py
@@ -78,7 +78,7 @@ async def test_master_give_out_chunks(master_server, log_to_stdout):
 
 @pytest.mark.asyncio
 async def test_worker():
-    with Pair1(listen=SERVER_URL, polyamorous=True, recv_timeout=100) as worker_socket:
+    with Pair1(listen=SERVER_URL, polyamorous=True, recv_timeout=500) as worker_socket:
 
         worker_task = asyncio.create_task(worker(SERVER_URL, num_workers=1))
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -103,7 +103,7 @@ def test_reporting(mongostore, reporting_store):
         assert "items" in update_doc
 
 
-def test_builder_py():
+def test_python_source():
 
     runner = CliRunner()
 
@@ -112,6 +112,23 @@ def test_builder_py():
             src=Path(__file__).parent / "builder_for_test.py", dst=Path(".").resolve()
         )
         result = runner.invoke(run, ["-v", "-n", "2", "builder_for_test.py"])
+
+    assert result.exit_code == 0
+    assert "Ended multiprocessing: TestBuilder" in result.output
+
+
+def test_python_notebook_source():
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        shutil.copy2(
+            src=Path(__file__).parent / "builder_notebook_for_test.ipynb",
+            dst=Path(".").resolve(),
+        )
+        result = runner.invoke(
+            run, ["-v", "-n", "2", "builder_notebook_for_test.ipynb"]
+        )
 
     assert result.exit_code == 0
     assert "Ended multiprocessing: TestBuilder" in result.output

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -114,7 +114,7 @@ def test_python_source():
         result = runner.invoke(run, ["-v", "-n", "2", "builder_for_test.py"])
 
     assert result.exit_code == 0
-    assert "Ended multiprocessing: TestBuilder" in result.output
+    assert "Ended multiprocessing: DummyBuilder" in result.output
 
 
 def test_python_notebook_source():
@@ -131,4 +131,4 @@ def test_python_notebook_source():
         )
 
     assert result.exit_code == 0
-    assert "Ended multiprocessing: TestBuilder" in result.output
+    assert "Ended multiprocessing: DummyBuilder" in result.output

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,4 +1,6 @@
+import shutil
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -99,3 +101,17 @@ def test_reporting(mongostore, reporting_store):
 
         update_doc = next(d for d in report_docs if d["event"] == "UPDATE")
         assert "items" in update_doc
+
+
+def test_builder_py():
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        shutil.copy2(
+            src=Path(__file__).parent / "builder_for_test.py", dst=Path(".").resolve()
+        )
+        result = runner.invoke(run, ["-v", "-n", "2", "builder_for_test.py"])
+
+    assert result.exit_code == 0
+    assert "Ended multiprocessing: TestBuilder" in result.output

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -1,5 +1,6 @@
 import time
 import zlib
+from datetime import datetime
 
 import boto3
 import msgpack
@@ -8,7 +9,6 @@ from botocore.exceptions import ClientError
 from monty.msgpack import default, object_hook
 from moto import mock_s3
 
-from datetime import datetime
 from maggma.stores import MemoryStore, MongoStore, S3Store
 
 


### PR DESCRIPTION
This PR enables adding a custom source file such as `.py` or `.ipynb` file. The only requirements are as follows:
1. The source file has to be in a subfolder from where `mrun` is called. This is a limitation of the pathfinding that has to convert  a module import command into a path
2. The custom python file has to include either a `__builder__` or `__builders__` defined somewhere in the file. This is what gets loaded by `mrun` to run. 

Addresses #277 

Examples:
`mrun -n 2 -v builder_test.py`
`mrun -n 2 -v builder_test.ipynb`
`mrun -n 2 -v main_builders.json builder_test.py`