### PR TITLE
Fix issue with `close` and `MongoStore` and update `_collection` attribute

### DIFF
--- a/src/maggma/core/store.py
+++ b/src/maggma/core/store.py
@@ -64,12 +64,10 @@ class Store(MSONable, metaclass=ABCMeta):
         self.logger = logging.getLogger(type(self).__name__)
         self.logger.addHandler(logging.NullHandler())
 
-    @abstractproperty  # type: ignore
-    @deprecated(message="This will be removed in the future")
-    def collection(self):
+    @abstractproperty
+    def _collection(self):
         """
         Returns a handle to the pymongo collection object
-        Not guaranteed to exist in the future
         """
 
     @abstractproperty

--- a/src/maggma/stores/advanced_stores.py
+++ b/src/maggma/stores/advanced_stores.py
@@ -50,7 +50,7 @@ class MongograntStore(MongoStore):
         self.mongogrant_spec = mongogrant_spec
         self.collection_name = collection_name
         self.mgclient_config_path = mgclient_config_path
-        self._collection = None
+        self._coll = None
 
         if self.mgclient_config_path:
             config = Config(check=check, path=self.mgclient_config_path)
@@ -371,8 +371,8 @@ class AliasingStore(Store):
         self.store.close()
 
     @property
-    def collection(self):
-        return self.store.collection
+    def _collection(self):
+        return self.store._collection
 
     def connect(self, force_reset=False):
         self.store.connect(force_reset=force_reset)
@@ -544,8 +544,8 @@ class SandboxStore(Store):
         self.store.close()
 
     @property
-    def collection(self):
-        return self.store.collection
+    def _collection(self):
+        return self.store._collection
 
     def connect(self, force_reset=False):
         self.store.connect(force_reset=force_reset)

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -34,18 +34,18 @@ class S3Store(Store):
     """
 
     def __init__(
-            self,
-            index: Store,
-            bucket: str,
-            s3_profile: Union[str, dict] = None,
-            compress: bool = False,
-            endpoint_url: str = None,
-            sub_dir: str = None,
-            s3_workers: int = 1,
-            key: str = "fs_id",
-            store_hash: bool = True,
-            searchable_fields: Optional[List[str]] = None,
-            **kwargs,
+        self,
+        index: Store,
+        bucket: str,
+        s3_profile: Union[str, dict] = None,
+        compress: bool = False,
+        endpoint_url: str = None,
+        sub_dir: str = None,
+        s3_workers: int = 1,
+        key: str = "fs_id",
+        store_hash: bool = True,
+        searchable_fields: Optional[List[str]] = None,
+        **kwargs,
     ):
         """
         Initializes an S3 Store
@@ -130,9 +130,8 @@ class S3Store(Store):
         self.s3 = None
         self.s3_bucket = None
 
-    @property  # type: ignore
-    @deprecated(message="This will be removed in the future")
-    def collection(self):
+    @property
+    def _collection(self):
         """
         Returns:
             a handle to the pymongo collection object
@@ -141,7 +140,7 @@ class S3Store(Store):
             Not guaranteed to exist in the future
         """
         # For now returns the index collection since that is what we would "search" on
-        return self.index
+        return self.index._collection
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
@@ -154,12 +153,12 @@ class S3Store(Store):
         return self.index.count(criteria)
 
     def query(
-            self,
-            criteria: Optional[Dict] = None,
-            properties: Union[Dict, List, None] = None,
-            sort: Optional[Dict[str, Union[Sort, int]]] = None,
-            skip: int = 0,
-            limit: int = 0,
+        self,
+        criteria: Optional[Dict] = None,
+        properties: Union[Dict, List, None] = None,
+        sort: Optional[Dict[str, Union[Sort, int]]] = None,
+        skip: int = 0,
+        limit: int = 0,
     ) -> Iterator[Dict]:
         """
         Queries the Store for a set of documents
@@ -179,7 +178,7 @@ class S3Store(Store):
             prop_keys = set(properties)
 
         for doc in self.index.query(
-                criteria=criteria, sort=sort, limit=limit, skip=skip
+            criteria=criteria, sort=sort, limit=limit, skip=skip
         ):
             if properties is not None and prop_keys.issubset(set(doc.keys())):
                 yield {p: doc[p] for p in properties if p in doc}
@@ -188,8 +187,8 @@ class S3Store(Store):
                     # TODO: THis is ugly and unsafe, do some real checking before pulling data
                     data = (
                         self.s3_bucket.Object(self.sub_dir + str(doc[self.key]))
-                            .get()["Body"]
-                            .read()
+                        .get()["Body"]
+                        .read()
                     )
                 except botocore.exceptions.ClientError as e:
                     # If a client error is thrown, then check that it was a 404 error.
@@ -220,7 +219,7 @@ class S3Store(Store):
                 yield unpacked_data
 
     def distinct(
-            self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
     ) -> List:
         """
         Get all distinct values for a field
