### PR TITLE
JSONStore: fix last_updated serialization problem

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -24,7 +24,7 @@ from pymongo.errors import ConfigurationError, DocumentTooLarge, OperationFailur
 from sshtunnel import SSHTunnelForwarder
 
 from maggma.core import Sort, Store, StoreError
-from maggma.utils import confirm_field_index
+from maggma.utils import confirm_field_index, to_dt
 
 try:
     import montydb
@@ -677,7 +677,10 @@ class JSONStore(MemoryStore):
     """
 
     def __init__(
-        self, paths: Union[str, List[str]], read_only: bool = True, **kwargs,
+        self,
+        paths: Union[str, List[str]],
+        read_only: bool = True,
+        **kwargs,
     ):
         """
         Args:
@@ -759,6 +762,14 @@ class JSONStore(MemoryStore):
             data = data.decode() if isinstance(data, bytes) else data
             objects = orjson.loads(data)
             objects = [objects] if not isinstance(objects, list) else objects
+            # datetime objects deserialize to str. Try to convert the last_updated
+            # field back to datetime. If it does not exist, create it and assign
+            # value of None. See Store.last_updated in store.py.
+            for obj in objects:
+                if obj.get(self.last_updated_field):
+                    obj[self.last_updated_field] = to_dt(obj[self.last_updated_field])
+                else:
+                    obj[self.last_updated_field] = None
 
         return objects
 

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -763,13 +763,13 @@ class JSONStore(MemoryStore):
             objects = orjson.loads(data)
             objects = [objects] if not isinstance(objects, list) else objects
             # datetime objects deserialize to str. Try to convert the last_updated
-            # field back to datetime. If it does not exist, create it and assign
-            # value of None. See Store.last_updated in store.py.
+            # field back to datetime.
+            # # TODO - there may still be problems caused if a JSONStore is init'ed from
+            # documents that don't contain a last_updated field
+            # See Store.last_updated in store.py.
             for obj in objects:
                 if obj.get(self.last_updated_field):
                     obj[self.last_updated_field] = to_dt(obj[self.last_updated_field])
-                else:
-                    obj[self.last_updated_field] = None
 
         return objects
 

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -510,16 +510,17 @@ def test_jsonstore_last_updated(jsonstore):
         jsonstore.last_updated
     assert cm.match(jsonstore.last_updated_field)
     start_time = datetime.utcnow()
-    jsonstore.close()
-    jsonstore.connect()
     # NOTE: mongo only stores datetime with ms precision (apparently), and that
     # can cause the test below to fail. So we add a wait here.
     import time
-
     time.sleep(0.1)
     jsonstore.update(
         [{jsonstore.key: 1, "a": 1, jsonstore.last_updated_field: datetime.utcnow()}]
     )
+    # These lines ensure that the read_json_file method gets called after
+    # last_updated is written to the .json file
+    jsonstore.close()
+    jsonstore.connect()
     assert jsonstore.last_updated > start_time
 
 

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -510,8 +510,8 @@ def test_jsonstore_last_updated(jsonstore):
         jsonstore.last_updated
     assert cm.match(jsonstore.last_updated_field)
     start_time = datetime.utcnow()
-    # jsonstore._collection.insert_one({jsonstore.key: 1, "a": 1})
-    # assert jsonstore.last_updated == datetime.min
+    jsonstore.close()
+    jsonstore.connect()
     # NOTE: mongo only stores datetime with ms precision (apparently), and that
     # can cause the test below to fail. So we add a wait here.
     import time

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -506,13 +506,17 @@ def test_json_store_writeable(test_dir):
 
 def test_jsonstore_last_updated(jsonstore):
     jsonstore.connect()
-    assert jsonstore.last_updated == datetime.min
+    with pytest.raises(StoreError) as cm:
+        jsonstore.last_updated
+    assert cm.match(jsonstore.last_updated_field)
     start_time = datetime.utcnow()
-    # all documents in the .json files are missing the last_updated field, so
-    # the field is instantiated with a value of None
-    # this will return datetime.min when last_updated is called
-    jsonstore._collection.insert_one({jsonstore.key: 1, "a": 1})
-    assert jsonstore.last_updated == datetime.min
+    # jsonstore._collection.insert_one({jsonstore.key: 1, "a": 1})
+    # assert jsonstore.last_updated == datetime.min
+    # NOTE: mongo only stores datetime with ms precision (apparently), and that
+    # can cause the test below to fail. So we add a wait here.
+    import time
+
+    time.sleep(0.1)
     jsonstore.update(
         [{jsonstore.key: 1, "a": 1, jsonstore.last_updated_field: datetime.utcnow()}]
     )


### PR DESCRIPTION
`datetime` objects serialize to `str` when using the `orjson` library, which breaks the `last_updated` functionality when a `JSONStore` is written and read back from disk. This PR fixes that problem by ensuring that the `last_updated` field, which is stored as a `str`, is properly deserialized into a `datetime`.

Also adds a new test and an additional test of the `last_updated` functionality in `MontyStore`.
