### PR TITLE
Enable monty encoded direct responses

### DIFF
--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -48,7 +48,7 @@ class ReadOnlyResource(Resource):
             enable_default_search: Enable default endpoint search behavior.
             monty_encoded_response: Whether to use MontyEncoder and provide a direct FastAPI response.
                 Note this will disable auto JSON serialization and response validation with the
-                provided model. 
+                provided model.
             include_in_schema: Whether the endpoint should be shown in the documented schema.
             sub_path: sub-URL path for the resource.
         """

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -69,7 +69,7 @@ def test_msonable(owner_store):
 
 
 def test_get_by_key(owner_store):
-    endpoint = ReadOnlyResource(owner_store, Owner)
+    endpoint = ReadOnlyResource(owner_store, Owner, monty_encoded_response=True)
     app = FastAPI()
     app.include_router(endpoint.router)
 

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -128,6 +128,7 @@ def search_helper(payload, base: str = "/?", debug=True) -> Response:
             NumericQuery(model=Owner),
             SparseFieldsQuery(model=Owner),
         ],
+        monty_encoded_response=True,
     )
     app = FastAPI()
     app.include_router(endpoint.router)


### PR DESCRIPTION
This PR contains:

- [x] ReadOnlyResource allows for direct unvalidated responses encoded with MontyEncoder