### PR TITLE
modify JSONStore file creation

### DIFF
--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -442,8 +442,8 @@ def test_json_store_writeable(test_dir):
     with ScratchDir("."):
         # if the .json does not exist, it should be created
         jsonstore = JSONStore("a.json", read_only=False)
-        assert Path("a.json").exists()
         jsonstore.connect()
+        assert Path("a.json").exists()
         # confirm RunTimeError with multiple paths
         with pytest.raises(RuntimeError, match="multiple JSON"):
             jsonstore = JSONStore(["a.json", "d.json"], read_only=False)


### PR DESCRIPTION
In the current implementation, if the file is writeable it is created in the `__init__` of the store. This can be an issue since I want to create a JSONStore and keep its `as_dict` for later usage, but also got the store json file created as well. It seems that the correct place to create the file would be in the `connect` method, so I moved it there.
