### PR TITLE
Fix array unwrapping in distinct

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -121,7 +121,7 @@ class MongoStore(Store):
                 d["_id"]
                 for d in self._collection.aggregate([{"$group": {"_id": f"${field}"}}])
             ]
-            if all(isinstance(d, list) for d in filter(None, distinct_vals)):
+            if all(isinstance(d, list) for d in filter(None, distinct_vals)):  # type: ignore
                 distinct_vals = list(chain.from_iterable(filter(None, distinct_vals)))
 
         return distinct_vals if distinct_vals is not None else []

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -7,7 +7,7 @@ various utilities
 from __future__ import annotations
 
 import json
-from itertools import groupby
+from itertools import groupby, chain
 from socket import socket
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -121,6 +121,8 @@ class MongoStore(Store):
                 d["_id"]
                 for d in self._collection.aggregate([{"$group": {"_id": f"${field}"}}])
             ]
+            if all(isinstance(d, list) for d in filter(None, distinct_vals)):
+                distinct_vals = list(chain.from_iterable(filter(None, distinct_vals)))
 
         return distinct_vals if distinct_vals is not None else []
 

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -78,9 +78,12 @@ def test_mongostore_distinct(mongostore):
     mongostore._collection.insert_one({"i": None})
     assert mongostore.distinct("i") == [None]
 
-    # Test to make sure DocumentTooLarge errors get dealt with properly
-    mongostore._collection.insert_many([{"a": f"mp-{i}"} for i in range(1000000)])
-    mongostore.distinct("a")
+    # Test to make sure DocumentTooLarge errors get dealt with properly using built in distinct
+    mongostore._collection.insert_many([{"key": [f"mp-{i}"]} for i in range(1000000)])
+    vals = mongostore.distinct("key")
+    # Test to make sure distinct on array field is unraveled when using manual distinct
+    assert len(vals) == len(list(range(1000000)))
+    assert all([isinstance(v, str) for v in vals])
 
 
 def test_mongostore_update(mongostore):


### PR DESCRIPTION
This ensures the built-in distinct call properly unwraps arrays. 