### PR TITLE
Fix header processing

### DIFF
--- a/src/maggma/api/resource/s3_url.py
+++ b/src/maggma/api/resource/s3_url.py
@@ -67,8 +67,10 @@ class S3URLResource(Resource):
 
         async def get_by_key(
             request: Request,
-            response: Response,
-            key: str = Path(..., alias=key_name, title=f"The {key_name} of the {model_name} to get",),
+            temp_response: Response,
+            key: str = Path(
+                ..., alias=key_name, title=f"The {key_name} of the {model_name} to get",
+            ),
         ):
             f"""
             Get's a document by the primary key in the store
@@ -89,7 +91,10 @@ class S3URLResource(Resource):
                 self.store.s3.Object(self.store.bucket, key).load()
             except ClientError:
                 raise HTTPException(
-                    status_code=404, detail="No object found for {} = {}".format(self.store.key, key.split("/")[-1]),
+                    status_code=404,
+                    detail="No object found for {} = {}".format(
+                        self.store.key, key.split("/")[-1]
+                    ),
                 )
 
             # Get URL
@@ -102,13 +107,19 @@ class S3URLResource(Resource):
             except Exception:
                 raise HTTPException(
                     status_code=404,
-                    detail="Problem obtaining URL for {} = {}".format(self.store.key, key.split("/")[-1]),
+                    detail="Problem obtaining URL for {} = {}".format(
+                        self.store.key, key.split("/")[-1]
+                    ),
                 )
 
             requested_datetime = datetime.utcnow()
             expiry_datetime = requested_datetime + timedelta(seconds=self.url_lifetime)
 
-            item = S3URLDoc(url=url, requested_datetime=requested_datetime, expiry_datetime=expiry_datetime,)
+            item = S3URLDoc(
+                url=url,
+                requested_datetime=requested_datetime,
+                expiry_datetime=expiry_datetime,
+            )
 
             response = {"data": [item.dict()]}  # type: ignore
 
@@ -118,7 +129,7 @@ class S3URLResource(Resource):
                 )
 
             if self.header_processor is not None:
-                self.header_processor.process_header(response, request)
+                self.header_processor.process_header(temp_response, request)
 
             return response
 


### PR DESCRIPTION
This PR fixes a variable name issue that was overwriting the temporary `Response` object FastAPI uses to extract header data to use in the response. This did not allow the correct header to be processed by a given `Resource` class.