### PR TITLE
Change to S3Store serialization behavior in update() and other Mongolike Store changes

### DIFF
--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -34,18 +34,18 @@ class S3Store(Store):
     """
 
     def __init__(
-        self,
-        index: Store,
-        bucket: str,
-        s3_profile: Union[str, dict] = None,
-        compress: bool = False,
-        endpoint_url: str = None,
-        sub_dir: str = None,
-        s3_workers: int = 1,
-        key: str = "fs_id",
-        store_hash: bool = True,
-        searchable_fields: Optional[List[str]] = None,
-        **kwargs,
+            self,
+            index: Store,
+            bucket: str,
+            s3_profile: Union[str, dict] = None,
+            compress: bool = False,
+            endpoint_url: str = None,
+            sub_dir: str = None,
+            s3_workers: int = 1,
+            key: str = "fs_id",
+            store_hash: bool = True,
+            searchable_fields: Optional[List[str]] = None,
+            **kwargs,
     ):
         """
         Initializes an S3 Store
@@ -154,12 +154,12 @@ class S3Store(Store):
         return self.index.count(criteria)
 
     def query(
-        self,
-        criteria: Optional[Dict] = None,
-        properties: Union[Dict, List, None] = None,
-        sort: Optional[Dict[str, Union[Sort, int]]] = None,
-        skip: int = 0,
-        limit: int = 0,
+            self,
+            criteria: Optional[Dict] = None,
+            properties: Union[Dict, List, None] = None,
+            sort: Optional[Dict[str, Union[Sort, int]]] = None,
+            skip: int = 0,
+            limit: int = 0,
     ) -> Iterator[Dict]:
         """
         Queries the Store for a set of documents
@@ -179,7 +179,7 @@ class S3Store(Store):
             prop_keys = set(properties)
 
         for doc in self.index.query(
-            criteria=criteria, sort=sort, limit=limit, skip=skip
+                criteria=criteria, sort=sort, limit=limit, skip=skip
         ):
             if properties is not None and prop_keys.issubset(set(doc.keys())):
                 yield {p: doc[p] for p in properties if p in doc}
@@ -188,8 +188,8 @@ class S3Store(Store):
                     # TODO: THis is ugly and unsafe, do some real checking before pulling data
                     data = (
                         self.s3_bucket.Object(self.sub_dir + str(doc[self.key]))
-                        .get()["Body"]
-                        .read()
+                            .get()["Body"]
+                            .read()
                     )
                 except botocore.exceptions.ClientError as e:
                     # If a client error is thrown, then check that it was a 404 error.
@@ -220,7 +220,7 @@ class S3Store(Store):
                 yield unpacked_data
 
     def distinct(
-        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+            self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
     ) -> List:
         """
         Get all distinct values for a field
@@ -233,13 +233,13 @@ class S3Store(Store):
         return self.index.distinct(field, criteria=criteria)
 
     def groupby(
-        self,
-        keys: Union[List[str], str],
-        criteria: Optional[Dict] = None,
-        properties: Union[Dict, List, None] = None,
-        sort: Optional[Dict[str, Union[Sort, int]]] = None,
-        skip: int = 0,
-        limit: int = 0,
+            self,
+            keys: Union[List[str], str],
+            criteria: Optional[Dict] = None,
+            properties: Union[Dict, List, None] = None,
+            sort: Optional[Dict[str, Union[Sort, int]]] = None,
+            skip: int = 0,
+            limit: int = 0,
     ) -> Iterator[Tuple[Dict, List[Dict]]]:
         """
         Simple grouping function that will group documents
@@ -280,10 +280,10 @@ class S3Store(Store):
         return self.index.ensure_index(key, unique=unique)
 
     def update(
-        self,
-        docs: Union[List[Dict], Dict],
-        key: Union[List, str, None] = None,
-        additional_metadata: Union[str, List[str], None] = None,
+            self,
+            docs: Union[List[Dict], Dict],
+            key: Union[List, str, None] = None,
+            additional_metadata: Union[str, List[str], None] = None,
     ):
         """
         Update documents into the Store
