### PR TITLE
Switch from monty to orjson for serialization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ uvicorn==0.13.4
 sshtunnel==0.4.0
 msgpack==1.0.2
 msgpack-python==0.5.6
+orjson==3.6.0

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -12,7 +12,6 @@ from maggma.api.resource.utils import attach_query_ops
 from maggma.api.utils import STORE_PARAMS, merge_queries, custom_serialization
 from maggma.core import Store
 
-from monty.serialization import MontyEncoder
 import orjson
 
 

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -9,7 +9,7 @@ from maggma.api.models import Meta, Response
 from maggma.api.query_operator import PaginationQuery, QueryOperator, SparseFieldsQuery
 from maggma.api.resource import Resource
 from maggma.api.resource.utils import attach_query_ops
-from maggma.api.utils import STORE_PARAMS, merge_queries, custom_serialization
+from maggma.api.utils import STORE_PARAMS, merge_queries, object_id_serilaization_helper
 from maggma.core import Store
 
 import orjson
@@ -32,7 +32,7 @@ class ReadOnlyResource(Resource):
         query: Optional[Dict] = None,
         enable_get_by_key: bool = True,
         enable_default_search: bool = True,
-        custom_encoded_response: bool = False,
+        disable_validation: bool = False,
         include_in_schema: Optional[bool] = True,
         sub_path: Optional[str] = "/",
     ):
@@ -46,7 +46,7 @@ class ReadOnlyResource(Resource):
                 to allow user to define these on-the-fly.
             enable_get_by_key: Enable default key route for endpoint.
             enable_default_search: Enable default endpoint search behavior.
-            custom_encoded_response: Whether to use ORJSON and provide a direct FastAPI response.
+            disable_validation: Whether to use ORJSON and provide a direct FastAPI response.
                 Note this will disable auto JSON serialization and response validation with the
                 provided model.
             include_in_schema: Whether the endpoint should be shown in the documented schema.
@@ -59,7 +59,7 @@ class ReadOnlyResource(Resource):
         self.versioned = False
         self.enable_get_by_key = enable_get_by_key
         self.enable_default_search = enable_default_search
-        self.custom_encoded_response = custom_encoded_response
+        self.disable_validation = disable_validation
         self.include_in_schema = include_in_schema
         self.sub_path = sub_path
         self.response_model = Response[model]  # type: ignore
@@ -138,9 +138,9 @@ class ReadOnlyResource(Resource):
 
             response = {"data": item}
 
-            if self.custom_encoded_response:
+            if self.disable_validation:
                 response = BareResponse(  # type: ignore
-                    orjson.dumps(response, default=custom_serialization)
+                    orjson.dumps(response, default=object_id_serilaization_helper)
                 )
 
             return response
@@ -195,9 +195,9 @@ class ReadOnlyResource(Resource):
 
             response = {"data": data, "meta": {**meta.dict(), **operator_meta}}
 
-            if self.custom_encoded_response:
+            if self.disable_validation:
                 response = BareResponse(  # type: ignore
-                    orjson.dumps(response, default=custom_serialization)
+                    orjson.dumps(response, default=object_id_serilaization_helper)
                 )
 
             return response

--- a/src/maggma/api/utils.py
+++ b/src/maggma/api/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import sys
 from typing import Any, Callable, Dict, List, Optional, Type
+from bson.objectid import ObjectId
 
 from monty.json import MSONable
 from pydantic import BaseModel
@@ -161,3 +162,9 @@ def allow_msonable_dict(monty_cls: Type[MSONable]):
     setattr(monty_cls, "validate_monty", classmethod(validate_monty))
 
     return monty_cls
+
+
+def custom_serialization(obj):
+    if isinstance(obj, ObjectId):
+        return str(obj)
+    raise TypeError

--- a/src/maggma/api/utils.py
+++ b/src/maggma/api/utils.py
@@ -164,7 +164,7 @@ def allow_msonable_dict(monty_cls: Type[MSONable]):
     return monty_cls
 
 
-def custom_serialization(obj):
+def object_id_serilaization_helper(obj):
     if isinstance(obj, ObjectId):
         return str(obj)
     raise TypeError

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -69,7 +69,7 @@ def test_msonable(owner_store):
 
 
 def test_get_by_key(owner_store):
-    endpoint = ReadOnlyResource(owner_store, Owner, custom_encoded_response=True)
+    endpoint = ReadOnlyResource(owner_store, Owner, disable_validation=True)
     app = FastAPI()
     app.include_router(endpoint.router)
 
@@ -128,7 +128,7 @@ def search_helper(payload, base: str = "/?", debug=True) -> Response:
             NumericQuery(model=Owner),
             SparseFieldsQuery(model=Owner),
         ],
-        custom_encoded_response=True,
+        disable_validation=True,
     )
     app = FastAPI()
     app.include_router(endpoint.router)

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -69,7 +69,7 @@ def test_msonable(owner_store):
 
 
 def test_get_by_key(owner_store):
-    endpoint = ReadOnlyResource(owner_store, Owner, monty_encoded_response=True)
+    endpoint = ReadOnlyResource(owner_store, Owner, custom_encoded_response=True)
     app = FastAPI()
     app.include_router(endpoint.router)
 
@@ -128,7 +128,7 @@ def search_helper(payload, base: str = "/?", debug=True) -> Response:
             NumericQuery(model=Owner),
             SparseFieldsQuery(model=Owner),
         ],
-        monty_encoded_response=True,
+        custom_encoded_response=True,
     )
     app = FastAPI()
     app.include_router(endpoint.router)

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -96,3 +96,9 @@ def test_api_sanitize():
 def test_object_id_serilaization_helper():
     oid = ObjectId("60b7d47bb671aa7b01a2adf6")
     assert object_id_serilaization_helper(oid) == "60b7d47bb671aa7b01a2adf6"
+
+
+@pytest.mark.xfail
+def test_object_id_serilaization_helper_xfail():
+    oid = "test"
+    object_id_serilaization_helper(oid)

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -5,8 +5,10 @@ import pytest
 from monty.json import MSONable
 from pydantic import BaseModel, Field
 
-from maggma.api.utils import api_sanitize
+from maggma.api.utils import api_sanitize, object_id_serilaization_helper
 from typing import Union
+
+from bson import ObjectId
 
 
 class SomeEnum(Enum):
@@ -89,3 +91,8 @@ def test_api_sanitize():
     temp_pet_dict = AnotherPet(name="fido", age=3).as_dict()
 
     assert isinstance(AnotherPet.validate_monty(temp_pet_dict), dict)
+
+
+def test_object_id_serilaization_helper():
+    oid = ObjectId("60b7d47bb671aa7b01a2adf6")
+    assert object_id_serilaization_helper(oid) == "60b7d47bb671aa7b01a2adf6"


### PR DESCRIPTION
This PR switches to using orjson for custom serialization in ReadOnlyResource.