### PR TITLE
Use tqdm.auto

### DIFF
--- a/src/maggma/cli/multiprocessing.py
+++ b/src/maggma/cli/multiprocessing.py
@@ -10,10 +10,10 @@ from asyncio import (
 from concurrent.futures import ProcessPoolExecutor
 from logging import getLogger
 from types import GeneratorType
-from typing import Any, Awaitable, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from aioitertools import enumerate
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from maggma.utils import primed
 
@@ -87,7 +87,9 @@ class AsyncUnorderedMap:
     async def get_from_iterator(self):
         loop = get_event_loop()
         async for idx, item in enumerate(self.iterator):
-            future = loop.run_in_executor(self.executor, safe_dispatch, (self.func, item))
+            future = loop.run_in_executor(
+                self.executor, safe_dispatch, (self.func, item)
+            )
 
             self.tasks[idx] = future
 

--- a/src/maggma/cli/serial.py
+++ b/src/maggma/cli/serial.py
@@ -4,7 +4,7 @@
 import logging
 from types import GeneratorType
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from maggma.core import Builder
 from maggma.utils import grouper, primed

--- a/src/maggma/utils.py
+++ b/src/maggma/utils.py
@@ -18,7 +18,7 @@ from pydash.utilities import to_path
 from pymongo.collection import Collection
 
 # import tqdm Jupyter widget if running inside Jupyter
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 
 def primed(iterable: Iterable) -> Iterable:


### PR DESCRIPTION
Use `tqdm.auto` to automatically detect whether you are in a notebook and avoid warnings on tqdm imports.