### PR TITLE
Enable disk use in `MongoStore` query

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -407,6 +407,7 @@ class MongoStore(Store):
             limit=limit,
             sort=sort_list,
             hint=hint_list,
+            allow_disk_use=True
         ):
             yield d
 


### PR DESCRIPTION
Sets `enable_disk_use=True` for calls to pymongo's `find` within `MongoStore` to help with memory errors when sorting large amounts of data. 