### PR TITLE
Ensure MongoStore can safely continue updating when documents are too large

### DIFF
--- a/src/maggma/core/drone.py
+++ b/src/maggma/core/drone.py
@@ -45,7 +45,11 @@ class RecordIdentifier(BaseModel):
         :return:
         """
         paths = [doc.path.as_posix() for doc in self.documents]
-        return Path(os.path.commonprefix(paths))
+        parent_path = Path(os.path.commonprefix(paths))
+        if not parent_path.is_dir():
+            return parent_path.parent
+
+        return parent_path
 
     def compute_state_hash(self) -> str:
         """

--- a/tests/builders/test_simple_bib_drone.py
+++ b/tests/builders/test_simple_bib_drone.py
@@ -66,8 +66,11 @@ def test_process_item(init_drone: SimpleBibDrone):
     :return:
         None
     """
-    list_record_id = init_drone.read(init_drone.path)
-    data = init_drone.process_item(list_record_id[0])
+    list_record_id = list(init_drone.read(init_drone.path))
+    text_record = next(
+        d for d in list_record_id if any("text" in f.name for f in d.documents)
+    )
+    data = init_drone.process_item(text_record)
     assert "citations" in data
     assert "text" in data
     assert "record_key" in data
@@ -125,7 +128,10 @@ def test_compute_data(init_drone: SimpleBibDrone):
     :return:
         None
     """
-    list_record_id = init_drone.read(init_drone.path)
-    data = init_drone.process_item(list_record_id[0])
+    list_record_id = list(init_drone.read(init_drone.path))
+    text_record = next(
+        d for d in list_record_id if any("text" in f.name for f in d.documents)
+    )
+    data = init_drone.process_item(text_record)
     assert "citations" in data
     assert "text" in data

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -106,8 +106,14 @@ def test_mongostore_update(mongostore):
     mongostore.validator = JSONSchemaValidator(schema=test_schema)
     mongostore.update({"e": 100, "d": 3}, key="e")
 
-    # Non strict update
+    # Continue to update doc when validator is not set to strict mode
     mongostore.update({"e": "abc", "d": 3}, key="e")
+
+    # Fail softly when document too large and ensure other docs get updated
+    large_doc = {f"mp-{i}": f"mp-{i}" for i in range(1000000)}
+    large_doc["e"] = 999
+    mongostore.update([large_doc, {"e": 1001}], key="e")
+    assert mongostore.query_one({"e": 1001}) is not None
 
 
 def test_mongostore_groupby(mongostore):


### PR DESCRIPTION
Ensures `MongoStore` has a means of safely failing on update with documents that are too large. The new behavior is as follows:
- if `safe_update` is False (Default), update will fail on `DocumentTooLarge` errors.
- if `safe_update` is True, then `update` will just ignore `DocumentTooLarge` errors and ensure all documents that fit are updated
