### PR TITLE
Fix Distinct in MongoStore

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -18,7 +18,7 @@ from monty.json import jsanitize, MSONable
 from monty.serialization import loadfn
 from pydash import get, has, set_
 from pymongo import MongoClient, ReplaceOne
-from pymongo.errors import OperationFailure
+from pymongo.errors import OperationFailure, DocumentTooLarge
 from sshtunnel import SSHTunnelForwarder
 
 
@@ -116,7 +116,7 @@ class MongoStore(Store):
         criteria = criteria or {}
         try:
             distinct_vals = self._collection.distinct(field, criteria)
-        except OperationFailure:
+        except (OperationFailure, DocumentTooLarge):
             distinct_vals = [
                 d["_id"]
                 for d in self._collection.aggregate([{"$group": {"_id": f"${field}"}}])

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -78,6 +78,10 @@ def test_mongostore_distinct(mongostore):
     mongostore._collection.insert_one({"i": None})
     assert mongostore.distinct("i") == [None]
 
+    # Test to make sure DocumentTooLarge errors get dealt with properly
+    mongostore._collection.insert_many([{"a": f"mp-{i}"} for i in range(1000000)])
+    mongostore.distinct("a")
+
 
 def test_mongostore_update(mongostore):
     mongostore.update({"e": 6, "d": 4}, key="e")


### PR DESCRIPTION
Fix the distinct operation from failing in the `MongoStore` when too much data is being pulled. This broke because pymongo made an explicit `DocumentTooLarge` error that was not being caught. 