### PR TITLE
Fixing bug in azure multi worker test

### DIFF
--- a/tests/stores/test_azure.py
+++ b/tests/stores/test_azure.py
@@ -160,8 +160,8 @@ def test_multi_update(blobstore_two_docs, blobstore_multi):
         search_doc = {k: doc[k] for k in search_keys}
         return search_doc
 
-    blobstore_two_docs.write_doc_to_s3 = fake_writing
-    blobstore_multi.write_doc_to_s3 = fake_writing
+    blobstore_two_docs.write_doc_to_blob = fake_writing
+    blobstore_multi.write_doc_to_blob = fake_writing
 
     start = time.time()
     blobstore_multi.update(data, key=["task_id"])


### PR DESCRIPTION
Following #807 I have realized that there was a bug in the referred test (a leftover of importing the tests from those of the `S3Store`). Hopefully this quick fix may already solve the issue. I cannot verify locally, since I have tried to run the test on my laptop with a python 3.11 environment and it always passed, even with the bugged version. 

If this will not be enough I will try to devise a different kind of check.
