### PR TITLE
mongoclient_kwargs

### DIFF
--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -26,6 +26,7 @@ class JointStore(Store):
         password: str = "",
         main: Optional[str] = None,
         merge_at_root: bool = False,
+        mongoclient_kwargs: Optional[Dict] = None,
         **kwargs,
     ):
         """
@@ -50,7 +51,9 @@ class JointStore(Store):
         self._coll = None  # type: Any
         self.main = main or collection_names[0]
         self.merge_at_root = merge_at_root
+        self.mongoclient_kwargs = mongoclient_kwargs or {}
         self.kwargs = kwargs
+
         super(JointStore, self).__init__(**kwargs)
 
     @property
@@ -75,9 +78,10 @@ class JointStore(Store):
                 port=self.port,
                 username=self.username,
                 password=self.password,
+                **self.mongoclient_kwargs,
             )
             if self.username != ""
-            else MongoClient(self.host, self.port)
+            else MongoClient(self.host, self.port, **self.mongoclient_kwargs)
         )
         db = conn[self.database]
         self._coll = db[self.main]

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -122,6 +122,7 @@ class MongoStore(Store):
         ssh_tunnel: Optional[SSHTunnel] = None,
         safe_update: bool = False,
         auth_source: Optional[str] = None,
+        mongoclient_kwargs: Optional[Dict] = None,
         **kwargs,
     ):
         """
@@ -149,6 +150,7 @@ class MongoStore(Store):
         if auth_source is None:
             auth_source = self.database
         self.auth_source = auth_source
+        self.mongoclient_kwargs = mongoclient_kwargs or {}
 
         super().__init__(**kwargs)
 
@@ -178,9 +180,10 @@ class MongoStore(Store):
                     username=self.username,
                     password=self.password,
                     authSource=self.auth_source,
+                    **self.mongoclient_kwargs,
                 )
                 if self.username != ""
-                else MongoClient(host, port)
+                else MongoClient(host, port, **self.mongoclient_kwargs)
             )
             db = conn[self.database]
             self._coll = db[self.collection_name]
@@ -564,7 +567,7 @@ class MongoURIStore(MongoStore):
         Connect to the source data
         """
         if self._coll is None or force_reset:  # pragma: no cover
-            conn = MongoClient(self.uri)
+            conn = MongoClient(self.uri, self.mongodb_client_kwargs)
             db = conn[self.database]
             self._coll = db[self.collection_name]
 

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -567,7 +567,7 @@ class MongoURIStore(MongoStore):
         Connect to the source data
         """
         if self._coll is None or force_reset:  # pragma: no cover
-            conn = MongoClient(self.uri, self.mongodb_client_kwargs)
+            conn = MongoClient(self.uri, **self.mongodb_client_kwargs)
             db = conn[self.database]
             self._coll = db[self.collection_name]
 


### PR DESCRIPTION
Allows additional kwargs to be passed to `MongoClient` in different stores that contain `MongoClient` inits.