@@ -233,13 +232,13 @@ class S3Store(Store):
         return self.index.distinct(field, criteria=criteria)
 
     def groupby(
-            self,
-            keys: Union[List[str], str],
-            criteria: Optional[Dict] = None,
-            properties: Union[Dict, List, None] = None,
-            sort: Optional[Dict[str, Union[Sort, int]]] = None,
-            skip: int = 0,
-            limit: int = 0,
+        self,
+        keys: Union[List[str], str],
+        criteria: Optional[Dict] = None,
+        properties: Union[Dict, List, None] = None,
+        sort: Optional[Dict[str, Union[Sort, int]]] = None,
+        skip: int = 0,
+        limit: int = 0,
     ) -> Iterator[Tuple[Dict, List[Dict]]]:
         """
         Simple grouping function that will group documents
@@ -280,10 +279,10 @@ class S3Store(Store):
         return self.index.ensure_index(key, unique=unique)
 
     def update(
-            self,
-            docs: Union[List[Dict], Dict],
-            key: Union[List, str, None] = None,
-            additional_metadata: Union[str, List[str], None] = None,
+        self,
+        docs: Union[List[Dict], Dict],
+        key: Union[List, str, None] = None,
+        additional_metadata: Union[str, List[str], None] = None,
     ):
         """
         Update documents into the Store
@@ -382,7 +381,9 @@ class S3Store(Store):
             )
 
         s3_bucket.put_object(
-            Key=self.sub_dir + str(doc[self.key]), Body=data, Metadata={k: str(v) for k, v in search_doc.items()}
+            Key=self.sub_dir + str(doc[self.key]),
+            Body=data,
+            Metadata={k: str(v) for k, v in search_doc.items()},
         )
 
         if lu_info is not None:
@@ -420,7 +421,7 @@ class S3Store(Store):
         return self.index.last_updated
 
     def newer_in(
-            self, target: Store, criteria: Optional[Dict] = None, exhaustive: bool = False
+        self, target: Store, criteria: Optional[Dict] = None, exhaustive: bool = False
     ) -> List[str]:
         """
         Returns the keys of documents that are newer in the target

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -12,7 +12,6 @@ from hashlib import sha1
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import msgpack  # type: ignore
-from monty.dev import deprecated
 from monty.msgpack import default as monty_default
 
 from maggma.core import Sort, Store

--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from itertools import groupby
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
-from monty.dev import deprecated
 from pydash import set_
 from pymongo import MongoClient
 

--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -363,9 +363,8 @@ class ConcatStore(Store):
         for store in self.stores:
             store.close()
 
-    @property  # type: ignore
-    @deprecated
-    def collection(self):
+    @property
+    def _collection(self):
         raise NotImplementedError("No collection property for ConcatStore")
 
     @property

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -14,7 +14,6 @@ from pymongo.errors import ConfigurationError
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import gridfs
-from monty.dev import deprecated
 from monty.json import jsanitize
 from pydash import get, has
 from pymongo import MongoClient, uri_parser

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -470,6 +470,7 @@ class MongoStore(Store):
     def close(self):
         """Close up all collections"""
         self._collection.database.client.close()
+        self._collection = None
         if self.ssh_tunnel is not None:
             self.ssh_tunnel.stop()
 

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -141,7 +141,7 @@ class MongoStore(Store):
         self.password = password
         self.ssh_tunnel = ssh_tunnel
         self.safe_update = safe_update
-        self._collection = None  # type: Any
+        self._coll = None  # type: Any
         self.kwargs = kwargs
         super().__init__(**kwargs)
 
@@ -156,7 +156,7 @@ class MongoStore(Store):
         """
         Connect to the source data
         """
-        if self._collection is None or force_reset:
+        if self._coll is None or force_reset:
             if self.ssh_tunnel is None:
                 host = self.host
                 port = self.port
@@ -176,7 +176,7 @@ class MongoStore(Store):
                 else MongoClient(host, port)
             )
             db = conn[self.database]
-            self._collection = db[self.collection_name]
+            self._coll = db[self.collection_name]
 
     def __hash__(self) -> int:
         """Hash for MongoStore"""
@@ -307,16 +307,15 @@ class MongoStore(Store):
         db_name = collection.database.name
 
         store = cls(db_name, coll_name)
-        store._collection = collection
+        store._coll = collection
         return store
 
-    @property  # type: ignore
-    @deprecated(message="This will be removed in the future")
-    def collection(self):
+    @property
+    def _collection(self):
         """Property referring to underlying pymongo collection"""
-        if self._collection is None:
+        if self._coll is None:
             raise StoreError("Must connect Mongo-like store before attemping to use it")
-        return self._collection
+        return self._coll
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
@@ -470,7 +469,7 @@ class MongoStore(Store):
     def close(self):
         """Close up all collections"""
         self._collection.database.client.close()
-        self._collection = None
+        self._coll = None
         if self.ssh_tunnel is not None:
             self.ssh_tunnel.stop()
 
@@ -523,7 +522,7 @@ class MongoURIStore(MongoStore):
 
         self.collection_name = collection_name
         self.kwargs = kwargs
-        self._collection = None
+        self._coll = None
         super(MongoStore, self).__init__(**kwargs)  # lgtm
 
     @property
@@ -538,10 +537,10 @@ class MongoURIStore(MongoStore):
         """
         Connect to the source data
         """
-        if self._collection is None or force_reset:  # pragma: no cover
+        if self._coll is None or force_reset:  # pragma: no cover
             conn = MongoClient(self.uri)
             db = conn[self.database]
-            self._collection = db[self.collection_name]
+            self._coll = db[self.collection_name]
 
 
 class MemoryStore(MongoStore):
@@ -557,8 +556,7 @@ class MemoryStore(MongoStore):
             collection_name: name for the collection in memory
         """
         self.collection_name = collection_name
