### PR TITLE
Add pymongo timeout context to queries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymongo==4.0.2
+pymongo==4.2.0
 monty==2022.4.26
 mongomock==4.0.0
 pydash==5.1.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "setuptools",
-        "pymongo>=4.0",
+        "pymongo>=4.2.0",
         "monty>=1.0.2",
         "mongomock>=3.10.0",
         "pydash>=4.1.0",

--- a/src/maggma/api/resource/aggregation.py
+++ b/src/maggma/api/resource/aggregation.py
@@ -81,7 +81,7 @@ class AggregationResource(Resource):
                 if e.timeout:
                     raise HTTPException(
                         status_code=504,
-                        detail=f"Server timed out trying to obtain data. Try again with a smaller request.",
+                        detail="Server timed out trying to obtain data. Try again with a smaller request.",
                     )
                 else:
                     raise HTTPException(

--- a/src/maggma/api/resource/post_resource.py
+++ b/src/maggma/api/resource/post_resource.py
@@ -115,7 +115,7 @@ class PostOnlyResource(Resource):
                 if e.timeout:
                     raise HTTPException(
                         status_code=504,
-                        detail=f"Server timed out trying to obtain data. Try again with a smaller request.",
+                        detail="Server timed out trying to obtain data. Try again with a smaller request.",
                     )
                 else:
                     raise HTTPException(status_code=500)

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -150,7 +150,7 @@ class ReadOnlyResource(Resource):
                 if e.timeout:
                     raise HTTPException(
                         status_code=504,
-                        detail=f"Server timed out trying to obtain data. Try again with a smaller request.",
+                        detail="Server timed out trying to obtain data. Try again with a smaller request.",
                     )
                 else:
                     raise HTTPException(
@@ -243,7 +243,7 @@ class ReadOnlyResource(Resource):
                 if e.timeout:
                     raise HTTPException(
                         status_code=504,
-                        detail=f"Server timed out trying to obtain data. Try again with a smaller request.",
+                        detail="Server timed out trying to obtain data. Try again with a smaller request.",
                     )
                 else:
                     raise HTTPException(

--- a/src/maggma/api/resource/submission.py
+++ b/src/maggma/api/resource/submission.py
@@ -156,7 +156,7 @@ class SubmissionResource(Resource):
                 if e.timeout:
                     raise HTTPException(
                         status_code=504,
-                        detail=f"Server timed out trying to obtain data. Try again with a smaller request.",
+                        detail="Server timed out trying to obtain data. Try again with a smaller request.",
                     )
                 else:
                     raise HTTPException(status_code=500)
@@ -221,13 +221,11 @@ class SubmissionResource(Resource):
                 if e.timeout:
                     raise HTTPException(
                         status_code=504,
-                        detail=f"Server timed out trying to obtain data. Try again with a smaller request.",
+                        detail="Server timed out trying to obtain data. Try again with a smaller request.",
                     )
                 else:
-                    raise HTTPException(
-                        status_code=500,
-                    )
-            
+                    raise HTTPException(status_code=500,)
+
             meta = Meta(total_doc=count)
 
             for operator in self.get_query_operators:  # type: ignore

--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -72,7 +72,7 @@ class JointStore(Store):
         Args:
             force_reset: whether to forcibly reset the connection
         """
-        conn = (
+        conn: MongoClient = (
             MongoClient(
                 host=self.host,
                 port=self.port,

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -126,7 +126,7 @@ class GridFSStore(Store):
         """
         Connect to the source data
         """
-        conn = (
+        conn: MongoClient = (
             MongoClient(
                 host=self.host,
                 port=self.port,
@@ -238,10 +238,7 @@ class GridFSStore(Store):
                 metadata = doc.get("metadata", {})
 
                 data = self._collection.find_one(
-                    filter={"_id": doc["_id"]},
-                    skip=skip,
-                    limit=limit,
-                    sort=sort,
+                    filter={"_id": doc["_id"]}, skip=skip, limit=limit, sort=sort,
                 ).read()
 
                 if metadata.get("compression", "") == "zlib":
@@ -511,7 +508,7 @@ class GridFSURIStore(GridFSStore):
         Connect to the source data
         """
         if not self._coll or force_reset:  # pragma: no cover
-            conn = MongoClient(self.uri, **self.mongoclient_kwargs)
+            conn: MongoClient = MongoClient(self.uri, **self.mongoclient_kwargs)
             db = conn[self.database]
             self._coll = gridfs.GridFS(db, self.collection_name)
             self._files_collection = db["{}.files".format(self.collection_name)]

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -173,7 +173,7 @@ class MongoStore(Store):
                 self.ssh_tunnel.start()
                 host, port = self.ssh_tunnel.local_address
 
-            conn = (
+            conn: MongoClient = (
                 MongoClient(
                     host=host,
                     port=port,
@@ -569,7 +569,7 @@ class MongoURIStore(MongoStore):
         Connect to the source data
         """
         if self._coll is None or force_reset:  # pragma: no cover
-            conn = MongoClient(self.uri, **self.mongoclient_kwargs)
+            conn: MongoClient = MongoClient(self.uri, **self.mongoclient_kwargs)
             db = conn[self.database]
             self._coll = db[self.collection_name]
 
@@ -677,10 +677,7 @@ class JSONStore(MemoryStore):
     """
 
     def __init__(
-        self,
-        paths: Union[str, List[str]],
-        read_only: bool = True,
-        **kwargs,
+        self, paths: Union[str, List[str]], read_only: bool = True, **kwargs,
     ):
         """
         Args:


### PR DESCRIPTION
Adds usage of the new `pymongo.timeout` (https://pymongo.readthedocs.io/en/stable/api/pymongo/index.html#pymongo.timeout) context manager to provide better control over API timeout errors when querying data in MongoDB