### PR TITLE
Fix API Sanitizing MSONable types in combined types

### DIFF
--- a/src/maggma/api/API.py
+++ b/src/maggma/api/API.py
@@ -3,9 +3,9 @@ from typing import Dict, List, Optional
 
 import uvicorn
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from monty.json import MSONable
 from starlette.responses import RedirectResponse
-from fastapi.middleware.cors import CORSMiddleware
 
 from maggma import __version__
 from maggma.api.resource import Resource
@@ -82,7 +82,7 @@ class API(MSONable):
 
         @app.get("/heartbeat", include_in_schema=False)
         def heartbeat():
-            """ API Heartbeat for Load Balancing """
+            """API Heartbeat for Load Balancing"""
 
             return {
                 "status": "OK",
@@ -93,7 +93,7 @@ class API(MSONable):
 
         @app.get("/", include_in_schema=False)
         def redirect_docs():
-            """ Redirects the root end point to the docs """
+            """Redirects the root end point to the docs"""
             return RedirectResponse(url=app.docs_url, status_code=301)
 
         return app

--- a/src/maggma/api/query_operator/__init__.py
+++ b/src/maggma/api/query_operator/__init__.py
@@ -1,6 +1,6 @@
 from maggma.api.query_operator.core import QueryOperator
 from maggma.api.query_operator.dynamic import NumericQuery, StringQueryOperator
 from maggma.api.query_operator.pagination import PaginationQuery
-from maggma.api.query_operator.sparse_fields import SparseFieldsQuery
 from maggma.api.query_operator.sorting import SortQuery
+from maggma.api.query_operator.sparse_fields import SparseFieldsQuery
 from maggma.api.query_operator.submission import SubmissionQuery

--- a/src/maggma/api/query_operator/dynamic.py
+++ b/src/maggma/api/query_operator/dynamic.py
@@ -1,7 +1,6 @@
 import inspect
-from typing import Type
 from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from fastapi.params import Query
 from monty.json import MontyDecoder
@@ -81,7 +80,7 @@ class DynamicQueryOperator(QueryOperator):
         self.query = query  # type: ignore
 
     def query(self):
-        " Stub query function for abstract class "
+        "Stub query function for abstract class"
         pass
 
     @abstractmethod
@@ -115,7 +114,7 @@ class DynamicQueryOperator(QueryOperator):
 
 
 class NumericQuery(DynamicQueryOperator):
-    " Query Operator to enable searching on numeric fields"
+    "Query Operator to enable searching on numeric fields"
 
     def field_to_operator(
         self, name: str, field: ModelField
@@ -140,7 +139,8 @@ class NumericQuery(DynamicQueryOperator):
                     f"{field.name}_max",
                     field_type,
                     Query(
-                        default=None, description=f"Query for maximum value of {title}",
+                        default=None,
+                        description=f"Query for maximum value of {title}",
                     ),
                     lambda val: {f"{field.name}": {"$lte": val}},
                 ),
@@ -148,7 +148,8 @@ class NumericQuery(DynamicQueryOperator):
                     f"{field.name}_min",
                     field_type,
                     Query(
-                        default=None, description=f"Query for minimum value of {title}",
+                        default=None,
+                        description=f"Query for minimum value of {title}",
                     ),
                     lambda val: {f"{field.name}": {"$gte": val}},
                 ),
@@ -209,7 +210,7 @@ class NumericQuery(DynamicQueryOperator):
 
 
 class StringQueryOperator(DynamicQueryOperator):