-        self._collection = None
-        self.ssh_tunnel = None  # This is to fix issues with the tunnel on close
+        self._coll = None
         self.kwargs = kwargs
         super(MongoStore, self).__init__(**kwargs)  # noqa
 
@@ -567,8 +565,12 @@ class MemoryStore(MongoStore):
         Connect to the source data
         """
 
-        if self._collection is None or force_reset:
-            self._collection = mongomock.MongoClient().db[self.name]
+        if self._coll is None or force_reset:
+            self._coll = mongomock.MongoClient().db[self.name]
+
+    def close(self):
+        """Close up all collections"""
+        self._coll.database.client.close()
 
     @property
     def name(self):
@@ -783,7 +785,7 @@ class MontyStore(MemoryStore):
         self.database_path = database_path
         self.database_name = database_name
         self.collection_name = collection_name
-        self._collection = None
+        self._coll = None
         self.ssh_tunnel = None  # This is to fix issues with the tunnel on close
         self.kwargs = kwargs
         self.storage = storage
@@ -805,8 +807,8 @@ class MontyStore(MemoryStore):
 
         set_storage(self.database_path, storage=self.storage, **self.storage_kwargs)
         client = MontyClient(self.database_path, **self.client_kwargs)
-        if not self._collection or force_reset:
-            self._collection = client["db"][self.collection_name]
+        if not self._coll or force_reset:
+            self._coll = client["db"][self.collection_name]
 
     @property
     def name(self) -> str:

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -14,7 +14,7 @@ from socket import socket
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import mongomock
-from monty.dev import deprecated, requires
+from monty.dev import requires
 from monty.io import zopen
 from monty.json import MSONable, jsanitize
 from monty.serialization import loadfn

--- a/tests/builders/test_copy_builder.py
+++ b/tests/builders/test_copy_builder.py
@@ -105,8 +105,9 @@ def test_run(source, target, old_docs, new_docs):
 
     builder = CopyBuilder(source, target)
     builder.run()
-    assert target.query_one(criteria={"k": 0})["v"] == "new"
-    assert target.query_one(criteria={"k": 10})["v"] == "old"
+    builder.target.connect()
+    assert builder.target.query_one(criteria={"k": 0})["v"] == "new"
+    assert builder.target.query_one(criteria={"k": 10})["v"] == "old"
 
 
 def test_query(source, target, old_docs, new_docs):
@@ -127,10 +128,10 @@ def test_delete_orphans(source, target, old_docs, new_docs):
     target.update(old_docs)
 
     deletion_criteria = {"k": {"$in": list(range(5))}}
-    source.collection.delete_many(deletion_criteria)
+    source._collection.delete_many(deletion_criteria)
     builder.run()
 
-    assert target.collection.count_documents(deletion_criteria) == 0
+    assert target._collection.count_documents(deletion_criteria) == 0
     assert target.query_one(criteria={"k": 5})["v"] == "new"
     assert target.query_one(criteria={"k": 10})["v"] == "old"
 

--- a/tests/builders/test_simple_bib_drone.py
+++ b/tests/builders/test_simple_bib_drone.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from maggma.stores import MemoryStore
+from maggma.stores.mongolike import MongoStore
 
 from .simple_bib_drone import SimpleBibDrone
 
@@ -16,7 +17,9 @@ def init_drone(test_dir):
     :return:
         initialized drone
     """
