### PR TITLE
Fix authentication for `MongoStore` to work with `pymongo==4.0`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,6 +53,9 @@ jobs:
         image: mongo:4.0
         ports:
           - 27017:27017
+        environment:
+          - MONGO_INITDB_ROOT_USERNAME=root
+          - MONGO_INITDB_ROOT_PASSWORD=password
 
     strategy:
       max-parallel: 6

--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -70,14 +70,14 @@ class JointStore(Store):
         Args:
             force_reset: whether to forcibly reset the connection
         """
-        conn = MongoClient(self.host, self.port)
-        db = conn[self.database]
-        if self.username != "":
-            db.authenticate(self.username, self.password)
-        self._collection = db[self.main]
-        self._has_merge_objects = (
-            self._collection.database.client.server_info()["version"] > "3.6"
+        conn = (
+            MongoClient(host=self.host, port=self.port, username=self.username, password=self.password)
+            if self.username != ""
+            else MongoClient(self.host, self.port)
         )
+        db = conn[self.database]
+        self._collection = db[self.main]
+        self._has_merge_objects = self._collection.database.client.server_info()["version"] > "3.6"
 
     def close(self):
         """
@@ -152,52 +152,26 @@ class JointStore(Store):
         collection_names = list(set(self.collection_names) - set(self.main))
         for cname in collection_names:
             pipeline.append(
-                {
-                    "$lookup": {
-                        "from": cname,
-                        "localField": self.key,
-                        "foreignField": self.key,
-                        "as": cname,
-                    }
-                }
+                {"$lookup": {"from": cname, "localField": self.key, "foreignField": self.key, "as": cname,}}
             )
 
             if self.merge_at_root:
                 if not self._has_merge_objects:
-                    raise Exception(
-                        "MongoDB server version too low to use $mergeObjects."
-                    )
+                    raise Exception("MongoDB server version too low to use $mergeObjects.")
 
                 pipeline.append(
                     {
                         "$replaceRoot": {
-                            "newRoot": {
-                                "$mergeObjects": [
-                                    {"$arrayElemAt": ["${}".format(cname), 0]},
-                                    "$$ROOT",
-                                ]
-                            }
+                            "newRoot": {"$mergeObjects": [{"$arrayElemAt": ["${}".format(cname), 0]}, "$$ROOT",]}
                         }
                     }
                 )
             else:
-                pipeline.append(
-                    {
-                        "$unwind": {
-                            "path": "${}".format(cname),
-                            "preserveNullAndEmptyArrays": True,
-                        }
-                    }
-                )
+                pipeline.append({"$unwind": {"path": "${}".format(cname), "preserveNullAndEmptyArrays": True,}})
 
         # Do projection for max last_updated
         lu_max_fields = ["${}".format(self.last_updated_field)]
-        lu_max_fields.extend(
-            [
-                "${}.{}".format(cname, self.last_updated_field)
-                for cname in self.collection_names
-            ]
-        )
+        lu_max_fields.extend(["${}.{}".format(cname, self.last_updated_field) for cname in self.collection_names])
         lu_proj = {self.last_updated_field: {"$max": lu_max_fields}}
         pipeline.append({"$addFields": lu_proj})
 
@@ -235,9 +209,7 @@ class JointStore(Store):
         skip: int = 0,
         limit: int = 0,
     ) -> Iterator[Dict]:
-        pipeline = self._get_pipeline(
-            criteria=criteria, properties=properties, skip=skip, limit=limit
-        )
+        pipeline = self._get_pipeline(criteria=criteria, properties=properties, skip=skip, limit=limit)
         agg = self._collection.aggregate(pipeline)
         for d in agg:
             yield d
@@ -251,9 +223,7 @@ class JointStore(Store):
         skip: int = 0,
         limit: int = 0,
     ) -> Iterator[Tuple[Dict, List[Dict]]]:
