### PR TITLE
Overhaul distributed framework and add RabbitMQ support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = *test*
+omit = *test*, rabbitmq*

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -44,17 +44,14 @@ sys.meta_path.append(ScriptFinder())
     help="Store in JSON/YAML form to send reporting data to",
     type=click.Path(exists=True),
 )
-@click.option(
-    "-u", "--url", "url", default=None, type=str, help="URL for the distributed manager"
-)
+@click.option("-u", "--url", "url", default=None, type=str, help="URL for the distributed manager")
 @click.option(
     "-p",
     "--port",
     "port",
     default=None,
     type=int,
-    help="Port for distributed communication."
-    " mrun will find an open port if None is provided to the manager",
+    help="Port for distributed communication." " mrun will find an open port if None is provided to the manager",
 )
 @click.option(
     "-N",
@@ -72,12 +69,8 @@ sys.meta_path.append(ScriptFinder())
     type=int,
     help="Number of distributed workers to process chunks",
 )
-@click.option(
-    "--no_bars", is_flag=True, help="Turns of Progress Bars for headless operations"
-)
-@click.option(
-    "--rabbitmq", is_flag=True, help="Enables the use of RabbitMQ as the work broker"
-)
+@click.option("--no_bars", is_flag=True, help="Turns of Progress Bars for headless operations")
+@click.option("--rabbitmq", is_flag=True, help="Enables the use of RabbitMQ as the work broker")
 @click.option(
     "-q",
     "--queue_prefix",
@@ -111,9 +104,7 @@ def run(
     root = logging.getLogger()
     root.setLevel(level)
     ch = TqdmLoggingHandler()
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     ch.setFormatter(formatter)
     root.addHandler(ch)
 
@@ -158,24 +149,17 @@ def run(
                 )
 
         else:
-            # worker
-            loop = asyncio.get_event_loop()
+            # Worker
             if rabbitmq:
-                loop.run_until_complete(
-                    worker(
-                        url=url,
-                        port=port,
-                        num_processes=num_processes,
-                        no_bars=no_bars,
-                        queue_prefix=queue_prefix,
-                    )
+                worker(
+                    url=url,
+                    port=port,
+                    num_processes=num_processes,
+                    no_bars=no_bars,
+                    queue_prefix=queue_prefix,
                 )
             else:
-                loop.run_until_complete(
-                    worker(
-                        url=url, port=port, num_processes=num_processes, no_bars=no_bars
-                    )
-                )
+                worker(url=url, port=port, num_processes=num_processes, no_bars=no_bars)
     else:
         if num_processes == 1:
             for builder in builder_objects:
@@ -183,6 +167,4 @@ def run(
         else:
             loop = asyncio.get_event_loop()
             for builder in builder_objects:
-                loop.run_until_complete(
-                    multi(builder=builder, num_processes=num_processes, no_bars=no_bars)
-                )
+                loop.run_until_complete(multi(builder=builder, num_processes=num_processes, no_bars=no_bars))

--- a/src/maggma/cli/multiprocessing.py
+++ b/src/maggma/cli/multiprocessing.py
@@ -230,9 +230,6 @@ async def multi(builder, num_processes, no_bars=False, socket=None):
         builder.update_targets(processed_items)
         update_items.update(len(processed_items))
 
-        if socket:
-            await ping_manager(socket)
-
     logger.info(
         f"Ended multiprocessing: {builder.__class__.__name__}",
         extra={

--- a/src/maggma/cli/rabbitmq.py
+++ b/src/maggma/cli/rabbitmq.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python
+# coding utf-8
+
+import json
+from logging import getLogger
+import socket as pysocket
+from typing import List
+import numpy as np
+from time import perf_counter
+from random import randint
+
+from monty.json import jsanitize
+from monty.serialization import MontyDecoder
+
+from maggma.cli.multiprocessing import multi, MANAGER_TIMEOUT
+from maggma.core import Builder
+from maggma.utils import tqdm
+
+try:
+    import pika
+    import aio_pika
+except ImportError:
+    raise ImportError("Both pika and aio-pika are required to use RabbitMQ as a broker")
+
+WORKER_TIMEOUT = 5400  # max timeout in seconds for a worker
+
+
+def find_port():
+    sock = pysocket.socket()
+    sock.bind(("", 0))
+    return sock.getsockname()[1]
+
+
+def manager(
+    url: str,
+    builders: List[Builder],
+    num_chunks: int,
+    num_workers: int,
+    queue_prefix: str,
+    port: int = 5672,
+):
+    """
+    Rabbit MQ manager for distributed processing that uses a builder prechunk to modify
+    the builder and send them out each worker to run.
+    """
+    logger = getLogger("Manager")
+
+    if not (num_chunks and num_workers):
+        raise ValueError("Both num_chunks and num_workers must be non-zero")
+
+    url = url.split("//")[-1]
+
+    logger.info(f"Binding to Manager URL {url}:{port}")
+
+    # Setup connection to RabbitMQ and ensure on all queues is one unit
+    connection, channel, status_queue, worker_queue = setup_rabbitmq(
+        url, queue_prefix, port
+    )
+
+    workers = {}  # type: ignore
+
+    logger.debug("Manager started and looking for workers")
+
+    for builder in builders:
+        logger.info(f"Working on {builder.__class__.__name__}")
+        builder_dict = builder.as_dict()
+
+        try:
+            builder.connect()
+            chunk_dicts = [
+                {"chunk": d, "distributed": False, "completed": False}
+                for d in builder.prechunk(num_chunks)
+            ]
+            pbar_distributed = tqdm(
+                total=len(chunk_dicts),
+                desc="Distributed chunks for {}".format(builder.__class__.__name__),
+            )
+
+            pbar_completed = tqdm(
+                total=len(chunk_dicts),
+                desc="Completed chunks for {}".format(builder.__class__.__name__),
+            )
+
+            logger.info(f"Distributing {len(chunk_dicts)} chunks to workers")
+
+        except NotImplementedError:
+            attempt_graceful_shutdown(connection, workers, channel, worker_queue)
+            raise RuntimeError(
+                f"Can't distribute process {builder.__class__.__name__} as no prechunk method exists."
+            )
+
+        completed = False
+
+        while not completed:
+            completed = all(chunk["completed"] for chunk in chunk_dicts)
+
+            if num_workers <= 0:
+                connection.close()
+                raise RuntimeError("No workers to distribute chunks to")
+
+            # If workers send messages decode and figure out what do
+
+            _, _, body = channel.basic_get(queue=status_queue, auto_ack=True)
+
+            if body is not None:
+                msg = body.decode("utf-8")
+
+                identity = msg.split("_")[-1]
+
+                if "READY" in msg:
+                    if identity not in workers:
+                        logger.debug(f"Got connection from worker: {msg.split('_')[1]}")
+                        workers[identity] = {
+                            "working": False,
+                            "heartbeats": 1,
+                            "last_ping": perf_counter(),
+                            "work_index": -1,
+                        }
+
+                elif "DONE":
+                    workers[identity]["working"] = False
+                    work_ind = workers[identity]["work_index"]
+                    if work_ind != -1:
+                        chunk_dicts[work_ind]["completed"] = True  # type: ignore
+                        pbar_completed.update(1)
+
+                        # If everything is distributed, send EXIT to the worker
+                        if all(chunk["distributed"] for chunk in chunk_dicts):
+                            logger.debug(
+                                f"Sending exit signal to worker: {msg.split('_')[1]}"
+                            )
+                            channel.basic_publish(
+                                exchange="",
+                                routing_key=worker_queue,
+                                body="EXIT".encode("utf-8"),
+                            )
+
+                            workers.pop(identity)
+
+                elif "ERROR" in msg:
+                    # Remove worker and requeue work sent to it
+                    attempt_graceful_shutdown(
+                        connection, workers, channel, worker_queue
+                    )
+                    raise RuntimeError(
+                        "At least one worker has stopped with error message: {}".format(
+                            msg.split("_")[1]
+                        )
+                    )
+
+                elif "PING" in msg:
+                    # Heartbeat from worker (no pong response)
+                    workers[identity]["last_ping"] = perf_counter()
+                    workers[identity]["heartbeats"] += 1
+
+            # Decide if any workers are dead and need to be removed
+            handle_dead_workers(connection, workers, channel, worker_queue)
+
+            for work_index, chunk_dict in enumerate(chunk_dicts):
+                if not chunk_dict["distributed"]:
+                    temp_builder_dict = dict(**builder_dict)
+                    temp_builder_dict.update(chunk_dict["chunk"])  # type: ignore
+                    temp_builder_dict = jsanitize(temp_builder_dict)
+
+                    # Send work for available workers
+                    for identity in workers:
+                        if not workers[identity]["working"]:
+                            # Send out a chunk to idle worker
+                            channel.basic_publish(
+                                exchange="",
+                                routing_key=worker_queue,
+                                body=json.dumps(temp_builder_dict).encode("utf-8"),
+                            )
+
+                            workers[identity]["work_index"] = work_index
+                            workers[identity]["working"] = True
+                            chunk_dicts[work_index]["distributed"] = True
+                            pbar_distributed.update(1)
+
+    # Send EXIT to any remaining workers
+    logger.info("Sending exit messages to workers once they are done")
+    attempt_graceful_shutdown(connection, workers, channel, worker_queue)
+
+
+def setup_rabbitmq(url, queue_prefix, port):
+    connection = pika.BlockingConnection(pika.ConnectionParameters(url, port))
+    channel = connection.channel()
+    channel.basic_qos(prefetch_count=1, global_qos=True)
+
+    # Ensure both worker status and work distribution queues exist
+    status_queue = queue_prefix + "_status"
+    worker_queue = queue_prefix + "_work"
+
+    channel.queue_declare(queue=status_queue, auto_delete=True)
+    channel.queue_declare(queue=worker_queue, auto_delete=True)
+
+    # Clear out work queue
+    channel.queue_purge(queue=worker_queue)
+
+    return connection, channel, status_queue, worker_queue
+
+
+def attempt_graceful_shutdown(connection, workers, channel, worker_queue):
+    for _ in workers:
+        channel.basic_publish(
+            exchange="",
+            routing_key=worker_queue,
+            body="EXIT".encode("utf-8"),
+        )
+    connection.close()
+
+
+def handle_dead_workers(connection, workers, channel, worker_queue):
+    if len(workers) == 1:
+        # Use global timeout
+        identity = list(workers.keys())[0]
+        if (perf_counter() - workers[identity]["last_ping"]) >= WORKER_TIMEOUT:
+            attempt_graceful_shutdown(connection, workers, channel, worker_queue)
+            raise RuntimeError("Worker has timed out. Stopping distributed build.")
+
+    elif len(workers) == 2:
+        # Use 10% ratio between workers
+        workers_sorted = sorted(list(workers.items()), key=lambda x: x[1]["heartbeats"])
+
+        ratio = workers_sorted[1][1]["heartbeats"] / workers_sorted[0][1]["heartbeats"]
+
+        if ratio <= 0.1:
+            attempt_graceful_shutdown(connection, workers, channel, worker_queue)
+            raise RuntimeError("One worker has timed out. Stopping distributed build.")
+
+    elif len(workers) > 2:
+        # Calculate modified z-score of heartbeat counts and see if any are <= -3.5
+        hearbeat_vals = [w["heartbeats"] for w in workers.values()]
+        median = np.median(hearbeat_vals)
+        mad = np.median([abs(i - median) for i in hearbeat_vals])
+        if mad > 0:
+            for identity in list(workers.keys()):
+                z_score = 0.6745 * (workers[identity]["heartbeats"] - median) / mad
+                if z_score <= -3.5:
+                    attempt_graceful_shutdown(
+                        connection, workers, channel, worker_queue
+                    )
+                    raise RuntimeError(
+                        "At least one worker has timed out. Stopping distributed build."
+                    )
+
+
+async def worker(
+    url: str, port: int, num_processes: int, no_bars: bool, queue_prefix: str
+):
+    """
+    Simple distributed worker that connects to a manager asks for work and deploys
+    using multiprocessing
+    """
+    identity = "%04X-%04X" % (randint(0, 0x10000), randint(0, 0x10000))
+    logger = getLogger(f"Worker {identity}")
+
+    url = url.split("//")[-1]
+
+    logger.info(f"Connnecting to Manager at {url}:{port}")
+
+    # Setup connection to RabbitMQ and ensure on all queues is one unit
+    connection: aio_pika.abc.AbstractRobustConnection = await aio_pika.connect_robust(
+        host=url, port=port
+    )
+    channel: aio_pika.abc.AbstractChannel = await connection.channel()
+    await channel.set_qos(prefetch_count=1, global_=True)
+
+    # Ensure both worker status and work distribution queues exist
+    status_queue_name = queue_prefix + "_status"
+    work_queue_name = queue_prefix + "_work"
+
+    status_queue: aio_pika.abc.AbstractQueue = await channel.declare_queue(
+        status_queue_name, auto_delete=True
+    )
+    work_queue: aio_pika.abc.AbstractQueue = await channel.declare_queue(
+        work_queue_name, auto_delete=True
+    )
+
+    # Purge queues
+    await status_queue.purge()
+
+    # Send ready signal to status queue
+    await channel.default_exchange.publish(
+        aio_pika.Message(body="READY_{}".format(identity).encode("utf-8")),
+        routing_key=status_queue_name,
+    )
+
+    try:
+        running = True
+        while running:
+            # Wait for work from manager
+            raw_message: aio_pika.abc.AbstractIncomingMessage = await work_queue.get(
+                no_ack=True, timeout=MANAGER_TIMEOUT, fail=False
+            )  # type: ignore
+
+            if raw_message is not None:
+                async with raw_message.process(ignore_processed=True):
+                    message = raw_message.body.decode("utf-8")
+
+                    if "@class" in message and "@module" in message:
+                        # We have a valid builder
+                        work = json.loads(message)
+                        builder = MontyDecoder().process_decoded(work)
+
+                        logger.info("Working on builder {}".format(builder.__class__))
+                        await channel.default_exchange.publish(
+                            aio_pika.Message(
+                                body="WORKING_{}".format(identity).encode("utf-8")
+                            ),
+                            routing_key=status_queue_name,
+                        )
+
+                        work = json.loads(message)
+                        builder = MontyDecoder().process_decoded(work)
+                        await multi(
+                            builder,
+                            num_processes,
+                            no_bars=no_bars,
+                            heartbeat_func=ping_manager,
+                            heartbeat_func_kwargs={
+                                "channel": channel,
+                                "identity": identity,
+                                "status_queue_name": status_queue_name,
+                            },
+                        )
+                        await channel.default_exchange.publish(
+                            aio_pika.Message(
+                                body="DONE_{}".format(identity).encode("utf-8")
+                            ),
+                            routing_key=status_queue_name,
+                        )
+                    elif message == "EXIT":
+                        # End the worker
+                        running = False
+
+        # try:
+        #     bmessage: bytes = await asyncio.wait_for(socket.recv(), timeout=MANAGER_TIMEOUT)  # type: ignore
+        # except asyncio.TimeoutError:
+        #     socket.close()
+        #     raise RuntimeError("Stopping work as manager timed out.")
+
+    except Exception as e:
+        logger.error(f"A worker failed with error: {repr(e)}")
+        await channel.default_exchange.publish(
+            aio_pika.Message(body="ERROR_{}".format(repr(e)).encode("utf-8")),
+            routing_key=status_queue_name,
+        )
+        await connection.close()
+
+    await connection.close()
+
+
+async def ping_manager(channel, identity, status_queue_name):
+    await channel.default_exchange.publish(
+        aio_pika.Message(body="PING_{}".format(identity).encode("utf-8")),
+        routing_key=status_queue_name,
+    )

--- a/src/maggma/cli/rabbitmq.py
+++ b/src/maggma/cli/rabbitmq.py
@@ -91,7 +91,7 @@ def manager(
 
         completed = False
 
-        while not completed:
+        while not (completed and workers):
             completed = all(chunk["completed"] for chunk in chunk_dicts)
 
             if num_workers <= 0:
@@ -124,8 +124,8 @@ def manager(
                         chunk_dicts[work_ind]["completed"] = True  # type: ignore
                         pbar_completed.update(1)
 
-                        # If everything is distributed, send EXIT to the worker
-                        if all(chunk["distributed"] for chunk in chunk_dicts):
+                        # If everything is completed, send EXIT to the worker
+                        if all(chunk["completed"] for chunk in chunk_dicts):
                             logger.debug(
                                 f"Sending exit signal to worker: {msg.split('_')[1]}"
                             )


### PR DESCRIPTION
This PR overhauls the code to run builders in a distributed mode across multiple nodes:

- [x] Existing ZeroMQ code is fixed to ensure better reliability
- [x] Flexible heartbeating now supported with increased pings
- [x] Add new code to support RabbitMQ with an additional flag in the CLI 
