### PR TITLE
Docs: add mermaid diagram support

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,5 +1,14 @@
 # Concepts
 
+`maggma`'s core classes -- [`Store`](#store) and [`Builder`](#builder) -- provide building blocks for
+modular data pipelines. Data resides in one or more `Store` and is processed by a
+`Builder`. The results of the processing are saved in another `Store`, and so on:
+
+```mermaid
+flowchart LR  
+    s1(Store 1) --Builder 1--> s2(Store 2) --Builder 2--> s3(Store 3)
+s2 -- Builder 3-->s4(Store 4)
+```
 
 ## Store
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,11 @@ markdown_extensions:
   - codehilite
   - attr_list
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.inlinehilite
   - toc:
       permalink: true


### PR DESCRIPTION
This PR adds support for [mermaid diagrams](https://mermaid-js.github.io/mermaid/#/flowchart) to `maggma` and adds a small diagram to `concepts.md` in the docs that illustrates the relationship between `Store` and `Builder`. I envision mermaid diagrams being very useful for future docs updates as a way of illustrating the steps in a build pipeline.

This introduces no new dependencies; it simply requires a small configuration change in `mkdocs.yml`
