### PR TITLE
JSONStore: write file on init, add descriptive KeyError, add tests

### DIFF
--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -416,8 +416,9 @@ def test_json_store_load(jsonstore, test_dir):
     assert len(list(jsonstore.query())) == 20
 
     # confirm descriptive error raised if you get a KeyError
-    with pytest.raises(KeyError, match="Key field 'random key' not found"):
+    with pytest.raises(KeyError, match="Key field 'random_key' not found"):
         jsonstore = JSONStore(test_dir / "test_set" / "c.json.gz", key="random_key")
+        jsonstore.connect()
 
 
 def test_json_store_writeable(test_dir):


### PR DESCRIPTION
This PR makes a few enhancements to `JSONStore`.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Allow `JSONStore` to create an empty .json file when `file_writeable=True` and the path given does not already exist
   -  [x] Raies a more descriptive error when a KeyError occurs on `.connect()`. This is helpful because when working with `JSONStore`, it is easy to init with a non-default key field and then forget that you did that when you try to reconnect to the store.
   - [x] ~~add a helper class to make it possible to write `datetime` objects to JSON. If there is already a solution to this somewhere in `maggma` please advise and I'll modify accordingly.~~
   - [x] migrate `JSONStore` from `json` to `orjson` 
   - [x] Add tests for the above and for an additional warning about multiple paths that was not previously tested
- [x] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
