### PR TITLE
added localhost test for MongoURIStore

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -527,6 +527,7 @@ class MongoURIStore(MongoStore):
         collection_name: str,
         database: str = None,
         ssh_tunnel: Optional[SSHTunnel] = None,
+        mongoclient_kwargs: Optional[Dict] = None,
         **kwargs,
     ):
         """
@@ -537,6 +538,7 @@ class MongoURIStore(MongoStore):
         """
         self.uri = uri
         self.ssh_tunnel = ssh_tunnel
+        self.mongoclient_kwargs = mongoclient_kwargs or {}
 
         # parse the dbname from the uri
         if database is None:

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -18,7 +18,10 @@ from maggma.validators import JSONSchemaValidator
 
 @pytest.fixture
 def mongostore():
-    store = MongoStore(database="maggma_test", collection_name="test",)
+    store = MongoStore(
+        database="maggma_test",
+        collection_name="test",
+    )
     store.connect()
     yield store
     store._collection.drop()
@@ -469,6 +472,11 @@ def test_mongo_uri():
     is_name = store.name is uri
     # This is try and keep the secret safe
     assert is_name
+
+
+def test_mongo_uri_localhost():
+    store = MongoURIStore("mongodb://localhost:27017/mp_core", collection_name="xas")
+    store.connect()
 
 
 def test_mongo_uri_dbname_parse():


### PR DESCRIPTION
The constructor for MongoURIStore bypasses the MongoStore constructor so the `mongoclient_kwarg` has to be explicitly added here.
Added test to catch these next time