@@ -382,7 +382,7 @@ class S3Store(Store):
             )
 
         s3_bucket.put_object(
-            Key=self.sub_dir + str(doc[self.key]), Body=data, Metadata={k:str(v) for k,v in search_doc.items()}
+            Key=self.sub_dir + str(doc[self.key]), Body=data, Metadata={k: str(v) for k, v in search_doc.items()}
         )
 
         if lu_info is not None:
@@ -420,7 +420,7 @@ class S3Store(Store):
         return self.index.last_updated
 
     def newer_in(
-        self, target: Store, criteria: Optional[Dict] = None, exhaustive: bool = False
+            self, target: Store, criteria: Optional[Dict] = None, exhaustive: bool = False
     ) -> List[str]:
         """
         Returns the keys of documents that are newer in the target

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -187,7 +187,7 @@ class S3Store(Store):
                 try:
                     # TODO: THis is ugly and unsafe, do some real checking before pulling data
                     data = (
-                        self.s3_bucket.Object(self.sub_dir + doc[self.key])
+                        self.s3_bucket.Object(self.sub_dir + str(doc[self.key]))
                         .get()["Body"]
                         .read()
                     )
@@ -357,7 +357,7 @@ class S3Store(Store):
         """
         s3_bucket = self._get_bucket()
 
-        search_doc = {k: str(doc[k]) for k in search_keys}
+        search_doc = {k: doc[k] for k in search_keys}
         search_doc[self.key] = doc[self.key]  # Ensure key is in metadata
         if self.sub_dir != "":
             search_doc["sub_dir"] = self.sub_dir
@@ -382,7 +382,7 @@ class S3Store(Store):
             )
 
         s3_bucket.put_object(
-            Key=self.sub_dir + str(doc[self.key]), Body=data, Metadata=search_doc
+            Key=self.sub_dir + str(doc[self.key]), Body=data, Metadata={k:str(v) for k,v in search_doc.items()}
         )
 
         if lu_info is not None:

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -87,7 +87,7 @@ class GridFSStore(Store):
         super().__init__(**kwargs)
 
     @classmethod
-    def from_launchpad_file(cls, lp_file, collection_name):
+    def from_launchpad_file(cls, lp_file, collection_name, **kwargs):
         """
         Convenience method to construct a GridFSStore from a launchpad file
 
@@ -105,7 +105,7 @@ class GridFSStore(Store):
                 db_creds.pop(key)
         db_creds['collection_name'] = collection_name
 
-        return cls(**db_creds)
+        return cls(**db_creds, **kwargs)
 
     @property
     def name(self) -> str:

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -8,6 +8,7 @@ various utillities
 import copy
 import json
 import zlib
+import yaml
 from datetime import datetime
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -61,7 +62,7 @@ class GridFSStore(Store):
             collection_name: The name of the collection.
                 This is the string portion before the GridFS extensions
             host: hostname for the database
-            port: port to connec to
+            port: port to connect to
             username: username to connect as
             password: password to authenticate as
             compression: compress the data as it goes into GridFS
@@ -84,6 +85,27 @@ class GridFSStore(Store):
         if "key" not in kwargs:
             kwargs["key"] = "_id"
         super().__init__(**kwargs)
+
+    @classmethod
+    def from_launchpad_file(cls, lp_file, collection_name):
+        """
+        Convenience method to construct a GridFSStore from a launchpad file
+
+        Note: A launchpad file is a special formatted yaml file used in fireworks
+
+        Returns:
+        """
+        with open(lp_file, 'r') as f:
+            lp_creds = yaml.load(f, Loader=None)
+
+        db_creds = lp_creds.copy()
+        db_creds['database'] = db_creds['name']
+        for key in list(db_creds.keys()):
+            if key not in ['database', 'host', 'port', 'username', 'password']:
+                db_creds.pop(key)
+        db_creds['collection_name'] = collection_name
+
+        return cls(**db_creds)
 
     @property
     def name(self) -> str:

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -166,7 +166,7 @@ class MongoStore(Store):
         return hash((self.database, self.collection_name, self.last_updated_field))
 
     @classmethod
-    def from_db_file(cls, filename: str):
+    def from_db_file(cls, filename: str, **kwargs):
         """
         Convenience method to construct MongoStore from db_file
         from old QueryEngine format
