### PR TITLE
Aggregation pipelines in resource classes

### DIFF
--- a/src/maggma/api/resource/post_resource.py
+++ b/src/maggma/api/resource/post_resource.py
@@ -103,7 +103,7 @@ class PostOnlyResource(Resource):
 
             try:
                 with query_timeout(self.timeout):
-                    count = self.store.count(
+                    count = self.store.count(  # type: ignore
                         **{field: query[field] for field in query if field in ["criteria", "hint"]}
                     )
 
@@ -111,16 +111,18 @@ class PostOnlyResource(Resource):
                         {"$match": query["criteria"]},
                     ]
 
+                    sort_dict = {"$sort": {self.store.key: 1}}
                     if "sort" in query:
                         if query["sort"]:
-                            pipeline.append({"$sort": query["sort"]})
+                            sort_dict["$sort"].update(query["sort"])
 
                     projection_dict = {"$project": {"_id": 0}}  # Do not return _id by default
                     if "properties" in query:
-                        projection_dict["$project"].update({p: 1 for p in query["properties"]})
+                        if query["properties"]:
+                            projection_dict["$project"].update({p: 1 for p in query["properties"]})
 
+                    pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
-
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
                     pipeline.append({"$limit": query["limit"] if "limit" in query else 0})
 

--- a/src/maggma/api/resource/post_resource.py
+++ b/src/maggma/api/resource/post_resource.py
@@ -112,22 +112,21 @@ class PostOnlyResource(Resource):
                     ]
 
                     sort_dict = {"$sort": {self.store.key: 1}}
-                    if "sort" in query:
-                        if query["sort"]:
-                            sort_dict["$sort"].update(query["sort"])
+
+                    if query.get("sort", False):
+                        sort_dict["$sort"].update(query["sort"])
 
                     projection_dict = {"$project": {"_id": 0}}  # Do not return _id by default
-                    if "properties" in query:
-                        if query["properties"]:
-                            projection_dict["$project"].update({p: 1 for p in query["properties"]})
+
+                    if query.get("properties", False):
+                        projection_dict["$project"].update({p: 1 for p in query["properties"]})
 
                     pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
 
