### PR TITLE
MemoryStore: fix groupby ignoring properties

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
-pre-commit==2.17.0
+pre-commit==2.18.1
 pytest==7.1.1
 pytest-asyncio==0.18.2
 pytest-cov==3.0.0

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -638,9 +638,15 @@ class MemoryStore(MongoStore):
             generator returning tuples of (key, list of elemnts)
         """
         keys = keys if isinstance(keys, list) else [keys]
+
+        if properties is None:
+            properties = []
+        if isinstance(properties, dict):
+            properties = list(properties.keys())
+
         data = [
             doc
-            for doc in self.query(properties=keys, criteria=criteria)
+            for doc in self.query(properties=keys + properties, criteria=criteria)
             if all(has(doc, k) for k in keys)
         ]
 

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -270,10 +270,12 @@ def test_groupby(memorystore):
         ],
         key="f",
     )
-    data = list(memorystore.groupby("d"))
+    data = list(memorystore.groupby("d", properties={"e": 1, "f": 1}))
     assert len(data) == 2
     grouped_by_9 = [g[1] for g in data if g[0]["d"] == 9][0]
     assert len(grouped_by_9) == 3
+    assert all([d.get("f", False) for d in grouped_by_9])
+    assert all([d.get("e", False) for d in grouped_by_9])
     grouped_by_10 = [g[1] for g in data if g[0]["d"] == 10][0]
     assert len(grouped_by_10) == 1
 
@@ -289,8 +291,9 @@ def test_groupby(memorystore):
         ],
         key="f",
     )
-    data = list(memorystore.groupby("e.d"))
+    data = list(memorystore.groupby("e.d", properties=["f"]))
     assert len(data) == 2
+    assert data[0][1][0].get("f", False)
 
 
 # Monty store tests


### PR DESCRIPTION
In the course of developing `FileStore` (#619 ) I discovered that `MemoryStore.groupby()` was not correctly passing the `properties` argument, making it impossible to project fields in the returned data. This small PR fixes that behavior.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Fix broken `MemoryStore.groupby`
- [x] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