@@ -179,7 +179,7 @@ class MongoStore(Store):
         return cls(**kwargs)
 
     @classmethod
-    def from_launchpad_file(cls, lp_file, collection_name):
+    def from_launchpad_file(cls, lp_file, collection_name, **kwargs):
         """
         Convenience method to construct MongoStore from a launchpad file
 
@@ -197,7 +197,7 @@ class MongoStore(Store):
                 db_creds.pop(key)
         db_creds['collection_name'] = collection_name
 
-        return cls(**db_creds)
+        return cls(**db_creds, **kwargs)
 
     def distinct(
         self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False

--- a/tests/stores/test_gridfs.py
+++ b/tests/stores/test_gridfs.py
@@ -234,6 +234,12 @@ def test_gfs_metadata(gridfsstore):
         assert gridfsstore.last_updated_field in d
 
 
+def test_gridfsstore_from_launchpad_file(lp_file):
+    ms = GridFSStore.from_launchpad_file(lp_file, collection_name='tmp')
+    ms.connect()
+    assert ms._collection.full_name == "maggma_tests.tmp"
+
+
 def test_searchable_fields(gridfsstore):
 
     tic = datetime(2018, 4, 12, 16)

--- a/tests/stores/test_gridfs.py
+++ b/tests/stores/test_gridfs.py
@@ -237,7 +237,7 @@ def test_gfs_metadata(gridfsstore):
 def test_gridfsstore_from_launchpad_file(lp_file):
     ms = GridFSStore.from_launchpad_file(lp_file, collection_name='tmp')
     ms.connect()
-    assert ms._collection.name == "gridfs://localhost/maggma_tests/tmp"
+    assert ms.name == "gridfs://localhost/maggma_tests/tmp"
 
 
 def test_searchable_fields(gridfsstore):

--- a/tests/stores/test_gridfs.py
+++ b/tests/stores/test_gridfs.py
@@ -237,7 +237,7 @@ def test_gfs_metadata(gridfsstore):
 def test_gridfsstore_from_launchpad_file(lp_file):
     ms = GridFSStore.from_launchpad_file(lp_file, collection_name='tmp')
     ms.connect()
-    assert ms._collection.full_name == "maggma_tests.tmp"
+    assert ms._collection.name == "gridfs://localhost/maggma_tests/tmp"
 
 
 def test_searchable_fields(gridfsstore):

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -162,6 +162,7 @@ def test_mongostore_from_db_file(mongostore, db_json):
     ms.connect()
     assert ms._collection.full_name == "maggma_tests.tmp"
 
+
 def test_mongostore_from_launchpad_file(lp_file):
     ms = MongoStore.from_launchpad_file(lp_file, collection_name='tmp')
     ms.connect()


### PR DESCRIPTION
1. Change the behavior of s3/minio stores, so metadata can be queried by its original type. 
2. Added from_launchpad_file for GridFS Store
3. Added kwargs to MongoStore.from_launchpad_file

### Description of 1:

* Store metadata as original type in index collection. For example, when inserting the following document into an s3store
  ```
  doc = {'formula_pretty': 'Si', 'nsites': 10, 'composition': {'Si': 1}}
  s3store.update(doc, key='formula_pretty')
  ```
  will be stored in the index with all keys and values converted to strings
  ```
  doc = {'formula_pretty': 'Si', 'nsites': '10', 'composition': "{'Si': 1}"}
  ```

* This also fixes an issue with having non-string types passed to s3_bucket.put_object() in the search_doc. Don't fully understand the issue, but it's possible one of the items that was later was not of type str.