-    " Query Operator to enable searching on numeric fields"
+    "Query Operator to enable searching on numeric fields"
 
     def field_to_operator(
         self, name: str, field: ModelField

--- a/src/maggma/api/query_operator/pagination.py
+++ b/src/maggma/api/query_operator/pagination.py
@@ -9,7 +9,9 @@ from maggma.api.utils import STORE_PARAMS
 class PaginationQuery(QueryOperator):
     """Query opertators to provides Pagination"""
 
-    def __init__(self, default_skip: int = 0, default_limit: int = 100, max_limit: int = 1000):
+    def __init__(
+        self, default_skip: int = 0, default_limit: int = 100, max_limit: int = 1000
+    ):
         """
         Args:
             default_skip: the default number of documents to skip
@@ -21,10 +23,13 @@ class PaginationQuery(QueryOperator):
         self.max_limit = max_limit
 
         def query(
-            skip: int = Query(default_skip, description="Number of entries to skip in the search"),
+            skip: int = Query(
+                default_skip, description="Number of entries to skip in the search"
+            ),
             limit: int = Query(
                 default_limit,
-                description="Max number of entries to return in a single query." f" Limited to {max_limit}",
+                description="Max number of entries to return in a single query."
+                f" Limited to {max_limit}",
             ),
         ) -> STORE_PARAMS:
             """
@@ -41,7 +46,7 @@ class PaginationQuery(QueryOperator):
         self.query = query  # type: ignore
 
     def query(self):
-        " Stub query function for abstract class "
+        "Stub query function for abstract class"
         pass
 
     def meta(self) -> Dict:

--- a/src/maggma/api/query_operator/sorting.py
+++ b/src/maggma/api/query_operator/sorting.py
@@ -1,7 +1,9 @@
 from typing import Optional
+
+from fastapi import HTTPException, Query
+
 from maggma.api.query_operator import QueryOperator
 from maggma.api.utils import STORE_PARAMS
-from fastapi import HTTPException, Query
 
 
 class SortQuery(QueryOperator):
@@ -12,7 +14,10 @@ class SortQuery(QueryOperator):
     def query(
         self,
         field: Optional[str] = Query(None, description="Field to sort with"),
-        ascending: Optional[bool] = Query(None, description="Whether the sorting should be ascending",),
+        ascending: Optional[bool] = Query(
+            None,
+            description="Whether the sorting should be ascending",
+        ),
     ) -> STORE_PARAMS:
 
         sort = {}
@@ -22,7 +27,8 @@ class SortQuery(QueryOperator):
 
         elif field or ascending is not None:
             raise HTTPException(
-                status_code=400, detail="Must specify both a field and order for sorting.",
+                status_code=400,
+                detail="Must specify both a field and order for sorting.",
             )
 
         return {"sort": sort}

--- a/src/maggma/api/query_operator/sparse_fields.py
+++ b/src/maggma/api/query_operator/sparse_fields.py
@@ -49,7 +49,7 @@ class SparseFieldsQuery(QueryOperator):
         self.query = query  # type: ignore
 
     def query(self):
-        " Stub query function for abstract class "
+        "Stub query function for abstract class"
         pass
 
     def meta(self) -> Dict:

--- a/src/maggma/api/query_operator/submission.py
+++ b/src/maggma/api/query_operator/submission.py
@@ -1,8 +1,10 @@
+from datetime import datetime
 from typing import Optional
+
+from fastapi import Query
+
 from maggma.api.query_operator import QueryOperator
 from maggma.api.utils import STORE_PARAMS
-from fastapi import Query
-from datetime import datetime
 
 
 class SubmissionQuery(QueryOperator):
@@ -19,7 +21,8 @@ class SubmissionQuery(QueryOperator):
                 None, description="Latest status of the submission"
             ),
             last_updated: Optional[datetime] = Query(
-                None, description="Minimum datetime of status update for submission",
+                None,
+                description="Minimum datetime of status update for submission",
             ),
         ) -> STORE_PARAMS:
 
@@ -45,5 +48,5 @@ class SubmissionQuery(QueryOperator):
         self.query = query
 
     def query(self):
-        " Stub query function for abstract class "
+        "Stub query function for abstract class"
         pass

--- a/src/maggma/api/resource/__init__.py
+++ b/src/maggma/api/resource/__init__.py
@@ -1,5 +1,9 @@
-from maggma.api.resource.aggregation import AggregationResource
+# isort: off
 from maggma.api.resource.core import Resource
