### PR TITLE
Encode `_` as `--` in metadata when using `S3Store.write_doc_to_s3`

### DIFF
--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -386,10 +386,11 @@ class S3Store(Store):
         # calling the PutObject operation: There were headers present in the request
         # which were not signed`
         # Metadata stored in the MongoDB index (self.index) is stored unchanged.
+        search_doc["s3-to-mongo-keys"] = {k: k.replace('_', '-') for k in search_doc.keys()}
         s3_bucket.put_object(
             Key=self.sub_dir + str(doc[self.key]),
             Body=data,
-            Metadata={k.replace('_', '--'): str(v) for k, v in search_doc.items()},
+            Metadata={search_doc["s3-to-mongo-keys"][k]: str(v) for k, v in search_doc.items()},
         )
 
         if lu_info is not None:

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -5,7 +5,7 @@ Advanced Stores for connecting to AWS data
 
 import threading
 import warnings
-import zlib
+import zlib     
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
 from hashlib import sha1
@@ -379,11 +379,11 @@ class S3Store(Store):
                 to_isoformat_ceil_ms(doc[self.last_updated_field])
             )
 
-        # Any underscores are encoded as double dashes in metadata, since keys with 
-        # underscores may be result in the corresponding HTTP header being stripped 
+        # Any underscores are encoded as double dashes in metadata, since keys with
+        # underscores may be result in the corresponding HTTP header being stripped
         # by certain server configurations (e.g. default nginx), leading to:
-        # `botocore.exceptions.ClientError: An error occurred (AccessDenied) when 
-        # calling the PutObject operation: There were headers present in the request 
+        # `botocore.exceptions.ClientError: An error occurred (AccessDenied) when
+        # calling the PutObject operation: There were headers present in the request
         # which were not signed`
         # Metadata stored in the MongoDB index (self.index) is stored unchanged.
         s3_bucket.put_object(

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -379,7 +379,10 @@ class S3Store(Store):
                 to_isoformat_ceil_ms(doc[self.last_updated_field])
             )
 
+        # keep a record of original keys, in case these are important for the individual researcher
+        # it is not expected that this information will be used except in disaster recovery
         search_doc["s3-to-mongo-keys"] = {k: self._sanitize_key(k) for k in search_doc.keys()}
+        search_doc["s3-to-mongo-keys"]["s3-to-mongo-keys"] = "s3-to-mongo-keys"  # inception
         s3_bucket.put_object(
             Key=self.sub_dir + str(doc[self.key]),
             Body=data,

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -395,7 +395,8 @@ class S3Store(Store):
             obj_hash = hasher.hexdigest()
             search_doc["obj_hash"] = obj_hash
         return search_doc
-    
+
+    @staticmethod
     def _sanitize_key(key):
         """
         Sanitize keys to store in S3/MinIO metadata.

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -410,7 +410,7 @@ class S3Store(Store):
         # Metadata stored in the MongoDB index (self.index) is stored unchanged.
 
         # Additionally, MinIO requires lowercase keys
-        return str(key).replace('_', '-').lower()        
+        return str(key).replace('_', '-').lower()
 
     def remove_docs(self, criteria: Dict, remove_s3_object: bool = False):
         """

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -5,7 +5,7 @@ Advanced Stores for connecting to AWS data
 
 import threading
 import warnings
-import zlib     
+import zlib
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
 from hashlib import sha1


### PR DESCRIPTION
To resolve a reported bug from @acrutt and @rkingsbury with:

```
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the PutObject operation: There were headers present in the request which were not signed
```

Fix proposed by @shreddd.