### PR TITLE
Fix aws module import

### DIFF
--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -12,7 +12,6 @@ from hashlib import sha1
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import msgpack  # type: ignore
-from botocore.exceptions import ClientError
 from monty.dev import deprecated
 from monty.msgpack import default as monty_default
 
@@ -22,8 +21,9 @@ from maggma.utils import grouper, to_isoformat_ceil_ms
 try:
     import boto3
     import botocore
+    from botocore.exceptions import ClientError
     from boto3.session import Session
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     boto3 = None  # type: ignore
 
 


### PR DESCRIPTION
Currently, maggma cannot be imported if the botocore library is not installed. botocore is not a core dependency of maggma so this PR fixes the imports.