### PR TITLE
Update MongoStore `count` method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,34 @@
+default_stages: [commit]
+
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.261
+    hooks:
+      - id: ruff
+        args: [--fix, --ignore, "D,E501"]
+
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black-jupyter
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.4.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: flake8
-  - repo: https://github.com/ambv/black
-    rev: stable
+      - id: check-case-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: destroyed-symlinks
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
     hooks:
-    - id: black
+      - id: codespell
+        stages: [commit, commit-msg]
+        exclude_types: [json, bib, svg]
+        args: [--ignore-words-list, "mater,fwe,te"]

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -28,7 +28,7 @@ from maggma.core import Sort, Store, StoreError
 from maggma.utils import confirm_field_index, to_dt
 
 try:
-    import montydb
+    import montydb  # type: ignore
 except ImportError:
     montydb = None
 
@@ -148,7 +148,7 @@ class MongoStore(Store):
         self.ssh_tunnel = ssh_tunnel
         self.safe_update = safe_update
         self.default_sort = default_sort
-        self._coll = None  # type: Any
+        self._coll = None
         self.kwargs = kwargs
 
         if auth_source is None:
@@ -300,7 +300,7 @@ class MongoStore(Store):
         group_id = {letter: f"${key}" for letter, key in zip(alpha, keys)}
         pipeline.append({"$group": {"_id": group_id, "docs": {"$push": "$$ROOT"}}})
         for d in self._collection.aggregate(pipeline, allowDiskUse=True):
-            id_doc = {}  # type: Dict[str,Any]
+            id_doc = {}
             for letter, key in group_id.items():
                 if has(d["_id"], letter):
                     set_(id_doc, key[1:], d["_id"][letter])
@@ -679,7 +679,7 @@ class MemoryStore(MongoStore):
             return tuple(get(doc, k) for k in keys)
 
         for vals, group in groupby(sorted(data, key=grouping_keys), key=grouping_keys):
-            doc = {}  # type: Dict[Any,Any]
+            doc = {}
             for k, v in zip(keys, vals):
                 set_(doc, k, v)
             yield doc, list(group)
@@ -931,7 +931,7 @@ class MontyStore(MemoryStore):
         Args:
             force_reset: Force connection reset.
         """
-        from montydb import set_storage, MontyClient
+        from montydb import set_storage, MontyClient  # type: ignore
 
         set_storage(self.database_path, storage=self.storage, **self.storage_kwargs)
         client = MontyClient(self.database_path, **self.client_kwargs)

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -942,6 +942,36 @@ class MontyStore(MemoryStore):
         """Return a string representing this data source."""
         return f"monty://{self.database_path}/{self.database}/{self.collection_name}"
 
+    def count(
+        self,
+        criteria: Optional[Dict] = None,
+        hint: Optional[Dict[str, Union[Sort, int]]] = None,
+    ) -> int:
+        """
+        Counts the number of documents matching the query criteria
+
+        Args:
+            criteria: PyMongo filter for documents to count in
+            hint: Dictionary of indexes to use as hints for query optimizer.
+                Keys are field names and values are 1 for ascending or -1 for descending.
+        """
+
+        criteria = criteria if criteria else {}
+
+        hint_list = (
+            [
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in hint.items()
+            ]
+            if hint
+            else None
+        )
+
+        if hint_list is not None:  # pragma: no cover
+            return self._collection.count_documents(filter=criteria, hint=hint_list)
+
+        return self._collection.count_documents(filter=criteria)
+
     def update(self, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None):
         """
         Update documents into the Store.

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -10,7 +10,7 @@ import yaml
 from itertools import chain, groupby
 from socket import socket
 import warnings
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import mongomock
 import orjson
@@ -20,6 +20,7 @@ from monty.json import MSONable, jsanitize
 from monty.serialization import loadfn
 from pydash import get, has, set_
 from pymongo import MongoClient, ReplaceOne, uri_parser
+from pymongo.collection import Collection
 from pymongo.errors import ConfigurationError, DocumentTooLarge, OperationFailure
 from sshtunnel import SSHTunnelForwarder
 
@@ -33,7 +34,6 @@ except ImportError:
 
 
 class SSHTunnel(MSONable):