+
+# isort: on
+
+from maggma.api.resource.aggregation import AggregationResource
 from maggma.api.resource.post_resource import PostOnlyResource
 from maggma.api.resource.read_resource import ReadOnlyResource, attach_query_ops
 from maggma.api.resource.submission import SubmissionResource

--- a/src/maggma/api/resource/__init__.py
+++ b/src/maggma/api/resource/__init__.py
@@ -1,5 +1,5 @@
+from maggma.api.resource.aggregation import AggregationResource
 from maggma.api.resource.core import Resource
+from maggma.api.resource.post_resource import PostOnlyResource
 from maggma.api.resource.read_resource import ReadOnlyResource, attach_query_ops
 from maggma.api.resource.submission import SubmissionResource
-from maggma.api.resource.aggregation import AggregationResource
-from maggma.api.resource.post_resource import PostOnlyResource

--- a/src/maggma/api/resource/aggregation.py
+++ b/src/maggma/api/resource/aggregation.py
@@ -7,10 +7,7 @@ from maggma.api.models import Meta, Response
 from maggma.api.query_operator import QueryOperator
 from maggma.api.resource import Resource
 from maggma.api.resource.utils import attach_query_ops
-from maggma.api.utils import (
-    STORE_PARAMS,
-    merge_queries,
-)
+from maggma.api.utils import STORE_PARAMS, merge_queries
 from maggma.core import Store
 
 

--- a/src/maggma/api/resource/post_resource.py
+++ b/src/maggma/api/resource/post_resource.py
@@ -1,21 +1,14 @@
-from typing import Any, Dict, List, Optional, Type
 from inspect import signature
+from typing import Any, Dict, List, Optional, Type
 
 from fastapi import HTTPException, Request
 from pydantic import BaseModel
 
 from maggma.api.models import Meta, Response
-from maggma.api.query_operator import (
-    PaginationQuery,
-    QueryOperator,
-    SparseFieldsQuery,
-)
+from maggma.api.query_operator import PaginationQuery, QueryOperator, SparseFieldsQuery
 from maggma.api.resource import Resource
 from maggma.api.resource.utils import attach_query_ops
-from maggma.api.utils import (
-    STORE_PARAMS,
-    merge_queries,
-)
+from maggma.api.utils import STORE_PARAMS, merge_queries
 from maggma.core import Store
 
 

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -1,21 +1,14 @@
-from typing import Any, Dict, List, Optional, Type
 from inspect import signature
+from typing import Any, Dict, List, Optional, Type
 
 from fastapi import Depends, HTTPException, Path, Request
 from pydantic import BaseModel
 
 from maggma.api.models import Meta, Response
-from maggma.api.query_operator import (
-    PaginationQuery,
-    QueryOperator,
-    SparseFieldsQuery,
-)
+from maggma.api.query_operator import PaginationQuery, QueryOperator, SparseFieldsQuery
 from maggma.api.resource import Resource
 from maggma.api.resource.utils import attach_query_ops
-from maggma.api.utils import (
-    STORE_PARAMS,
-    merge_queries,
-)
+from maggma.api.utils import STORE_PARAMS, merge_queries
 from maggma.core import Store
 
 
@@ -104,7 +97,9 @@ class ReadOnlyResource(Resource):
 
         async def get_by_key(
             key: str = Path(
-                ..., alias=key_name, title=f"The {key_name} of the {model_name} to get",
+                ...,
+                alias=key_name,
+                title=f"The {key_name} of the {model_name} to get",
             ),
             fields: STORE_PARAMS = Depends(field_input),
         ):

--- a/src/maggma/api/resource/submission.py
+++ b/src/maggma/api/resource/submission.py
@@ -1,23 +1,18 @@
-from typing import Any, List, Optional, Type
-from inspect import signature
 from datetime import datetime
+from enum import Enum
+from inspect import signature
+from typing import Any, List, Optional, Type
 from uuid import uuid4
 
 from fastapi import HTTPException, Path, Request
+from pydantic import BaseModel, Field, create_model
 
-from maggma.api.models import Response, Meta
-
+from maggma.api.models import Meta, Response
 from maggma.api.query_operator import QueryOperator, SubmissionQuery
