### PR TITLE
Default sort on _id for determinacy

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -388,7 +388,7 @@ class MongoStore(Store):
                 for k, v in sort.items()
             ]
             if sort
-            else None
+            else [("_id", 1)]
         )
 
         hint_list = (


### PR DESCRIPTION
This PR adds a default sort to the MongoDB `_id` document key to enforce determinacy of document order by default.