### PR TITLE
Enable enhanced documentation

### DIFF
--- a/src/maggma/api/API.py
+++ b/src/maggma/api/API.py
@@ -23,6 +23,8 @@ class API(MSONable):
         version: str = "v0.0.0",
         debug: bool = False,
         heartbeat_meta: Optional[Dict] = None,
+        description: str = None,
+        tags_meta: List[Dict] = None,
     ):
         """
         Args:
@@ -31,11 +33,15 @@ class API(MSONable):
             version: the version for this API
             debug: turns debug on in FastAPI
             heartbeat_meta: dictionary of additional metadata to include in the heartbeat response
+            description: decription of the API to be used in the generated docs
+            tags_meta: descriptions of tags to be used in the generated docs
         """
         self.title = title
         self.version = version
         self.debug = debug
         self.heartbeat_meta = heartbeat_meta
+        self.description = description
+        self.tags_meta = tags_meta
 
         if len(resources) == 0:
             raise RuntimeError("ERROR: There are no endpoints provided")
@@ -60,6 +66,8 @@ class API(MSONable):
             version=self.version,
             on_startup=[self.on_startup],
             debug=self.debug,
+            description=self.description,
+            openapi_tags=self.tags_meta,
         )
 
         # Allow requests from other domains in debug mode. This allows

--- a/src/maggma/api/query_operator/sparse_fields.py
+++ b/src/maggma/api/query_operator/sparse_fields.py
@@ -30,7 +30,8 @@ class SparseFieldsQuery(QueryOperator):
         def query(
             fields: str = Query(
                 None,
-                description=f"Fields to project from {str(model_name)} as a list of comma seperated strings",
+                description=f"Fields to project from {str(model_name)} as a list of comma seperated strings.\
+                    Fields include: {model_fields}",
             ),
             all_fields: bool = Query(False, description="Include all fields."),
         ) -> STORE_PARAMS:

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -147,7 +147,8 @@ class ReadOnlyResource(Resource):
 
         self.router.get(
             f"{self.sub_path}{{{key_name}}}/",
-            response_description=f"Get an {model_name} by {key_name}",
+            summary=f"Get a {model_name} document by by {key_name}",
+            response_description=f"Get a {model_name} document by {key_name}",
             response_model=self.response_model,
             response_model_exclude_unset=True,
             tags=self.tags,


### PR DESCRIPTION
This PR includes:

- [x] API and tag descriptions can now be passed to `API` for FastAPI generated documentation
- [x] GetByKey now has a more detailed description
- [x] Model fields to project now explicitly listed in sparse fields query op