-    mongo_store = MemoryStore(collection_name="drone_test", key="record_key")
+    mongo_store = MongoStore(
+        database="drone_test", collection_name="drone_test", key="record_key"
+    )
     simple_path = test_dir / "simple_bib_example_data"
     assert simple_path.exists(), f"{simple_path} not found"
     simple_bib_drone = SimpleBibDrone(store=mongo_store, path=simple_path)

--- a/tests/stores/test_advanced_stores.py
+++ b/tests/stores/test_advanced_stores.py
@@ -333,7 +333,7 @@ def test_sandbox_count(sandbox_store):
 
 
 def test_sandbox_query(sandbox_store):
-    sandbox_store._collection.ipytensert_one({"a": 1, "b": 2, "c": 3})
+    sandbox_store._collection.insert_one({"a": 1, "b": 2, "c": 3})
     assert sandbox_store.query_one(properties=["a"])["a"] == 1
 
     sandbox_store._collection.insert_one({"a": 2, "b": 2, "sbxn": ["test"]})

--- a/tests/stores/test_advanced_stores.py
+++ b/tests/stores/test_advanced_stores.py
@@ -325,33 +325,33 @@ def sandbox_store():
 
 
 def test_sandbox_count(sandbox_store):
-    sandbox_store.collection.insert_one({"a": 1, "b": 2, "c": 3})
+    sandbox_store._collection.insert_one({"a": 1, "b": 2, "c": 3})
     assert sandbox_store.count({"a": 1}) == 1
 
-    sandbox_store.collection.insert_one({"a": 1, "b": 3, "sbxn": ["test"]})
+    sandbox_store._collection.insert_one({"a": 1, "b": 3, "sbxn": ["test"]})
     assert sandbox_store.count({"a": 1}) == 2
 
 
 def test_sandbox_query(sandbox_store):
-    sandbox_store.collection.insert_one({"a": 1, "b": 2, "c": 3})
+    sandbox_store._collection.ipytensert_one({"a": 1, "b": 2, "c": 3})
     assert sandbox_store.query_one(properties=["a"])["a"] == 1
 
-    sandbox_store.collection.insert_one({"a": 2, "b": 2, "sbxn": ["test"]})
+    sandbox_store._collection.insert_one({"a": 2, "b": 2, "sbxn": ["test"]})
     assert sandbox_store.query_one(properties=["b"], criteria={"a": 2})["b"] == 2
 
-    sandbox_store.collection.insert_one({"a": 3, "b": 2, "sbxn": ["not_test"]})
+    sandbox_store._collection.insert_one({"a": 3, "b": 2, "sbxn": ["not_test"]})
     assert sandbox_store.query_one(properties=["c"], criteria={"a": 3}) is None
 
 
 def test_sandbox_distinct(sandbox_store):
     sandbox_store.connect()
-    sandbox_store.collection.insert_one({"a": 1, "b": 2, "c": 3})
+    sandbox_store._collection.insert_one({"a": 1, "b": 2, "c": 3})
     assert sandbox_store.distinct("a") == [1]
 
-    sandbox_store.collection.insert_one({"a": 4, "d": 5, "e": 6, "sbxn": ["test"]})
+    sandbox_store._collection.insert_one({"a": 4, "d": 5, "e": 6, "sbxn": ["test"]})
     assert sandbox_store.distinct("a")[1] == 4
 
