### PR TITLE
Direct passing of AWS login to S3Store

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,6 +1,6 @@
 uvicorn==0.12.1
-boto3==1.16.4
+boto3==1.16.9
 hvac==0.10.5
 IPython==7.18.1
 nbformat==5.0.7
-regex==2020.9.27
+regex==2020.10.23

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,6 +1,6 @@
 uvicorn==0.12.1
 boto3==1.16.9
 hvac==0.10.5
-IPython==7.18.1
+IPython==7.19.0
 nbformat==5.0.7
 regex==2020.10.23

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
-pre-commit==2.7.1
+pre-commit==2.8.2
 pytest==6.1.1
 pytest-asyncio==0.14.0
 pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tqdm==4.51.0
 mongogrant==0.3.1
 aioitertools==0.7.0
 pydantic==1.6.1
-fastapi==0.61.1
+fastapi==0.61.2
 numpy==1.19.2
 pynng==0.5.0
 dnspython==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pymongo==3.11.0
-monty==4.0.0
+monty==4.0.2
 mongomock==3.20.0
 pydash==4.8.0
 jsonschema==3.2.0
@@ -11,7 +11,7 @@ fastapi==0.61.1
 numpy==1.19.2
 pynng==0.5.0
 dnspython==2.0.0
-uvicorn==0.12.1
+uvicorn==0.12.2
 sshtunnel==0.1.5
 msgpack==1.0.0
 msgpack-python==0.5.6

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -41,7 +41,7 @@ class S3Store(Store):
         sub_dir: str = None,
         s3_workers: int = 1,
         key: str = "task_id",
-        searchable_fields: List[str] = None,
+        searchable_fields: Optional[List[str]] = None,
         **kwargs,
     ):
         """

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -273,7 +273,7 @@ def test_searchable_fields(s3store):
 
 def test_newer_in(s3store):
     with mock_s3():
-        tic = datetime.utcnow()
+        tic = datetime(2018, 4, 12, 16)
         tic2 = datetime.utcnow()
         conn = boto3.client("s3")
         conn.create_bucket(Bucket="bucket")
@@ -289,13 +289,12 @@ def test_newer_in(s3store):
         new_store.connect()
         new_store.update([{"task_id": "mp-1", "last_updated": tic2}])
         new_store.update([{"task_id": "mp-2", "last_updated": tic2}])
-        print(new_store.query_one())
-        print(new_store.index.query_one())
-        # assert len(old_store.newer_in(new_store)) == 2
-        # assert len(new_store.newer_in(old_store)) == 0
-        #
-        # assert len(old_store.newer_in(new_store.index)) == 2
-        # assert len(new_store.newer_in(old_store.index)) == 0
+
+        assert len(old_store.newer_in(new_store)) == 2
+        assert len(new_store.newer_in(old_store)) == 0
+
+        assert len(old_store.newer_in(new_store.index)) == 2
+        assert len(new_store.newer_in(old_store.index)) == 0
 
 
 def test_additional_metadata(s3store):

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -310,3 +310,17 @@ def test_additional_metadata(s3store):
 
     # This should only work if the searchable field was put into the index store
     assert set(s3store.distinct("task_id")) == {"mp-0", "mp-1", "mp-2", "mp-3"}
+
+
+def test_get_session(s3store):
+    index = MemoryStore("index")
+    store = S3Store(
+        index,
+        "bucket1",
+        s3_profile={
+            "aws_access_key_id": "ACCESS_KEY",
+            "aws_secret_access_key": "SECRET_KEY",
+        },
+    )
+    assert store._get_session().get_credentials().access_key == "ACCESS_KEY"
+    assert store._get_session().get_credentials().secret_key == "SECRET_KEY"


### PR DESCRIPTION
Now allows AWS information to be giving as the s3_profile (should consider renaming the parameter to s3_login).
