### PR TITLE
Fixe ruamel.yaml dependency 

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,4 +3,3 @@ mkdocs-material==8.3.9
 mkdocs-minify-plugin==0.5.0
 mkdocstrings==0.18.1
 jinja2<3.2.0
-ruamel-yaml<18.0

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "setuptools",
+        "ruamel.yaml",
         "pydantic<=1.10.11",
         "pydantic>=0.32.2",
         "pymongo>=4.2.0",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "setuptools",
-        "ruamel.yaml",
+        "ruamel.yaml<0.18",
         "pydantic<=1.10.11",
         "pydantic>=0.32.2",
         "pymongo>=4.2.0",


### PR DESCRIPTION
Currently fresh installs of `jobflow` and `maggma` are not working since ruamel yaml is missing from the setup.py file