### PR TITLE
Remove default sorting from API

### DIFF
--- a/src/maggma/api/resource/post_resource.py
+++ b/src/maggma/api/resource/post_resource.py
@@ -126,7 +126,10 @@ class PostOnlyResource(Resource):
                         detail="Server timed out trying to obtain data. Try again with a smaller request.",
                     )
                 else:
-                    raise HTTPException(status_code=500)
+                    raise HTTPException(
+                        status_code=500,
+                        detail="Server timed out trying to obtain data. Try again with a smaller request, "
+                        "or remove sorting fields and sort data locally.",)
 
             operator_meta = {}
 

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -255,6 +255,8 @@ class ReadOnlyResource(Resource):
                 else:
                     raise HTTPException(
                         status_code=500,
+                        detail="Server timed out trying to obtain data. Try again with a smaller request,"
+                        " or remove sorting fields and sort data locally.",
                     )
 
             operator_meta = {}

--- a/src/maggma/api/resource/submission.py
+++ b/src/maggma/api/resource/submission.py
@@ -230,6 +230,8 @@ class SubmissionResource(Resource):
                 else:
                     raise HTTPException(
                         status_code=500,
+                        detail="Server timed out trying to obtain data. Try again with a smaller request, "
+                        "or remove sorting fields and sort data locally.",
                     )
 
             meta = Meta(total_doc=count)


### PR DESCRIPTION
Since API queries are not all aggregation pipelines, default sorting by unique key to ensure deterministic result order can now be removed.