### PR TITLE
Add from_launchpad_file classmethod to MongoStore

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -199,7 +199,6 @@ class MongoStore(Store):
 
         return cls(**db_creds)
 
-
     def distinct(
         self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
     ) -> List:

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -6,6 +6,7 @@ various utilities
 """
 
 import json
+import yaml
 from itertools import chain, groupby
 from socket import socket
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -176,6 +177,28 @@ class MongoStore(Store):
         # Get rid of aliases from traditional query engine db docs
         kwargs.pop("aliases", None)
         return cls(**kwargs)
+
+    @classmethod
+    def from_launchpad_file(cls, lp_file, collection_name):
+        """
+        Convenience method to construct MongoStore from a launchpad file
+
+        Note: A launchpad file is a special formatted yaml file used in fireworks
+
+        Returns:
+        """
+        with open(lp_file, 'r') as f:
+            lp_creds = yaml.load(f, Loader=None)
+
+        db_creds = lp_creds.copy()
+        db_creds['database'] = db_creds['name']
+        for key in list(db_creds.keys()):
+            if key not in ['database', 'host', 'port', 'username', 'password']:
+                db_creds.pop(key)
+        db_creds['collection_name'] = collection_name
+
+        return cls(**db_creds)
+
 
     def distinct(
         self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def db_json(test_dir):
 @pytest.fixture
 def lp_file(test_dir):
     db_dir = test_dir / "settings_files"
-    lp_file = db_dir / "db.json"
+    lp_file = db_dir / "my_launchpad.yaml"
     return lp_file.resolve()
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,12 @@ def db_json(test_dir):
 
 
 @pytest.fixture
+def lp_file(test_dir):
+    db_dir = test_dir / "settings_files"
+    lp_file = db_dir / "db.json"
+    return lp_file.resolve()
+
+@pytest.fixture
 def log_to_stdout():
     # Set Logging
     root = logging.getLogger()

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -162,6 +162,11 @@ def test_mongostore_from_db_file(mongostore, db_json):
     ms.connect()
     assert ms._collection.full_name == "maggma_tests.tmp"
 
+def test_mongostore_from_launchpad_file(lp_file):
+    ms = MongoStore.from_launchpad_file(lp_file, collection_name='tmp')
+    ms.connect()
+    assert ms._collection.full_name == "maggma_tests.tmp"
+
 
 def test_mongostore_from_collection(mongostore, db_json):
     ms = MongoStore.from_db_file(db_json)

--- a/tests/test_files/settings_files/my_launchpad.yaml
+++ b/tests/test_files/settings_files/my_launchpad.yaml
@@ -1,0 +1,5 @@
+{
+ 'name': "maggma_tests",
+ 'host': "localhost"
+ 'port': 27017,
+}

--- a/tests/test_files/settings_files/my_launchpad.yaml
+++ b/tests/test_files/settings_files/my_launchpad.yaml
@@ -1,5 +1,3 @@
-{
- 'name': "maggma_tests",
- 'host': "localhost"
- 'port': 27017,
-}
+host: "localhost"
+port: 27017
+name: "maggma_tests"


### PR DESCRIPTION
This pull request adds a convenience method to create a MongoStore from launchpad file.

- [ ] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