-        pipeline = self._get_pipeline(
-            criteria=criteria, properties=properties, skip=skip, limit=limit
-        )
+        pipeline = self._get_pipeline(criteria=criteria, properties=properties, skip=skip, limit=limit)
         if not isinstance(keys, list):
             keys = [keys]
         group_id = {}  # type: Dict[str,Any]
@@ -390,9 +360,7 @@ class ConcatStore(Store):
         """
         raise NotImplementedError("No update method for ConcatStore")
 
-    def distinct(
-        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
-    ) -> List:
+    def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
         """
         Get all distinct values for a field
 
@@ -485,14 +453,7 @@ class ConcatStore(Store):
         docs = []
         for store in self.stores:
             temp_docs = list(
-                store.groupby(
-                    keys=keys,
-                    criteria=criteria,
-                    properties=properties,
-                    sort=sort,
-                    skip=skip,
-                    limit=limit,
-                )
+                store.groupby(keys=keys, criteria=criteria, properties=properties, sort=sort, skip=skip, limit=limit,)
             )
             for key, group in temp_docs:
                 docs.extend(group)

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -119,11 +119,13 @@ class GridFSStore(Store):
         """
         Connect to the source data
         """
-        conn = MongoClient(self.host, self.port)
+        conn = (
+            MongoClient(host=self.host, port=self.port, username=self.username, password=self.password)
+            if self.username != ""
+            else MongoClient(self.host, self.port)
+        )
         if not self._collection or force_reset:
             db = conn[self.database]
-            if self.username != "":
-                db.authenticate(self.username, self.password)
 
             self._collection = gridfs.GridFS(db, self.collection_name)
             self._files_collection = db["{}.files".format(self.collection_name)]
@@ -154,9 +156,7 @@ class GridFSStore(Store):
         """
         new_criteria = dict()
         for field in criteria:
-            if field not in files_collection_fields and not field.startswith(
-                "metadata."
-            ):
+            if field not in files_collection_fields and not field.startswith("metadata."):
                 new_criteria["metadata." + field] = copy.copy(criteria[field])
             else:
                 new_criteria[field] = copy.copy(criteria[field])
@@ -210,18 +210,14 @@ class GridFSStore(Store):
         elif isinstance(properties, list):
             prop_keys = set(properties)
 
-        for doc in self._files_store.query(
-            criteria=criteria, sort=sort, limit=limit, skip=skip
-        ):
+        for doc in self._files_store.query(criteria=criteria, sort=sort, limit=limit, skip=skip):
             if properties is not None and prop_keys.issubset(set(doc.keys())):
                 yield {p: doc[p] for p in properties if p in doc}
             else:
 
                 metadata = doc.get("metadata", {})
 
-                data = self._collection.find_one(
-                    filter={"_id": doc["_id"]}, skip=skip, limit=limit, sort=sort,
-                ).read()
+                data = self._collection.find_one(filter={"_id": doc["_id"]}, skip=skip, limit=limit, sort=sort,).read()
 
                 if metadata.get("compression", "") == "zlib":
                     data = zlib.decompress(data).decode("UTF-8")
@@ -241,9 +237,7 @@ class GridFSStore(Store):
 
                 yield data
 
-    def distinct(
-        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
-    ) -> List:
+    def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
         """
         Get all distinct values for a field. This function only operates
         on the metadata in the files collection
@@ -252,17 +246,10 @@ class GridFSStore(Store):
             field: the field(s) to get distinct values for
             criteria: PyMongo filter for documents to search in
         """
-        criteria = (
-            self.transform_criteria(criteria)
-            if isinstance(criteria, dict)
-            else criteria
-        )
+        criteria = self.transform_criteria(criteria) if isinstance(criteria, dict) else criteria
 
         field = (
-            f"metadata.{field}"
-            if field not in files_collection_fields
-            and not field.startswith("metadata.")
-            else field
+            f"metadata.{field}" if field not in files_collection_fields and not field.startswith("metadata.") else field
         )
 
         return self._files_store.distinct(field=field, criteria=criteria)
@@ -294,30 +281,15 @@ class GridFSStore(Store):
             generator returning tuples of (dict, list of docs)
         """
 
