### PR TITLE
Add ruamel-yaml as a dependency

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,3 +3,4 @@ mkdocs-material==8.3.9
 mkdocs-minify-plugin==0.5.0
 mkdocstrings==0.18.1
 jinja2<3.2.0
+ruamel-yaml<18.0

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -13,4 +13,3 @@ responses<0.22.0
 types-PyYAML==6.0.11
 types-setuptools==65.4.0.0
 types-python-dateutil==2.8.19.2
-ruamel.yaml<18.0

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -13,3 +13,4 @@ responses<0.22.0
 types-PyYAML==6.0.11
 types-setuptools==65.4.0.0
 types-python-dateutil==2.8.19.2
+ruamel.yaml<18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ orjson==3.8.0
 boto3==1.24.42
 python-dateutil==2.8.2
 pydantic
+ruamel.yaml<0.18

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -107,7 +107,7 @@ class GridFSStore(Store):
         Returns:
         """
         with open(lp_file, "r") as f:
-            lp_creds = yaml.load(f, Loader=yaml.FullLoader)
+            lp_creds = yaml.safe_load(f.read())
 
         db_creds = lp_creds.copy()
         db_creds["database"] = db_creds["name"]

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -8,7 +8,7 @@ various utillities
 import copy
 import json
 import zlib
-from ruamel import yaml
+import ruamel
 from datetime import datetime
 from pymongo.errors import ConfigurationError
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -107,7 +107,7 @@ class GridFSStore(Store):
         Returns:
         """
         with open(lp_file, "r") as f:
-            lp_creds = yaml.safe_load(f.read())
+            lp_creds = ruamel.yaml.safe_load(f.read())
 
         db_creds = lp_creds.copy()
         db_creds["database"] = db_creds["name"]

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -8,7 +8,7 @@ various utillities
 import copy
 import json
 import zlib
-import yaml
+from ruamel import yaml
 from datetime import datetime
 from pymongo.errors import ConfigurationError
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -8,7 +8,7 @@ various utillities
 import copy
 import json
 import zlib
-import ruamel
+from ruamel import yaml
 from datetime import datetime
 from pymongo.errors import ConfigurationError
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -107,7 +107,7 @@ class GridFSStore(Store):
         Returns:
         """
         with open(lp_file, "r") as f:
-            lp_creds = ruamel.yaml.safe_load(f.read())
+            lp_creds = yaml.safe_load(f.read())
 
         db_creds = lp_creds.copy()
         db_creds["database"] = db_creds["name"]

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -6,7 +6,7 @@ various utilities
 """
 
 from pathlib import Path
-import yaml
+from ruamel import yaml
 from itertools import chain, groupby
 from socket import socket
 import warnings

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -218,7 +218,7 @@ class MongoStore(Store):
         Returns:
         """
         with open(lp_file, "r") as f:
-            lp_creds = yaml.load(f, Loader=yaml.FullLoader)
+            lp_creds = yaml.safe_load(f.read())
 
         db_creds = lp_creds.copy()
         db_creds["database"] = db_creds["name"]

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -6,7 +6,7 @@ various utilities
 """
 
 from pathlib import Path
-from ruamel import yaml
+import ruamel
 from itertools import chain, groupby
 from socket import socket
 import warnings
@@ -218,7 +218,7 @@ class MongoStore(Store):
         Returns:
         """
         with open(lp_file, "r") as f:
-            lp_creds = yaml.safe_load(f.read())
+            lp_creds = ruamel.yaml.safe_load(f.read())
 
         db_creds = lp_creds.copy()
         db_creds["database"] = db_creds["name"]

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -6,7 +6,7 @@ various utilities
 """
 
 from pathlib import Path
-import ruamel
+from ruamel import yaml
 from itertools import chain, groupby
 from socket import socket
 import warnings
@@ -218,7 +218,7 @@ class MongoStore(Store):
         Returns:
         """
         with open(lp_file, "r") as f:
-            lp_creds = ruamel.yaml.safe_load(f.read())
+            lp_creds = yaml.safe_load(f.read())
 
         db_creds = lp_creds.copy()
         db_creds["database"] = db_creds["name"]


### PR DESCRIPTION
Pyyaml is not a requirement of maggma, despite there being imports in `maggma.stores.mongolike` and `maggma.stores.gridfs`. I surmise this passes the tests because pyyaml is already installed when running the testing workflow.

While we're adding this dependency, we might as well start using ruamel-yaml, which other MP codes use.