### PR TITLE
Fix gridfs URI store

### DIFF
--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -467,6 +467,8 @@ class GridFSURIStore(GridFSStore):
         compression: bool = False,
         ensure_metadata: bool = False,
         searchable_fields: List[str] = None,
+        auth_source: Optional[str] = None,
+        mongoclient_kwargs: Optional[Dict] = None,
         **kwargs,
     ):
         """
@@ -499,6 +501,7 @@ class GridFSURIStore(GridFSStore):
         self.ensure_metadata = ensure_metadata
         self.searchable_fields = [] if searchable_fields is None else searchable_fields
         self.kwargs = kwargs
+        self.mongoclient_kwargs = mongoclient_kwargs or {}
 
         if "key" not in kwargs:
             kwargs["key"] = "_id"

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -467,7 +467,6 @@ class GridFSURIStore(GridFSStore):
         compression: bool = False,
         ensure_metadata: bool = False,
         searchable_fields: List[str] = None,
-        auth_source: Optional[str] = None,
         mongoclient_kwargs: Optional[Dict] = None,
         **kwargs,
     ):


### PR DESCRIPTION
Trying to connect to a GridFSURIStore results in the following error:

```
Traceback (most recent call last):
  File "/Users/alexmganose/test_connect.py", line 6, in <module>
    store.connect()
  File "/Users/alexmganose/dev/src/jobflow/src/jobflow/core/store.py", line 109, in connect
    additional_store.connect(force_reset=force_reset)
  File "/Users/alexmganose/.conda/envs/atomate2/lib/python3.9/site-packages/maggma/stores/gridfs.py", line 512, in connect
    conn = MongoClient(self.uri, **self.mongoclient_kwargs)
AttributeError: 'GridFSURIStore' object has no attribute 'mongoclient_kwargs'
```

This PR fixes the error. 

If possible, please can you push a new release once this is merged.