-
 from maggma.api.resource import Resource
 from maggma.api.resource.utils import attach_query_ops
-from maggma.api.utils import (
-    STORE_PARAMS,
-    merge_queries,
-)
+from maggma.api.utils import STORE_PARAMS, merge_queries
 from maggma.core import Store
-from enum import Enum
-from pydantic import create_model, Field, BaseModel
 
 
 class SubmissionResource(Resource):
@@ -73,9 +68,7 @@ class SubmissionResource(Resource):
         self.tags = tags or []
         self.post_query_operators = post_query_operators
         self.get_query_operators = (
-            [
-                op for op in get_query_operators if op is not None  # type: ignore
-            ]
+            [op for op in get_query_operators if op is not None]  # type: ignore
             + [SubmissionQuery(state_enum)]
             if state_enum is not None
             else get_query_operators
@@ -281,7 +274,8 @@ class SubmissionResource(Resource):
                 self.store.update(docs=query["criteria"])  # type: ignore
             except Exception:
                 raise HTTPException(
-                    status_code=400, detail="Problem when trying to post data.",
+                    status_code=400,
+                    detail="Problem when trying to post data.",
                 )
 
             response = {

--- a/src/maggma/api/resource/utils.py
+++ b/src/maggma/api/resource/utils.py
@@ -1,5 +1,7 @@
-from typing import Callable, List, Dict
-from fastapi import Request, Depends
+from typing import Callable, Dict, List
+
+from fastapi import Depends, Request
+
 from maggma.api.query_operator import QueryOperator
 from maggma.api.utils import STORE_PARAMS, attach_signature
 

--- a/src/maggma/api/utils.py
+++ b/src/maggma/api/utils.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type, get_args
 
 from monty.json import MSONable
 from pydantic import BaseModel
@@ -110,12 +110,13 @@ def api_sanitize(
                 field.required = False
                 field.field_info.default = None
 
-            if (
-                field_type is not None
-                and lenient_issubclass(field_type, MSONable)
-                and allow_dict_msonable
-            ):
-                field.type_ = allow_msonable_dict(field_type)
+            if field_type is not None and allow_dict_msonable:
+                if lenient_issubclass(field_type, MSONable):
+                    field.type_ = allow_msonable_dict(field_type)
+                else:
+                    for sub_type in get_args(field_type):
+                        if lenient_issubclass(sub_type, MSONable):
+                            allow_msonable_dict(sub_type)
                 field.populate_validators()
 
     return pydantic_model

--- a/src/maggma/api/utils.py
+++ b/src/maggma/api/utils.py
@@ -1,11 +1,18 @@
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Type, get_args
+import sys
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from monty.json import MSONable
 from pydantic import BaseModel
 from pydantic.schema import get_flat_models_from_model
 from pydantic.utils import lenient_issubclass
 from typing_extensions import Literal
+
+if sys.version_info >= (3, 8):
+    from typing import get_args
+else:
+    from typing_extensions import get_args
+
 
 QUERY_PARAMS = ["criteria", "properties", "skip", "limit"]
 STORE_PARAMS = Dict[

--- a/src/maggma/core/store.py
+++ b/src/maggma/core/store.py
@@ -18,14 +18,14 @@ from maggma.utils import LU_KEY_ISOFORMAT
 
 
 class Sort(Enum):
-    """ Enumeration for sorting order """
+    """Enumeration for sorting order"""
 
     Ascending = 1
     Descending = -1
 
 
 class DateTimeFormat(Enum):
-    """ Datetime format in store document """
+    """Datetime format in store document"""
 
     DateTime = "datetime"
     IsoFormat = "isoformat"
@@ -354,7 +354,7 @@ class Store(MSONable, metaclass=ABCMeta):
 
 
 class StoreError(Exception):
-    """ General Store-related error """
+    """General Store-related error"""
 
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)


### PR DESCRIPTION
This should fix the issue where MSONable types in a combined type such as `Union` and `Dict` were not being properly sanitized for the API.