### PR TITLE
BugFix: Manual distinct in MongoStore not using Criteria

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -177,7 +177,9 @@ class MongoStore(Store):
         kwargs.pop("aliases", None)
         return cls(**kwargs)
 
-    def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
+    def distinct(
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+    ) -> List:
         """
         Get all distinct values for a field
 
@@ -190,7 +192,12 @@ class MongoStore(Store):
         try:
             distinct_vals = self._collection.distinct(field, criteria)
         except (OperationFailure, DocumentTooLarge):
-            distinct_vals = [d["_id"] for d in self._collection.aggregate([{"$group": {"_id": f"${field}"}}])]
+            distinct_vals = [
+                d["_id"]
+                for d in self._collection.aggregate(
+                    [{"$match": criteria}, {"$group": {"_id": f"${field}"}}]
+                )
+            ]
             if all(isinstance(d, list) for d in filter(None, distinct_vals)):  # type: ignore
                 distinct_vals = list(chain.from_iterable(filter(None, distinct_vals)))
 
@@ -306,10 +313,21 @@ class MongoStore(Store):
             properties = {p: 1 for p in properties}
 
         sort_list = (
-            [(k, Sort(v).value) if isinstance(v, int) else (k, v.value) for k, v in sort.items()] if sort else None
+            [
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in sort.items()
+            ]
+            if sort
+            else None
         )
 
-        for d in self._collection.find(filter=criteria, projection=properties, skip=skip, limit=limit, sort=sort_list,):
+        for d in self._collection.find(
+            filter=criteria,
+            projection=properties,
+            skip=skip,
+            limit=limit,
+            sort=sort_list,
+        ):
             yield d
 
     def ensure_index(self, key: str, unique: Optional[bool] = False) -> bool:
@@ -423,7 +441,12 @@ class MongoURIStore(MongoStore):
     """
 
     def __init__(
-        self, uri: str, collection_name: str, database: str = None, ssh_tunnel: Optional[SSHTunnel] = None, **kwargs
+        self,
+        uri: str,
+        collection_name: str,
+        database: str = None,
+        ssh_tunnel: Optional[SSHTunnel] = None,
+        **kwargs,
     ):
         """
         Args:
@@ -438,7 +461,9 @@ class MongoURIStore(MongoStore):
         if database is None:
             d_uri = uri_parser.parse_uri(uri)
             if d_uri["database"] is None:
-                raise ConfigurationError("If database name is not supplied, a database must be set in the uri")
+                raise ConfigurationError(
+                    "If database name is not supplied, a database must be set in the uri"
+                )
             self.database = d_uri["database"]
         else:
             self.database = database
@@ -527,7 +552,11 @@ class MemoryStore(MongoStore):
             generator returning tuples of (key, list of elemnts)
         """
         keys = keys if isinstance(keys, list) else [keys]
-        data = [doc for doc in self.query(properties=keys, criteria=criteria) if all(has(doc, k) for k in keys)]
+        data = [
+            doc
+            for doc in self.query(properties=keys, criteria=criteria)
+            if all(has(doc, k) for k in keys)
+        ]
 
         def grouping_keys(doc):
             return tuple(get(doc, k) for k in keys)

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -86,6 +86,13 @@ def test_mongostore_distinct(mongostore):
     assert len(vals) == len(list(range(1000000)))
     assert all([isinstance(v, str) for v in vals])
 
+    # Test to make sure manual distinct uses the criteria query
+    mongostore._collection.insert_many(
+        [{"key": f"mp-{i}", "a": 2} for i in range(1000001, 2000001)]
+    )
+    vals = mongostore.distinct("key", {"a": 2})
+    assert len(vals) == len(list(range(1000001, 2000001)))
+
 
 def test_mongostore_update(mongostore):
     mongostore.update({"e": 6, "d": 4}, key="e")


### PR DESCRIPTION
This PR fixes a bug in `MongoStore` where the manual distinct operation, which triggers if the server side distinct returns > 16mb of data, was not using `criteria` to filter the result.

- [x] Added test for bug and ensures it failed
- [x] Fixed bug in code