### PR TITLE
Alter sorting query operator to take comma delimited string

### DIFF
--- a/src/maggma/api/query_operator/sorting.py
+++ b/src/maggma/api/query_operator/sorting.py
@@ -13,14 +13,17 @@ class SortQuery(QueryOperator):
 
     def query(
         self,
-        sort_fields: Optional[List[str]] = Query(None, description="Fields to sort with. Prefixing '-' to a field will\
- force a sort in descending order."),
+        sort_fields: Optional[str] = Query(
+            None,
+            description="Comma delimited fields to sort with.\
+ Prefixing '-' to a field will force a sort in descending order.",
+        ),
     ) -> STORE_PARAMS:
 
         sort = {}
 
         if sort_fields:
-            for sort_field in sort_fields:
+            for sort_field in sort_fields.split(","):
                 if sort_field[0] == "-":
                     sort.update({sort_field[1:]: -1})
                 else:

--- a/tests/api/test_query_operators.py
+++ b/tests/api/test_query_operators.py
@@ -87,7 +87,7 @@ def test_sort_query_functionality():
 
     op = SortQuery()
 
-    assert op.query(sort_fields=["volume", "-density"]) == {"sort": {"volume": 1, "density": -1}}
+    assert op.query(sort_fields="volume,-density") == {"sort": {"volume": 1, "density": -1}}
 
 
 def test_sort_serialization():
@@ -97,7 +97,7 @@ def test_sort_serialization():
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-        assert new_op.query(sort_fields=["volume", "-density"]) == {"sort": {"volume": 1, "density": -1}}
+        assert new_op.query(sort_fields="volume,-density") == {"sort": {"volume": 1, "density": -1}}
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR alters the `sort_fields` input for the sorting query operator to be a comma delimited string of fields instead of a list. 