-
     __TUNNELS: Dict[str, SSHTunnelForwarder] = {}
 
     def __init__(
@@ -230,7 +230,9 @@ class MongoStore(Store):
 
         return cls(**db_creds, **kwargs)
 
-    def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
+    def distinct(
+        self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False
+    ) -> List:
         """
         Get all distinct values for a field
 
@@ -244,7 +246,10 @@ class MongoStore(Store):
             distinct_vals = self._collection.distinct(field, criteria)
         except (OperationFailure, DocumentTooLarge):
             distinct_vals = [
-                d["_id"] for d in self._collection.aggregate([{"$match": criteria}, {"$group": {"_id": f"${field}"}}])
+                d["_id"]
+                for d in self._collection.aggregate(
+                    [{"$match": criteria}, {"$group": {"_id": f"${field}"}}]
+                )
             ]
             if all(isinstance(d, list) for d in filter(None, distinct_vals)):  # type: ignore
                 distinct_vals = list(chain.from_iterable(filter(None, distinct_vals)))
@@ -316,14 +321,16 @@ class MongoStore(Store):
         db_name = collection.database.name
 
         store = cls(db_name, coll_name)
-        store._coll = collection
+        store._coll: Collection = collection
         return store
 
     @property
     def _collection(self):
         """Property referring to underlying pymongo collection"""
         if self._coll is None:
-            raise StoreError("Must connect Mongo-like store before attemping to use it")
+            raise StoreError(
+                "Must connect Mongo-like store before attempting to use it"
+            )
         return self._coll
 
     def count(
@@ -343,13 +350,22 @@ class MongoStore(Store):
         criteria = criteria if criteria else {}
 
         hint_list = (
-            [(k, Sort(v).value) if isinstance(v, int) else (k, v.value) for k, v in hint.items()] if hint else None
+            [
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in hint.items()
+            ]
+            if hint
+            else None
         )
 
         if hint_list is not None:  # pragma: no cover
             return self._collection.count_documents(filter=criteria, hint=hint_list)
 
-        return self._collection.count_documents(filter=criteria)
+        return (
+            self._collection.count_documents(filter=criteria)
+            if criteria
+            else self._collection.estimated_document_count()
+        )
 
     def query(  # type: ignore
         self,
@@ -382,27 +398,42 @@ class MongoStore(Store):
 
         if self.default_sort is not None:
             default_sort_formatted = [
-                (k, Sort(v).value) if isinstance(v, int) else (k, v.value) for k, v in self.default_sort.items()
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in self.default_sort.items()
             ]
 
         sort_list = (
-            [(k, Sort(v).value) if isinstance(v, int) else (k, v.value) for k, v in sort.items()]
+            [
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in sort.items()
+            ]
             if sort
             else default_sort_formatted
         )
 
         hint_list = (
-            [(k, Sort(v).value) if isinstance(v, int) else (k, v.value) for k, v in hint.items()] if hint else None
+            [
+                (k, Sort(v).value) if isinstance(v, int) else (k, v.value)
+                for k, v in hint.items()
+            ]
+            if hint
+            else None
         )
 
         for d in self._collection.find(
-            filter=criteria, projection=properties, skip=skip, limit=limit, sort=sort_list, hint=hint_list, **kwargs
+            filter=criteria,
+            projection=properties,
+            skip=skip,
+            limit=limit,
+            sort=sort_list,
+            hint=hint_list,
+            **kwargs,
         ):
             yield d
 
     def ensure_index(self, key: str, unique: Optional[bool] = False) -> bool:
         """
-        Tries to create an index and return true if it suceeded
+        Tries to create an index and return true if it succeeded
         Args:
             key: single key to index
             unique: Whether or not this index contains only unique keys
@@ -438,7 +469,6 @@ class MongoStore(Store):
             docs = [docs]
 
         for d in docs:
-
             d = jsanitize(d, allow_bson=True)
 
             # document-level validation is optional
@@ -538,7 +568,9 @@ class MongoURIStore(MongoStore):
         if database is None:
             d_uri = uri_parser.parse_uri(uri)
             if d_uri["database"] is None:
-                raise ConfigurationError("If database name is not supplied, a database must be set in the uri")
+                raise ConfigurationError(
+                    "If database name is not supplied, a database must be set in the uri"
+                )
             self.database = d_uri["database"]
         else:
             self.database = database
@@ -628,7 +660,7 @@ class MemoryStore(MongoStore):
             limit: limit on total number of documents returned
 
         Returns:
-            generator returning tuples of (key, list of elemnts)
+            generator returning tuples of (key, list of elements)
         """
         keys = keys if isinstance(keys, list) else [keys]
 
@@ -638,7 +670,9 @@ class MemoryStore(MongoStore):
             properties = list(properties.keys())
 
         data = [
-            doc for doc in self.query(properties=keys + properties, criteria=criteria) if all(has(doc, k) for k in keys)
+            doc
+            for doc in self.query(properties=keys + properties, criteria=criteria)
+            if all(has(doc, k) for k in keys)
         ]
 
         def grouping_keys(doc):
@@ -710,7 +744,9 @@ class JSONStore(MemoryStore):
         self.kwargs = kwargs
 
         if not self.read_only and len(paths) > 1:
-            raise RuntimeError("Cannot instantiate file-writable JSONStore with multiple JSON files.")
+            raise RuntimeError(
+                "Cannot instantiate file-writable JSONStore with multiple JSON files."
+            )
 
         # create the .json file if it does not exist
         if not self.read_only and not Path(self.paths[0]).exists():

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -20,7 +20,6 @@ from monty.json import MSONable, jsanitize
 from monty.serialization import loadfn
 from pydash import get, has, set_
 from pymongo import MongoClient, ReplaceOne, uri_parser
-from pymongo.collection import Collection
 from pymongo.errors import ConfigurationError, DocumentTooLarge, OperationFailure
 from sshtunnel import SSHTunnelForwarder
 
@@ -148,7 +147,7 @@ class MongoStore(Store):
         self.ssh_tunnel = ssh_tunnel
         self.safe_update = safe_update
         self.default_sort = default_sort
-        self._coll = None
+        self._coll = None  # type: ignore
         self.kwargs = kwargs
 
         if auth_source is None:
@@ -190,7 +189,7 @@ class MongoStore(Store):
                 else MongoClient(host, port, **self.mongoclient_kwargs)
             )
             db = conn[self.database]
-            self._coll = db[self.collection_name]
+            self._coll = db[self.collection_name]  # type: ignore
 
     def __hash__(self) -> int:
         """Hash for MongoStore"""
@@ -300,7 +299,7 @@ class MongoStore(Store):
         group_id = {letter: f"${key}" for letter, key in zip(alpha, keys)}
         pipeline.append({"$group": {"_id": group_id, "docs": {"$push": "$$ROOT"}}})
         for d in self._collection.aggregate(pipeline, allowDiskUse=True):
-            id_doc = {}
+            id_doc = {}  # type: ignore
             for letter, key in group_id.items():
                 if has(d["_id"], letter):
                     set_(id_doc, key[1:], d["_id"][letter])
@@ -321,7 +320,7 @@ class MongoStore(Store):
         db_name = collection.database.name
 
         store = cls(db_name, coll_name)
-        store._coll: Collection = collection
+        store._coll = collection
         return store
 
     @property
@@ -679,7 +678,7 @@ class MemoryStore(MongoStore):
             return tuple(get(doc, k) for k in keys)
 
         for vals, group in groupby(sorted(data, key=grouping_keys), key=grouping_keys):
-            doc = {}
+            doc = {}  # type: ignore
             for k, v in zip(keys, vals):
                 set_(doc, k, v)
             yield doc, list(group)
@@ -912,7 +911,7 @@ class MontyStore(MemoryStore):
         self.database_path = database_path
         self.database_name = database_name
         self.collection_name = collection_name
-        self._coll = None
+        self._coll = None  # type: ignore
         self.default_sort = None
         self.ssh_tunnel = None  # This is to fix issues with the tunnel on close
         self.kwargs = kwargs

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -594,7 +594,7 @@ class MongoURIStore(MongoStore):
         if self._coll is None or force_reset:  # pragma: no cover
             conn: MongoClient = MongoClient(self.uri, **self.mongoclient_kwargs)
             db = conn[self.database]
-            self._coll = db[self.collection_name]
+            self._coll = db[self.collection_name]  # type: ignore
 
 
 class MemoryStore(MongoStore):
@@ -621,7 +621,7 @@ class MemoryStore(MongoStore):
         """
 
         if self._coll is None or force_reset:
-            self._coll = mongomock.MongoClient().db[self.name]
+            self._coll = mongomock.MongoClient().db[self.name]  # type: ignore
 
     def close(self):
         """Close up all collections"""


### PR DESCRIPTION
This PR ensures that the `count` method in both `MongoStore` and `MongoURIStore` used `estimated_document_count` for empty queries to speed up calls.