### PR TITLE
Up worker timeout

### DIFF
--- a/src/maggma/cli/distributed.py
+++ b/src/maggma/cli/distributed.py
@@ -20,7 +20,7 @@ from maggma.utils import tqdm
 import zmq
 import zmq.asyncio as azmq
 
-WORKER_TIMEOUT = 1200  # max timeout in seconds for a worker
+WORKER_TIMEOUT = 5400  # max timeout in seconds for a worker
 
 
 def find_port():


### PR DESCRIPTION
Increase worker timeout to accommodate longer running workers in distributed build.