-                    if "limit" in query:
-                        if query["limit"]:
-                            pipeline.append({"$limit": query["limit"]})
+                    if query.get("limit", False):
+                        pipeline.append({"$limit": query["limit"]})
 
                     data = list(
                         self.store._collection.aggregate(

--- a/src/maggma/api/resource/post_resource.py
+++ b/src/maggma/api/resource/post_resource.py
@@ -124,7 +124,10 @@ class PostOnlyResource(Resource):
                     pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
-                    pipeline.append({"$limit": query["limit"] if "limit" in query else 0})
+
+                    if "limit" in query:
+                        if query["limit"]:
+                            pipeline.append({"$limit": query["limit"]})
 
                     data = list(
                         self.store._collection.aggregate(

--- a/src/maggma/api/resource/post_resource.py
+++ b/src/maggma/api/resource/post_resource.py
@@ -86,20 +86,14 @@ class PostOnlyResource(Resource):
             queries.pop("temp_response")  # type: ignore
 
             query_params = [
-                entry
-                for _, i in enumerate(self.query_operators)
-                for entry in signature(i.query).parameters
+                entry for _, i in enumerate(self.query_operators) for entry in signature(i.query).parameters
             ]
 
-            overlap = [
-                key for key in request.query_params.keys() if key not in query_params
-            ]
+            overlap = [key for key in request.query_params.keys() if key not in query_params]
             if any(overlap):
                 raise HTTPException(
                     status_code=400,
-                    detail="Request contains query parameters which cannot be used: {}".format(
-                        ", ".join(overlap)
-                    ),
+                    detail="Request contains query parameters which cannot be used: {}".format(", ".join(overlap)),
                 )
 
             query: Dict[Any, Any] = merge_queries(list(queries.values()))  # type: ignore
@@ -109,8 +103,32 @@ class PostOnlyResource(Resource):
 
             try:
                 with query_timeout(self.timeout):
-                    count = self.store.count(query["criteria"])
-                    data = list(self.store.query(**query))
+                    count = self.store.count(
+                        **{field: query[field] for field in query if field in ["criteria", "hint"]}
+                    )
+
+                    pipeline = [
+                        {"$match": query["criteria"]},
+                    ]
+
+                    if "sort" in query:
+                        if query["sort"]:
+                            pipeline.append({"$sort": query["sort"]})
+
+                    projection_dict = {"$project": {"_id": 0}}  # Do not return _id by default
+                    if "properties" in query:
+                        projection_dict["$project"].update({p: 1 for p in query["properties"]})
+
+                    pipeline.append(projection_dict)
+
+                    pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
+                    pipeline.append({"$limit": query["limit"] if "limit" in query else 0})
+
+                    data = list(
+                        self.store._collection.aggregate(
+                            pipeline, **{field: query[field] for field in query if field in ["hint"]}
+                        )
+                    )
             except (NetworkTimeout, PyMongoError) as e:
                 if e.timeout:
                     raise HTTPException(

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -233,7 +233,7 @@ class ReadOnlyResource(Resource):
                     pipeline = [
                         {"$match": query["criteria"]},
                     ]
-                    
+
                     sort_dict = {"$sort": {self.store.key: 1}}
                     if "sort" in query:
                         if query["sort"]:

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -247,7 +247,10 @@ class ReadOnlyResource(Resource):
                     pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
-                    pipeline.append({"$limit": query["limit"] if "limit" in query else 0})
+
+                    if "limit" in query:
+                        if query["limit"]:
+                            pipeline.append({"$limit": query["limit"]})
 
                     data = list(
                         self.store._collection.aggregate(

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -235,22 +235,21 @@ class ReadOnlyResource(Resource):
                     ]
 
                     sort_dict = {"$sort": {self.store.key: 1}}
-                    if "sort" in query:
-                        if query["sort"]:
-                            sort_dict["$sort"].update(query["sort"])
+
+                    if query.get("sort", False):
+                        sort_dict["$sort"].update(query["sort"])
 
                     projection_dict = {"$project": {"_id": 0}}  # Do not return _id by default
-                    if "properties" in query:
-                        if query["properties"]:
-                            projection_dict["$project"].update({p: 1 for p in query["properties"]})
+
+                    if query.get("properties", False):
+                        projection_dict["$project"].update({p: 1 for p in query["properties"]})
 
                     pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
 
-                    if "limit" in query:
-                        if query["limit"]:
-                            pipeline.append({"$limit": query["limit"]})
+                    if query.get("limit", False):
+                        pipeline.append({"$limit": query["limit"]})
 
                     data = list(
                         self.store._collection.aggregate(

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -226,24 +226,26 @@ class ReadOnlyResource(Resource):
 
             try:
                 with query_timeout(self.timeout):
-                    count = self.store.count(
+                    count = self.store.count(  # type: ignore
                         **{field: query[field] for field in query if field in ["criteria", "hint"]}
                     )
 
                     pipeline = [
                         {"$match": query["criteria"]},
                     ]
-
+                    
+                    sort_dict = {"$sort": {self.store.key: 1}}
                     if "sort" in query:
                         if query["sort"]:
-                            pipeline.append({"$sort": query["sort"]})
+                            sort_dict["$sort"].update(query["sort"])
 
                     projection_dict = {"$project": {"_id": 0}}  # Do not return _id by default
                     if "properties" in query:
-                        projection_dict["$project"].update({p: 1 for p in query["properties"]})
+                        if query["properties"]:
+                            projection_dict["$project"].update({p: 1 for p in query["properties"]})
 
+                    pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
-
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
                     pipeline.append({"$limit": query["limit"] if "limit" in query else 0})
 

--- a/src/maggma/api/resource/submission.py
+++ b/src/maggma/api/resource/submission.py
@@ -214,16 +214,18 @@ class SubmissionResource(Resource):
                         {"$match": query["criteria"]},
                     ]
 
+                    sort_dict = {"$sort": {self.store.key: 1}}
                     if "sort" in query:
                         if query["sort"]:
-                            pipeline.append({"$sort": query["sort"]})
+                            sort_dict["$sort"].update(query["sort"])
 
                     projection_dict = {"$project": {"_id": 0}}  # Do not return _id by default
                     if "properties" in query:
-                        projection_dict["$project"].update({p: 1 for p in query["properties"]})
+                        if query["properties"]:
+                            projection_dict["$project"].update({p: 1 for p in query["properties"]})
 
+                    pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
-
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
                     pipeline.append({"$limit": query["limit"] if "limit" in query else 0})
 

--- a/src/maggma/api/resource/submission.py
+++ b/src/maggma/api/resource/submission.py
@@ -206,7 +206,7 @@ class SubmissionResource(Resource):
 
             try:
                 with query_timeout(self.timeout):
-                    count = self.store.count(
+                    count = self.store.count(  # type: ignore
                         **{field: query[field] for field in query if field in ["criteria", "hint"]}
                     )
 

--- a/src/maggma/api/resource/submission.py
+++ b/src/maggma/api/resource/submission.py
@@ -215,22 +215,21 @@ class SubmissionResource(Resource):
                     ]
 
                     sort_dict = {"$sort": {self.store.key: 1}}
-                    if "sort" in query:
-                        if query["sort"]:
-                            sort_dict["$sort"].update(query["sort"])
+
+                    if query.get("sort", False):
+                        sort_dict["$sort"].update(query["sort"])
 
                     projection_dict = {"$project": {"_id": 0}}  # Do not return _id by default
-                    if "properties" in query:
-                        if query["properties"]:
-                            projection_dict["$project"].update({p: 1 for p in query["properties"]})
+
+                    if query.get("properties", False):
+                        projection_dict["$project"].update({p: 1 for p in query["properties"]})
 
                     pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
 
-                    if "limit" in query:
-                        if query["limit"]:
-                            pipeline.append({"$limit": query["limit"]})
+                    if query.get("limit", False):
+                        pipeline.append({"$limit": query["limit"]})
 
                     data = list(
                         self.store._collection.aggregate(

--- a/src/maggma/api/resource/submission.py
+++ b/src/maggma/api/resource/submission.py
@@ -227,7 +227,10 @@ class SubmissionResource(Resource):
                     pipeline.append(sort_dict)
                     pipeline.append(projection_dict)
                     pipeline.append({"$skip": query["skip"] if "skip" in query else 0})
-                    pipeline.append({"$limit": query["limit"] if "limit" in query else 0})
+
+                    if "limit" in query:
+                        if query["limit"]:
+                            pipeline.append({"$limit": query["limit"]})
 
                     data = list(
                         self.store._collection.aggregate(

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -53,9 +53,7 @@ def test_init(owner_store):
     resource = ReadOnlyResource(store=owner_store, model=Owner, enable_get_by_key=False)
     assert len(resource.router.routes) == 2
 
-    resource = ReadOnlyResource(
-        store=owner_store, model=Owner, enable_default_search=False
-    )
+    resource = ReadOnlyResource(store=owner_store, model=Owner, enable_default_search=False)
     assert len(resource.router.routes) == 2
 
 
@@ -162,7 +160,7 @@ def test_numeric_query_operator():
 
     # Checking int
     payload = {"age": 20, "_all_fields": True}
-    res, data = search_helper(payload=payload, base="/?", debug=True)z
+    res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 1
     assert data[0]["age"] == 20

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -53,9 +53,7 @@ def test_init(owner_store):
     resource = ReadOnlyResource(store=owner_store, model=Owner, enable_get_by_key=False)
     assert len(resource.router.routes) == 2
 
-    resource = ReadOnlyResource(
-        store=owner_store, model=Owner, enable_default_search=False
-    )
+    resource = ReadOnlyResource(store=owner_store, model=Owner, enable_default_search=False)
     assert len(resource.router.routes) == 2
 
 
@@ -161,23 +159,24 @@ def search_helper(payload, base: str = "/?", debug=True) -> Response:
 def test_numeric_query_operator():
 
     # Checking int
-    payload = {"age": 20, "_all_fields": True}
+    payload = {"age": 20, "_all_fields": True, "limit": 100}
     res, data = search_helper(payload=payload, base="/?", debug=True)
+    print(data)
     assert res.status_code == 200
     assert len(data) == 1
     assert data[0]["age"] == 20
 
-    payload = {"age_not_eq": 9, "_all_fields": True}
+    payload = {"age_not_eq": 9, "_all_fields": True, "limit": 100}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 11
 
-    payload = {"age_max": 9}
+    payload = {"age_max": 9, "limit": 100}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 8
 
-    payload = {"age_min": 0}
+    payload = {"age_min": 0, "limit": 100}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 13
@@ -185,13 +184,13 @@ def test_numeric_query_operator():
 
 def test_string_query_operator():
 
-    payload = {"name": "PersonAge9", "_all_fields": True}
+    payload = {"name": "PersonAge9", "_all_fields": True, "limit": 100}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 1
     assert data[0]["name"] == "PersonAge9"
 
-    payload = {"name_not_eq": "PersonAge9", "_all_fields": True}
+    payload = ({"name_not_eq": "PersonAge9", "_all_fields": True, "limit": 100},)
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 12
@@ -204,6 +203,7 @@ def test_resource_compound():
         "weight_min": 199.1,
         "weight_max": 201.4,
         "age": 20,
+        "limit": 100,
     }
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
@@ -217,6 +217,7 @@ def test_resource_compound():
         "weight_min": 199.3,
         "weight_max": 201.9,
         "age": 20,
+        "limit": 100,
     }
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -53,7 +53,9 @@ def test_init(owner_store):
     resource = ReadOnlyResource(store=owner_store, model=Owner, enable_get_by_key=False)
     assert len(resource.router.routes) == 2
 
-    resource = ReadOnlyResource(store=owner_store, model=Owner, enable_default_search=False)
+    resource = ReadOnlyResource(
+        store=owner_store, model=Owner, enable_default_search=False
+    )
     assert len(resource.router.routes) == 2
 
 
@@ -159,24 +161,23 @@ def search_helper(payload, base: str = "/?", debug=True) -> Response:
 def test_numeric_query_operator():
 
     # Checking int
-    payload = {"age": 20, "_all_fields": True, "limit": 100}
-    res, data = search_helper(payload=payload, base="/?", debug=True)
-    print(data)
+    payload = {"age": 20, "_all_fields": True}
+    res, data = search_helper(payload=payload, base="/?", debug=True)z
     assert res.status_code == 200
     assert len(data) == 1
     assert data[0]["age"] == 20
 
-    payload = {"age_not_eq": 9, "_all_fields": True, "limit": 100}
+    payload = {"age_not_eq": 9, "_all_fields": True}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 11
 
-    payload = {"age_max": 9, "limit": 100}
+    payload = {"age_max": 9}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 8
 
-    payload = {"age_min": 0, "limit": 100}
+    payload = {"age_min": 0}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 13
@@ -184,13 +185,13 @@ def test_numeric_query_operator():
 
 def test_string_query_operator():
 
-    payload = {"name": "PersonAge9", "_all_fields": True, "limit": 100}
+    payload = {"name": "PersonAge9", "_all_fields": True}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 1
     assert data[0]["name"] == "PersonAge9"
 
-    payload = ({"name_not_eq": "PersonAge9", "_all_fields": True, "limit": 100},)
+    payload = {"name_not_eq": "PersonAge9", "_all_fields": True}
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
     assert len(data) == 12
@@ -203,7 +204,6 @@ def test_resource_compound():
         "weight_min": 199.1,
         "weight_max": 201.4,
         "age": 20,
-        "limit": 100,
     }
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200
@@ -217,7 +217,6 @@ def test_resource_compound():
         "weight_min": 199.3,
         "weight_max": 201.9,
         "age": 20,
-        "limit": 100,
     }
     res, data = search_helper(payload=payload, base="/?", debug=True)
     assert res.status_code == 200


### PR DESCRIPTION
Convert all calls to `query` method in `Resource` classes to aggregation pipelines. This is to ensure determinacy in return results when different `skip` and `limit` values are used for the same set of `criteria`.