### PR TITLE
Memray memory profiler support for mrun command line tool

### DIFF
--- a/docs/getting_started/running_builders.md
+++ b/docs/getting_started/running_builders.md
@@ -119,3 +119,23 @@ mrun -n 32 -vv my_first_builder.json builder_2_and_3.py last_builder.ipynb
 * `BUILD_ENDED` - This event tells us the build process finished this specific builder. It also indicates the total number of `errors` and `warnings` that were caught during the process.
 
 These event docs also contain the `builder`, a `build_id` which is unique for each time a builder is run and anonymous but unique ID for the machine the builder was run on.
+
+
+## Profiling Memory Usage of Builders
+
+`mrun` can optionally profile the memory usage of a running builder by using the Memray Python memory profiling tool ([Memray](https://github.com/bloomberg/memray)). To get started, `maggma` will first need to be installed from source ([Maggma installation](https://materialsproject.github.io/maggma/#installation-from-source)) followed by `pip` installing Memray using `pip install memray`, or by installing the optional `maggma` requirements by using `pip install requirements-optional.txt` in the `maggma` base directory.
+
+Setting the `--memray` (`-m`) option to `on`, or `True`, will signal `mrun` to profile the memory usage of any builders passed to `mrun` as the builders are running. The profiler also supports profiling of both single and forked processes. For example, spawning multiple processes in `mrun` with `-n` will signal the profiler to track any forked child processes spawned from the parent process.
+
+A basic invocation of the memory profiler using the `mrun` command line tool would look like this:
+``` shell
+mrun --memray on my_builder.json
+```
+
+The profiler will generate two files after the builder finishes: 
+1. An output `.bin` file that is dumped by default into the `temp` directory, which is platform/OS dependent. For Linux/MacOS this will be `/tmp/` and for Windows the target directory will be `C:\TEMP\`.The output file will have a generic naming pattern as follows: `BUILDER_NAME_PASSED_TO_MRUN + BUILDER_START_DATETIME_ISO.bin`, e.g., `my_builder.json_2023-06-09T13:57:48.446361.bin`. 
+2. A `.html` flamegraph file that will be written to the same directory as the `.bin` dump file. The flamegraph will have a naming pattern similar to the following: `memray-flamegraph-my_builder.json_2023-06-09T13:57:48.446361.html`. The flamegraph can be viewed using any web browser.
+
+***Note***: Different platforms/operating systems purge their system's `temp` directory at different intervals. It is recommended to move at least the `.bin` file to a more stable location. The `.bin` file can be used to recreate the flamegraph at anytime using the Memray CLI.
+
+Further data visualization and transform examples can be found in Memray's documentation ([Memray reporters](https://bloomberg.github.io/memray/live.html)).

--- a/docs/getting_started/running_builders.md
+++ b/docs/getting_started/running_builders.md
@@ -123,7 +123,7 @@ These event docs also contain the `builder`, a `build_id` which is unique for ea
 
 ## Profiling Memory Usage of Builders
 
-`mrun` can optionally profile the memory usage of a running builder by using the Memray Python memory profiling tool ([Memray](https://github.com/bloomberg/memray)). To get started, `maggma` will first need to be installed from source ([Maggma installation](https://materialsproject.github.io/maggma/#installation-from-source)) followed by `pip` installing Memray using `pip install memray`, or by installing the optional `maggma` requirements by using `pip install requirements-optional.txt` in the `maggma` base directory.
+`mrun` can optionally profile the memory usage of a running builder by using the Memray Python memory profiling tool ([Memray](https://github.com/bloomberg/memray)). To get started, Memray should be installed in the same environment as `maggma` using `pip install memray`.
 
 Setting the `--memray` (`-m`) option to `on`, or `True`, will signal `mrun` to profile the memory usage of any builders passed to `mrun` as the builders are running. The profiler also supports profiling of both single and forked processes. For example, spawning multiple processes in `mrun` with `-n` will signal the profiler to track any forked child processes spawned from the parent process.
 

--- a/docs/getting_started/running_builders.md
+++ b/docs/getting_started/running_builders.md
@@ -138,4 +138,6 @@ The profiler will generate two files after the builder finishes:
 
 ***Note***: Different platforms/operating systems purge their system's `temp` directory at different intervals. It is recommended to move at least the `.bin` file to a more stable location. The `.bin` file can be used to recreate the flamegraph at anytime using the Memray CLI.
 
+Using the flag `--memray-dir` (`-md`) allows for specifying an output directory for the `.bin` and `.html` files created by the profiler. The provided directory will be created if the directory does not exist, mimicking the `mkdir -p` command.
+
 Further data visualization and transform examples can be found in Memray's documentation ([Memray reporters](https://bloomberg.github.io/memray/live.html)).

--- a/docs/getting_started/running_builders.md
+++ b/docs/getting_started/running_builders.md
@@ -100,7 +100,7 @@ mrun -n 2 -v my_builder.py
 ```
 
 
-## Running multiple builders
+## Running Multiple Builders
 
 `mrun` can run multiple builders. You can have multiple builders in a single file: `json`, `python`, or `jupyter-notebook`. Or you can chain multiple files in the order you want to run them:
 ``` shell

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -6,3 +6,4 @@ regex==2022.9.13
 montydb==2.4.0
 azure-storage-blob==12.16.0
 azure-identity==1.12.0
+memray==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,4 @@ orjson==3.8.14
 boto3==1.24.42
 python-dateutil==2.8.2
 pydantic
-memray==1.7.0
 ruamel.yaml<0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ orjson==3.8.0
 boto3==1.24.42
 python-dateutil==2.8.2
 pydantic
+memray==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
         "msgpack>=0.5.6",
         "orjson>=3.6.0",
         "boto3>=1.20.41",
-        "python-dateutil>=2.8.2"
+        "python-dateutil>=2.8.2",
+        "memray>=1.7.0",
     ],
     extras_require={
         "vault": ["hvac>=0.9.5"],

--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,12 @@ setup(
         "orjson>=3.6.0",
         "boto3>=1.20.41",
         "python-dateutil>=2.8.2",
-        "memray>=1.7.0",
     ],
     extras_require={
         "vault": ["hvac>=0.9.5"],
         "montydb": ["montydb>=2.3.12"],
         "notebook_runner": ["IPython>=7.16", "nbformat>=5.0", "regex>=2020.6"],
-        "azure": ["azure-storage-blob>=12.16.0", "azure-identity>=1.12.0"]
+        "azure": ["azure-storage-blob>=12.16.0", "azure-identity>=1.12.0"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -118,13 +118,17 @@ def run(
 ):
     if memray:
         follow_fork = False
+
         if num_processes > 1:
             follow_fork = True
+
+        memray_file = (
+            f"{settings.TEMP_DIR}/{builders[0]}_{datetime.now().isoformat()}.bin"
+        )
+
         ctx.obj = ctx.with_resource(
             Tracker(
-                destination=FileDestination(
-                    f"{settings.TEMP_DIR}/{builders[0]}_{datetime.now().isoformat()}.bin"
-                ),
+                destination=FileDestination(memray_file),
                 native_traces=False,
                 trace_python_allocators=False,
                 follow_fork=follow_fork,
@@ -210,3 +214,8 @@ def run(
                 loop.run_until_complete(
                     multi(builder=builder, num_processes=num_processes, no_bars=no_bars)
                 )
+
+    if memray_file:
+        import subprocess
+
+        subprocess.run(["memray", "flamegraph", memray_file], shell=False)

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import sys
 from itertools import chain
-from contextlib import nullcontext
 
 import click
 from monty.serialization import loadfn
@@ -114,14 +113,17 @@ def run(
     memray,
 ):
     if memray:
+        follow_fork = False
+        if num_processes > 1:
+            follow_fork = True
         ctx.obj = ctx.with_resource(
             Tracker(
                 destination=FileDestination(
-                    "/home/tsmathis/dev/fermi_builder/memray_logs/log_test.bin"
+                    "/home/tsmathis/dev/fermi_builder/memray_logs/mp_log_test.bin"
                 ),
                 native_traces=False,
                 trace_python_allocators=False,
-                follow_fork=False,
+                follow_fork=follow_fork,
             )
         )
     # Import proper manager and worker

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -105,7 +105,9 @@ settings = CLISettings()
     "memray_dir",
     default=None,
     type=str,
-    help="Directory to dump memory profiler output files. Only runs if --memray is True. Will create directory if directory does not exist, mimicking mkdir -p command. If not provided files will be dumped to system's temp directory",
+    help="""Directory to dump memory profiler output files. Only runs if --memray is True. 
+    Will create directory if directory does not exist, mimicking mkdir -p command. 
+    If not provided files will be dumped to system's temp directory""",
 )
 @click.pass_context
 def run(

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import sys
 from itertools import chain
+from datetime import datetime
 
 import click
 from monty.serialization import loadfn
@@ -14,11 +15,14 @@ from maggma.cli.distributed import find_port
 from maggma.cli.multiprocessing import multi
 from maggma.cli.serial import serial
 from maggma.cli.source_loader import ScriptFinder, load_builder_from_source
+from maggma.cli.settings import CLISettings
 from maggma.utils import ReportingHandler, TqdmLoggingHandler
 
 from memray import Tracker, FileDestination
 
 sys.meta_path.append(ScriptFinder())
+
+settings = CLISettings()
 
 
 @click.command()
@@ -119,7 +123,7 @@ def run(
         ctx.obj = ctx.with_resource(
             Tracker(
                 destination=FileDestination(
-                    "/home/tsmathis/dev/fermi_builder/memray_logs/mp_log_test.bin"
+                    f"{settings.TEMP_DIR}/{builders[0]}_{datetime.now().isoformat()}.bin"
                 ),
                 native_traces=False,
                 trace_python_allocators=False,

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -105,8 +105,8 @@ settings = CLISettings()
     "memray_dir",
     default=None,
     type=str,
-    help="""Directory to dump memory profiler output files. Only runs if --memray is True. 
-    Will create directory if directory does not exist, mimicking mkdir -p command. 
+    help="""Directory to dump memory profiler output files. Only runs if --memray is True.
+    Will create directory if directory does not exist, mimicking mkdir -p command.
     If not provided files will be dumped to system's temp directory""",
 )
 @click.pass_context

--- a/src/maggma/cli/settings.py
+++ b/src/maggma/cli/settings.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+import platform
+import tempfile
+
 from pydantic import BaseSettings, Field
+
+tempdir = "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()
 
 
 class CLISettings(BaseSettings):
-
     WORKER_TIMEOUT: int = Field(
         3600,
         description="Timeout in seconds for a distributed worker",
@@ -11,6 +16,11 @@ class CLISettings(BaseSettings):
     MANAGER_TIMEOUT: int = Field(
         900,
         description="Timeout in seconds for the worker manager",
+    )
+
+    TEMP_DIR: str = Field(
+        tempdir,
+        description="Directory that memory profile .bin files are dumped to",
     )
 
     class Config:

--- a/src/maggma/cli/settings.py
+++ b/src/maggma/cli/settings.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import platform
 import tempfile
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -32,7 +33,6 @@ def reporting_store():
 
 
 def test_basic_run():
-
     runner = CliRunner()
     result = runner.invoke(run, ["--help"])
     assert result.exit_code == 0
@@ -43,7 +43,6 @@ def test_basic_run():
 
 
 def test_run_builder(mongostore):
-
     memorystore = MemoryStore("temp")
     builder = CopyBuilder(mongostore, memorystore)
 
@@ -81,7 +80,6 @@ def test_run_builder(mongostore):
 
 
 def test_run_builder_chain(mongostore):
-
     memorystore = MemoryStore("temp")
     builder1 = CopyBuilder(mongostore, memorystore)
     builder2 = CopyBuilder(mongostore, memorystore)
@@ -120,7 +118,6 @@ def test_run_builder_chain(mongostore):
 
 
 def test_reporting(mongostore, reporting_store):
-
     memorystore = MemoryStore("temp")
     builder = CopyBuilder(mongostore, memorystore)
 
@@ -156,7 +153,6 @@ def test_reporting(mongostore, reporting_store):
 
 
 def test_python_source():
-
     runner = CliRunner()
 
     with runner.isolated_filesystem():
@@ -170,7 +166,6 @@ def test_python_source():
 
 
 def test_python_notebook_source():
-
     runner = CliRunner()
 
     with runner.isolated_filesystem():
@@ -184,3 +179,65 @@ def test_python_notebook_source():
 
     assert result.exit_code == 0
     assert "Ended multiprocessing: DummyBuilder" in result.output
+
+
+def test_memray_run_builder(mongostore):
+    memorystore = MemoryStore("temp")
+    builder = CopyBuilder(mongostore, memorystore)
+
+    mongostore.update(
+        [
+            {mongostore.key: i, mongostore.last_updated_field: datetime.utcnow()}
+            for i in range(10)
+        ]
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        dumpfn(builder, "test_builder.json")
+        result = runner.invoke(run, ["-v", "--memray", "on", "test_builder.json"])
+        assert result.exit_code == 0
+        assert "CopyBuilder" in result.output
+        assert "SerialProcessor" in result.output
+
+        result = runner.invoke(
+            run, ["-vvv", "--no_bars", "--memray", "on", "test_builder.json"]
+        )
+        assert result.exit_code == 0
+        assert "Get" not in result.output
+        assert "Update" not in result.output
+
+        result = runner.invoke(
+            run, ["-v", "-n", "2", "--memray", "on", "test_builder.json"]
+        )
+        assert result.exit_code == 0
+        assert "CopyBuilder" in result.output
+        assert "MultiProcessor" in result.output
+
+        result = runner.invoke(
+            run, ["-vvv", "-n", "2", "--no_bars", "--memray", "on", "test_builder.json"]
+        )
+        assert result.exit_code == 0
+        assert "Get" not in result.output
+        assert "Update" not in result.output
+
+
+def test_memray_user_output_dir(mongostore):
+    memorystore = MemoryStore("temp")
+    builder = CopyBuilder(mongostore, memorystore)
+
+    mongostore.update(
+        [
+            {mongostore.key: i, mongostore.last_updated_field: datetime.utcnow()}
+            for i in range(10)
+        ]
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        dumpfn(builder, "test_builder.json")
+        result = runner.invoke(
+            run, ["--memray", "on", "-md", "memray_output_dir/", "test_builder.json"]
+        )
+        assert result.exit_code == 0
+        assert (Path.cwd() / "memray_output_dir").exists() is True


### PR DESCRIPTION
This PR adds an additional optional flag to `mrun`: `--memray`, or alternatively `-m`, to enable memory profiling of a builder using the Memray Python memory profiling tool ([Memray repo](https://github.com/bloomberg/memray)).

The profiler supports profiling of both single and forked processes. For example, spawning multiple processes in `mrun` with `-n` will signal the profiler to track any forked child process spawned from the parent process.

A basic invocation from a terminal would look something like `mrun --memray on builder_dump_file.json`. `--memray` is a Click boolean parameter ([Click](https://click.palletsprojects.com/en/5.x/parameters/)) and thus accepts the values `1`, `yes`, `y`, `on`, and `true`, which convert to `True`, and `0`, `no`, `n`, `off`, and `false`, which convert to `False`.

The output `.bin` file produced by Memray is dumped by default into the user's `temp` directory, which is platform/OS dependent. For Linux/MacOS this will be `/tmp/` and for Windows the target directory will be `C:\TEMP\`.

The output file will have a generic naming pattern as follows: `BUILDER_NAME_PASSED_TO_MRUN + BUILDER_START_DATETIME_ISO.bin`, e.g., `builder_dump.json_2023-06-06T16.14.19.272030.bin`.

Following completion, the `.bin` output file can be converted into a flamegraph using the Memray CLI, i.e, `memray flamegraph builder_dump.bin`.

Further visualization and data transform examples can be found in Memray's documentation ([Memray reporters](https://bloomberg.github.io/memray/live.html)).