-    sandbox_store.collection.insert_one({"a": 7, "d": 8, "e": 9, "sbxn": ["not_test"]})
+    sandbox_store._collection.insert_one({"a": 7, "d": 8, "e": 9, "sbxn": ["not_test"]})
     assert sandbox_store.distinct("a")[1] == 4
 
 
@@ -362,7 +362,7 @@ def test_sandbox_update(sandbox_store):
         next(sandbox_store.query(criteria={"d": {"$exists": 1}}, properties=["d"]))["d"]
         == 4
     )
-    assert sandbox_store.collection.find_one({"e": 6})["sbxn"] == ["test"]
+    assert sandbox_store._collection.find_one({"e": 6})["sbxn"] == ["test"]
     sandbox_store.update([{"e": 7, "sbxn": ["core"]}], key="e")
     assert set(sandbox_store.query_one(criteria={"e": 7})["sbxn"]) == {"test", "core"}
 

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -18,10 +18,7 @@ from maggma.validators import JSONSchemaValidator
 
 @pytest.fixture
 def mongostore():
-    store = MongoStore(
-        database="maggma_test",
-        collection_name="test",
-    )
+    store = MongoStore(database="maggma_test", collection_name="test",)
     store.connect()
     yield store
     store._collection.drop()
@@ -56,6 +53,15 @@ def test_mongostore_connect():
     assert mongostore._collection is None
     mongostore.connect()
     assert isinstance(mongostore._collection, pymongo.collection.Collection)
+
+
+def test_mongostore_connect_disconnect():
+    mongostore = MongoStore("maggma_test", "test")
+    assert mongostore._collection is None
+    mongostore.connect()
+    assert isinstance(mongostore._collection, pymongo.collection.Collection)
+    mongostore.close()
+    assert mongostore._collection is None
 
 
 def test_mongostore_query(mongostore):

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -62,6 +62,7 @@ def test_mongostore_connect_disconnect():
     assert isinstance(mongostore._collection, pymongo.collection.Collection)
     mongostore.close()
     assert mongostore._collection is None
+    mongostore.connect()
 
 
 def test_mongostore_query(mongostore):

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -48,20 +48,19 @@ def jsonstore(test_dir):
     return JSONStore(files)
 
 
-def test_mongostore_connect():
+@pytest.mark.xfail(raises=StoreError)
+def test_mongostore_connect_error():
     mongostore = MongoStore("maggma_test", "test")
-    assert mongostore._collection is None
-    mongostore.connect()
-    assert isinstance(mongostore._collection, pymongo.collection.Collection)
+    mongostore.count()
 
 
-def test_mongostore_connect_disconnect():
+def test_mongostore_connect_reconnect():
     mongostore = MongoStore("maggma_test", "test")
-    assert mongostore._collection is None
+    assert mongostore._coll is None
     mongostore.connect()
     assert isinstance(mongostore._collection, pymongo.collection.Collection)
     mongostore.close()
-    assert mongostore._collection is None
+    assert mongostore._coll is None
     mongostore.connect()
 
 
@@ -196,7 +195,7 @@ def test_mongostore_from_collection(mongostore, db_json):
     ms.connect()
 
     other_ms = MongoStore.from_collection(ms._collection)
-    assert ms._collection.full_name == other_ms._collection.full_name
+    assert ms._coll.full_name == other_ms._collection.full_name
     assert ms.database == other_ms.database
 
 
@@ -253,7 +252,7 @@ def test_mongostore_newer_in(mongostore):
 # Memory store tests
 def test_memory_store_connect():
     memorystore = MemoryStore()
-    assert memorystore._collection is None
+    assert memorystore._coll is None
     memorystore.connect()
     assert isinstance(memorystore._collection, mongomock.collection.Collection)
 
@@ -294,7 +293,7 @@ def test_groupby(memorystore):
 # Monty store tests
 def test_monty_store_connect(tmp_dir):
     montystore = MontyStore(collection_name="my_collection")
-    assert montystore._collection is None
+    assert montystore._coll is None
     montystore.connect()
     assert montystore._collection is not None
 


### PR DESCRIPTION
This PR fixes an issue where `collection` was not getting set back to `None` when closing the MongoDB connection. This is required to support changes in `pymongo==4.0`.

Also, `collection` as store property is replaced with `_collection` to provide better error handling surrounding connection issues.