-        criteria = (
-            self.transform_criteria(criteria)
-            if isinstance(criteria, dict)
-            else criteria
-        )
+        criteria = self.transform_criteria(criteria) if isinstance(criteria, dict) else criteria
         keys = [keys] if not isinstance(keys, list) else keys
         keys = [
-            f"metadata.{k}"
-            if k not in files_collection_fields and not k.startswith("metadata.")
-            else k
-            for k in keys
+            f"metadata.{k}" if k not in files_collection_fields and not k.startswith("metadata.") else k for k in keys
         ]
-        for group, ids in self._files_store.groupby(
-            keys, criteria=criteria, properties=[f"metadata.{self.key}"]
-        ):
-            ids = [
-                get(doc, f"metadata.{self.key}")
-                for doc in ids
-                if has(doc, f"metadata.{self.key}")
-            ]
+        for group, ids in self._files_store.groupby(keys, criteria=criteria, properties=[f"metadata.{self.key}"]):
+            ids = [get(doc, f"metadata.{self.key}") for doc in ids if has(doc, f"metadata.{self.key}")]
 
-            group = {
-                k.replace("metadata.", ""): get(group, k) for k in keys if has(group, k)
-            }
+            group = {k.replace("metadata.", ""): get(group, k) for k in keys if has(group, k)}
 
             yield group, list(self.query(criteria={self.key: {"$in": ids}}))
 
@@ -379,9 +351,7 @@ class GridFSStore(Store):
 
             metadata = {
                 k: get(d, k)
-                for k in [self.last_updated_field]
-                + additional_metadata
-                + self.searchable_fields
+                for k in [self.last_updated_field] + additional_metadata + self.searchable_fields
                 if has(d, k)
             }
             metadata.update(search_doc)
@@ -394,11 +364,7 @@ class GridFSStore(Store):
             search_doc = self.transform_criteria(search_doc)
 
             # Cleans up old gridfs entries
-            for fdoc in (
-                self._files_collection.find(search_doc, ["_id"])
-                .sort("uploadDate", -1)
-                .skip(1)
-            ):
+            for fdoc in self._files_collection.find(search_doc, ["_id"]).sort("uploadDate", -1).skip(1):
                 self._collection.delete(fdoc["_id"])
 
     def remove_docs(self, criteria: Dict):
@@ -465,9 +431,7 @@ class GridFSURIStore(GridFSStore):
         if database is None:
             d_uri = uri_parser.parse_uri(uri)
             if d_uri["database"] is None:
