### PR TITLE
python 3.11 support + expand python versions tested in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,7 +64,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     runs-on: ${{ matrix.os }}
 
@@ -109,4 +109,3 @@ jobs:
 
     - name: Build
       run: mkdocs build
-  

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,6 @@ repos:
     -   id: trailing-whitespace
     -   id: flake8
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.10.0
     hooks:
     - id: black

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,6 +3,6 @@ hvac==1.0.2
 IPython==7.31.1;python_version>"3.6"
 nbformat==5.4.0
 regex==2022.9.13
-montydb==2.4.0
+montydb==2.5.0
 azure-storage-blob==12.16.0
 azure-identity==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ mongogrant==0.3.3
 aioitertools==0.10.0
 pydantic==1.10.2
 fastapi==0.79.0
-numpy==1.21.0;python_version>"3.6"
+numpy==1.23.0;python_version>"3.8"
 pyzmq==24.0.1
 dnspython==2.2.1
 uvicorn==0.18.3


### PR DESCRIPTION
- Add python 3.10 and 3.11 to CI test suite
- bump `numpy` to 1.23 to enable python 3.11 support
- bump `montdb` to 2.5.0 to enable python 3.11 support

Note: Per[ NEP 29,](https://numpy.org/neps/nep-0029-deprecation_policy.html) we are past the Python 3.7 support window, but since we are still supporting python 3.7 (it's not causing any problems); we should leave it in the CI test matrix.