### PR TITLE
Added on-disk MongoDB compatible MontyStore

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -5,3 +5,4 @@ IPython==7.16.1;python_version<"3.7"
 IPython==7.25.0;python_version>"3.6"
 nbformat==5.1.3
 regex==2020.11.13
+montydb==2.3.12

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     extras_require={
         "vault": ["hvac>=0.9.5"],
         "S3": ["boto3>=1.14.56"],
+        "montydb": ["monty>=2.3.12"],
         "notebook_runner": ["IPython>=7.16", "nbformat>=5.0", "regex>=2020.6"],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     extras_require={
         "vault": ["hvac>=0.9.5"],
         "S3": ["boto3>=1.14.56"],
-        "montydb": ["monty>=2.3.12"],
+        "montydb": ["montydb>=2.3.12"],
         "notebook_runner": ["IPython>=7.16", "nbformat>=5.0", "regex>=2020.6"],
     },
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,25 @@ import pytest
 
 
 @pytest.fixture
+def tmp_dir():
+    """
+    Create a clean directory and cd into it.
+
+    The directory will be removed at the end of the test.
+    """
+    import os
+    import shutil
+    import tempfile
+
+    old_cwd = os.getcwd()
+    newpath = tempfile.mkdtemp()
+    os.chdir(newpath)
+    yield
+    os.chdir(old_cwd)
+    shutil.rmtree(newpath)
+
+
+@pytest.fixture
 def test_dir():
     module_dir = Path(__file__).resolve().parent
     test_dir = module_dir / "test_files"
@@ -24,6 +43,7 @@ def lp_file(test_dir):
     db_dir = test_dir / "settings_files"
     lp_file = db_dir / "my_launchpad.yaml"
     return lp_file.resolve()
+
 
 @pytest.fixture
 def log_to_stdout():

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -12,6 +12,7 @@ from pymongo.errors import ConfigurationError, DocumentTooLarge, OperationFailur
 import maggma.stores
 from maggma.core import StoreError
 from maggma.stores import JSONStore, MemoryStore, MongoStore, MongoURIStore
+from maggma.stores.mongolike import MontyStore
 from maggma.validators import JSONSchemaValidator
 
 
@@ -21,6 +22,13 @@ def mongostore():
     store.connect()
     yield store
     store._collection.drop()
+
+
+@pytest.fixture
+def montystore(tmp_dir):
+    store = MontyStore("maggma_test")
+    store.connect()
+    return store
 
 
 @pytest.fixture
@@ -168,7 +176,7 @@ def test_mongostore_from_db_file(mongostore, db_json):
 
 
 def test_mongostore_from_launchpad_file(lp_file):
-    ms = MongoStore.from_launchpad_file(lp_file, collection_name='tmp')
+    ms = MongoStore.from_launchpad_file(lp_file, collection_name="tmp")
     ms.connect()
     assert ms._collection.full_name == "maggma_tests.tmp"
 
@@ -273,6 +281,116 @@ def test_groupby(memorystore):
     assert len(data) == 2
 
 
+# Monty store tests
+def test_monty_store_connect(tmp_dir):
+    montystore = MontyStore(collection_name="my_collection")
+    assert montystore._collection is None
+    montystore.connect()
+    assert montystore._collection is not None
+
+
+def test_monty_store_groupby(montystore):
+    montystore.update(
+        [
+            {"e": 7, "d": 9, "f": 9},
+            {"e": 7, "d": 9, "f": 10},
+            {"e": 8, "d": 9, "f": 11},
+            {"e": 9, "d": 10, "f": 12},
+        ],
+        key="f",
+    )
+    data = list(montystore.groupby("d"))
+    assert len(data) == 2
+    grouped_by_9 = [g[1] for g in data if g[0]["d"] == 9][0]
+    assert len(grouped_by_9) == 3
+    grouped_by_10 = [g[1] for g in data if g[0]["d"] == 10][0]
+    assert len(grouped_by_10) == 1
+
+    data = list(montystore.groupby(["e", "d"]))
+    assert len(data) == 3
+
+    montystore.update(
+        [
+            {"e": {"d": 9}, "f": 9},
+            {"e": {"d": 9}, "f": 10},
+            {"e": {"d": 9}, "f": 11},
+            {"e": {"d": 10}, "f": 12},
+        ],
+        key="f",
+    )
+    data = list(montystore.groupby("e.d"))
+    assert len(data) == 2
+
+
+def test_montystore_query(montystore):
+    montystore._collection.insert_one({"a": 1, "b": 2, "c": 3})
+    assert montystore.query_one(properties=["a"])["a"] == 1
+    assert montystore.query_one(properties=["a"])["a"] == 1
+    assert montystore.query_one(properties=["b"])["b"] == 2
+    assert montystore.query_one(properties=["c"])["c"] == 3
+
+
+def test_montystore_count(montystore):
+    montystore._collection.insert_one({"a": 1, "b": 2, "c": 3})
+    assert montystore.count() == 1
+    montystore._collection.insert_one({"aa": 1, "b": 2, "c": 3})
+    assert montystore.count() == 2
+    assert montystore.count({"a": 1}) == 1
+
+
+def test_montystore_distinct(montystore):
+    montystore._collection.insert_one({"a": 1, "b": 2, "c": 3})
+    montystore._collection.insert_one({"a": 4, "d": 5, "e": 6, "g": {"h": 1}})
+    assert set(montystore.distinct("a")) == {1, 4}
+
+    # Test list distinct functionality
+    montystore._collection.insert_one({"a": 4, "d": 6, "e": 7})
+    montystore._collection.insert_one({"a": 4, "d": 6, "g": {"h": 2}})
+
+    # Test distinct subdocument functionality
+    ghs = montystore.distinct("g.h")
+    assert set(ghs) == {1, 2}
+
+    # Test when key doesn't exist
+    assert montystore.distinct("blue") == []
+
+    # Test when null is a value
+    montystore._collection.insert_one({"i": None})
+    assert montystore.distinct("i") == [None]
+
+
+def test_montystore_update(montystore):
+    montystore.update({"e": 6, "d": 4}, key="e")
+    assert (
+        montystore.query_one(criteria={"d": {"$exists": 1}}, properties=["d"])["d"] == 4
+    )
+
+    montystore.update([{"e": 7, "d": 8, "f": 9}], key=["d", "f"])
+    assert montystore.query_one(criteria={"d": 8, "f": 9}, properties=["e"])["e"] == 7
+
+    montystore.update([{"e": 11, "d": 8, "f": 9}], key=["d", "f"])
+    assert montystore.query_one(criteria={"d": 8, "f": 9}, properties=["e"])["e"] == 11
+
+    test_schema = {
+        "type": "object",
+        "properties": {"e": {"type": "integer"}},
+        "required": ["e"],
+    }
+    montystore.validator = JSONSchemaValidator(schema=test_schema)
+    montystore.update({"e": 100, "d": 3}, key="e")
+
+    # Continue to update doc when validator is not set to strict mode
+    montystore.update({"e": "abc", "d": 3}, key="e")
+
+
+def test_montystore_remove_docs(montystore):
+    montystore._collection.insert_one({"a": 1, "b": 2, "c": 3})
+    montystore._collection.insert_one({"a": 4, "d": 5, "e": 6, "g": {"h": 1}})
+    montystore.remove_docs({"a": 1})
+    assert len(list(montystore.query({"a": 4}))) == 1
+    assert len(list(montystore.query({"a": 1}))) == 0
+
+
 def test_json_store_load(jsonstore, test_dir):
     jsonstore.connect()
     assert len(list(jsonstore.query())) == 20
@@ -288,30 +406,34 @@ def test_json_store_writeable(test_dir):
         jsonstore = JSONStore("d.json", file_writable=True)
         jsonstore.connect()
         assert jsonstore.count() == 2
-        jsonstore.update({'new': 'hello', 'task_id': 2})
+        jsonstore.update({"new": "hello", "task_id": 2})
         assert jsonstore.count() == 3
         jsonstore.close()
         jsonstore = JSONStore("d.json", file_writable=True)
         jsonstore.connect()
         assert jsonstore.count() == 3
-        jsonstore.remove_docs({'a': 5})
+        jsonstore.remove_docs({"a": 5})
         assert jsonstore.count() == 2
         jsonstore.close()
         jsonstore = JSONStore("d.json", file_writable=True)
         jsonstore.connect()
         assert jsonstore.count() == 2
         jsonstore.close()
-        with mock.patch("maggma.stores.JSONStore.update_json_file") as update_json_file_mock:
+        with mock.patch(
+            "maggma.stores.JSONStore.update_json_file"
+        ) as update_json_file_mock:
             jsonstore = JSONStore("d.json", file_writable=False)
             jsonstore.connect()
-            jsonstore.update({'new': 'hello', 'task_id': 5})
+            jsonstore.update({"new": "hello", "task_id": 5})
             assert jsonstore.count() == 3
             jsonstore.close()
             update_json_file_mock.assert_not_called()
-        with mock.patch("maggma.stores.JSONStore.update_json_file") as update_json_file_mock:
+        with mock.patch(
+            "maggma.stores.JSONStore.update_json_file"
+        ) as update_json_file_mock:
             jsonstore = JSONStore("d.json", file_writable=False)
             jsonstore.connect()
-            jsonstore.remove_docs({'task_id': 5})
+            jsonstore.remove_docs({"task_id": 5})
             assert jsonstore.count() == 2
             jsonstore.close()
             update_json_file_mock.assert_not_called()


### PR DESCRIPTION
In my opinion, one missing component of the maggma stores is a persistent on disk store that can be accessed simultaneously from multiple python processes. Think an almost fully formed MongoDB instance but hosted locally on the file system. I think this is what #507 is hinting towards.

In this PR I've implemented a store based on the [MontyDB](https://github.com/davidlatwe/montydb) backend. This provides a MongoDB interface to several on disk stores including:

- sqlite: Uses an sqlite database to store documents.
- lightning: Uses Lightning Memory-Mapped Database (LMDB) for storage. This can provide fast read and write times but requires lmdb to be installed (in most cases this can be achieved using ``pip install lmdb``).
- flatfile: Uses a system of flat json files. This is not recommended as multiple simultaneous connections to the store will not work correctly.

The data is stored in a folder on disk controlled by the ``database_path`` option. Multiple databases and collections are stored as different files.

I've added full tests and MontyDB as an optional requirement. @davidwaroquiers you may be interested in this.

