### PR TITLE
Add header processing abilities to certain `Resource` classes

### DIFF
--- a/src/maggma/api/resource/__init__.py
+++ b/src/maggma/api/resource/__init__.py
@@ -1,6 +1,7 @@
 # isort: off
 from maggma.api.resource.core import Resource
 from maggma.api.resource.core import HintScheme
+from maggma.api.resource.core import HeaderProcessor
 
 # isort: on
 

--- a/src/maggma/api/resource/core.py
+++ b/src/maggma/api/resource/core.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from typing import Dict, Type
 
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Request
 from monty.json import MontyDecoder, MSONable
 from pydantic import BaseModel
 from starlette.responses import RedirectResponse
@@ -96,4 +96,16 @@ class HintScheme(MSONable, metaclass=ABCMeta):
     def generate_hints(self, query: STORE_PARAMS) -> STORE_PARAMS:
         """
         This method takes in a MongoDB query and returns hints
+        """
+
+
+class HeaderProcessor(MSONable, metaclass=ABCMeta):
+    """
+    Base class for generic header processing
+    """
+
+    @abstractmethod
+    def process_header(self, request: Request):
+        """
+        This method takes in a FastAPI Request object and processes a new header for it in-place
         """

--- a/src/maggma/api/resource/core.py
+++ b/src/maggma/api/resource/core.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from typing import Dict, Type
 
-from fastapi import APIRouter, FastAPI, Request
+from fastapi import APIRouter, FastAPI, Response, Request
 from monty.json import MontyDecoder, MSONable
 from pydantic import BaseModel
 from starlette.responses import RedirectResponse
@@ -105,7 +105,9 @@ class HeaderProcessor(MSONable, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def process_header(self, request: Request):
+    def process_header(self, response: Response, request: Request):
         """
-        This method takes in a FastAPI Request object and processes a new header for it in-place
+        This method takes in a FastAPI Response object and processes a new header for it in-place.
+        It can use data in the upstream request to generate the header.
+        (https://fastapi.tiangolo.com/advanced/response-headers/#use-a-response-parameter)
         """

--- a/src/maggma/api/resource/utils.py
+++ b/src/maggma/api/resource/utils.py
@@ -1,6 +1,6 @@
 from typing import Callable, Dict, List
 
-from fastapi import Depends, Request
+from fastapi import Depends, Request, Response
 
 from maggma.api.query_operator import QueryOperator
 from maggma.api.utils import STORE_PARAMS, attach_signature
@@ -21,6 +21,7 @@ def attach_query_ops(
         annotations={
             **{f"dep{i}": STORE_PARAMS for i, _ in enumerate(query_ops)},
             "request": Request,
+            "temp_response": Response,
         },
         defaults={f"dep{i}": Depends(dep.query) for i, dep in enumerate(query_ops)},
     )


### PR DESCRIPTION
This PR allows the `ReadOnlyResource` to take in a `HeaderProcessor` object to manipulate header information for each request.