### PR TITLE
enforce key matching

### DIFF
--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -93,8 +93,8 @@ class S3Store(Store):
         if not isinstance(index.key, str):
             raise TypeError("Since we are using the key as a file name in S3, they key must be a string")
         if key != index.key:
-            raise ValueError(
-                f"The desired S3Store key {key} does not match the index key {index.key}"
+            warnings.warn(
+                f"The desired S3Store key {key} does not match the index key {index.key}. "
             )
         kwargs["key"] = str(index.key)
 

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -90,14 +90,11 @@ class S3Store(Store):
         self.store_hash = store_hash
 
         # Force the key to be the same as the index
-        assert isinstance(
-            index.key, str
-        ), "Since we are using the key as a file name in S3, they key must be a string"
+        if not isinstance(index.key, str):
+            raise TypeError("Since we are using the key as a file name in S3, they key must be a string")
         if key != index.key:
-            warnings.warn(
-                f'The desired S3Store key "{key}" does not match the index key "{index.key},"'
-                "the index key will be used",
-                UserWarning,
+            raise ValueError(
+                f"The desired S3Store key {key} does not match the index key {index.key}"
             )
         kwargs["key"] = str(index.key)
 

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -83,7 +83,7 @@ def test_keys():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
         index = MemoryStore("index", key=1)
-        with pytest.raises(AssertionError, match=r"Since we are.*"):
+        with pytest.raises(TypeError, match=r"Since we are.*"):
             store = S3Store(index, "bucket1", s3_workers=4, key=1)
         index = MemoryStore("index", key="key1")
         with pytest.warns(UserWarning, match=r"The desired S3Store.*$"):


### PR DESCRIPTION
Raise errors when the index/S3Store keys are not matching or not in the correct format