-                raise ConfigurationError(
-                    "If database name is not supplied, a database must be set in the uri"
-                )
+                raise ConfigurationError("If database name is not supplied, a database must be set in the uri")
             self.database = d_uri["database"]
         else:
             self.database = database

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -166,7 +166,11 @@ class MongoStore(Store):
 
             conn = (
                 MongoClient(
-                    host=host, port=port, username=self.username, password=self.password, authSource=self.database
+                    host=host,
+                    port=port,
+                    username=self.username,
+                    password=self.password,
+                    authSource=self.database,
                 )
                 if self.username != ""
                 else MongoClient(host, port)
@@ -212,7 +216,9 @@ class MongoStore(Store):
 
         return cls(**db_creds, **kwargs)
 
-    def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
+    def distinct(
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+    ) -> List:
         """
         Get all distinct values for a field
 
@@ -226,7 +232,10 @@ class MongoStore(Store):
             distinct_vals = self._collection.distinct(field, criteria)
         except (OperationFailure, DocumentTooLarge):
             distinct_vals = [
-                d["_id"] for d in self._collection.aggregate([{"$match": criteria}, {"$group": {"_id": f"${field}"}}])
+                d["_id"]
+                for d in self._collection.aggregate(
+                    [{"$match": criteria}, {"$group": {"_id": f"${field}"}}]
+                )
             ]
             if all(isinstance(d, list) for d in filter(None, distinct_vals)):  # type: ignore
                 distinct_vals = list(chain.from_iterable(filter(None, distinct_vals)))
@@ -346,15 +355,30 @@ class MongoStore(Store):
             properties = {p: 1 for p in properties}
 
         sort_list = (
-            [(k, Sort(v).value) if isinstance(v, int) else (k, v.value) for k, v in sort.items()] if sort else None
+            [
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in sort.items()
+            ]
+            if sort
+            else None
         )
 
         hint_list = (
-            [(k, Sort(v).value) if isinstance(v, int) else (k, v.value) for k, v in hint.items()] if hint else None
+            [
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in hint.items()
+            ]
+            if hint
+            else None
         )
 
         for d in self._collection.find(
-            filter=criteria, projection=properties, skip=skip, limit=limit, sort=sort_list, hint=hint_list,
+            filter=criteria,
+            projection=properties,
+            skip=skip,
+            limit=limit,
+            sort=sort_list,
+            hint=hint_list,
         ):
             yield d
 
@@ -469,7 +493,12 @@ class MongoURIStore(MongoStore):
     """
 
     def __init__(
-        self, uri: str, collection_name: str, database: str = None, ssh_tunnel: Optional[SSHTunnel] = None, **kwargs,
+        self,
+        uri: str,
+        collection_name: str,
+        database: str = None,
+        ssh_tunnel: Optional[SSHTunnel] = None,
+        **kwargs,
     ):
         """
         Args:
@@ -484,7 +513,9 @@ class MongoURIStore(MongoStore):
         if database is None:
             d_uri = uri_parser.parse_uri(uri)
             if d_uri["database"] is None:
-                raise ConfigurationError("If database name is not supplied, a database must be set in the uri")
+                raise ConfigurationError(
+                    "If database name is not supplied, a database must be set in the uri"
+                )
             self.database = d_uri["database"]
         else:
             self.database = database
@@ -573,7 +604,11 @@ class MemoryStore(MongoStore):
             generator returning tuples of (key, list of elemnts)
         """
         keys = keys if isinstance(keys, list) else [keys]
-        data = [doc for doc in self.query(properties=keys, criteria=criteria) if all(has(doc, k) for k in keys)]
+        data = [
+            doc
+            for doc in self.query(properties=keys, criteria=criteria)
+            if all(has(doc, k) for k in keys)
+        ]
 
         def grouping_keys(doc):
             return tuple(get(doc, k) for k in keys)
@@ -617,7 +652,9 @@ class JSONStore(MemoryStore):
         paths = paths if isinstance(paths, (list, tuple)) else [paths]
         self.paths = paths
         if file_writable and len(paths) > 1:
-            raise RuntimeError("Cannot instantiate file-writable JSONStore with multiple JSON files.")
+            raise RuntimeError(
+                "Cannot instantiate file-writable JSONStore with multiple JSON files."
+            )
         self.file_writable = file_writable
         self.kwargs = kwargs
         super().__init__(collection_name="collection", **kwargs)

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -18,7 +18,12 @@ from maggma.validators import JSONSchemaValidator
 
 @pytest.fixture
 def mongostore():
-    store = MongoStore("maggma_test", "test")
+    store = MongoStore(
+        database="maggma_test",
+        collection_name="test",
+        username="root",
+        password="password",
+    )
     store.connect()
     yield store
     store._collection.drop()
@@ -26,7 +31,7 @@ def mongostore():
 
 @pytest.fixture
 def montystore(tmp_dir):
-    store = MontyStore("maggma_test")
+    store = MontyStore("maggma_test", username="root", password="password")
     store.connect()
     return store
 


### PR DESCRIPTION
The authentication method for `Database` is removed as of pymongo 4.0. This PR updates `MongoStore` to authenticate at the `MongoClient` level as per these [docs](https://pymongo.readthedocs.io/en/stable/examples/authentication.html).