### PR TITLE
FileStore performance enhancements

### DIFF
--- a/src/maggma/stores/file_store.py
+++ b/src/maggma/stores/file_store.py
@@ -241,7 +241,7 @@ class FileStore(MemoryStore):
         digest2.update(self.name.encode())
         with open(f.as_posix(), "rb", buffering=0) as file:
             try:
-                digest2.update(hashlib.file_digest(f, "md5"))  # python >= 3.11
+                digest2.update(hashlib.file_digest(file, "md5"))  # python >= 3.11
             except AttributeError:
                 for n in iter(lambda: file.readinto(mv), 0):
                     digest2.update(mv[:n])

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -467,9 +467,7 @@ class MongoStore(Store):
         if not isinstance(docs, list):
             docs = [docs]
 
-        for d in docs:
-            d = jsanitize(d, allow_bson=True)
-
+        for d in map(lambda x: jsanitize(x, allow_bson=True), docs):
             # document-level validation is optional
             validates = True
             if self.validator:

--- a/tests/stores/test_file_store.py
+++ b/tests/stores/test_file_store.py
@@ -267,7 +267,7 @@ def test_query(test_dir):
         properties=["name", "contents"],
         contents_size_limit=50,
     )
-    assert d["contents"] == "Unable to read: file too large"
+    assert d["contents"] == "File exceeds size limit of 50 bytes"
     assert d.get("name")
 
 


### PR DESCRIPTION
The performance of `FileStore.connect()` can be quite slow, especially with large numbers of files (more than a few hundred). This PR seeks to address some performance bottlenecks.

Using profiling, I determined that on systems with **slow storage** (in my case, a 5400 HDD), the bottleneck in the `connect` method is related to iterating and hashing files. On the other hand, in systems with **fast storage** (my test system was the SSD on a Macbook), the bottleneck occurs in inserting the documents into the internal `MemoryStore` and comes from `mongomock`.

In this PR, I reworked the hashing algorithms to be more efficient, resulting in a ~30% speedup on my 400 file test on **slow storage** systems. I did not do anything to speed up `mongomock`, and hence there is no benefit for **fast storage** systems, but I may explore that in a different PR.

### Notable changes:
- use `os.walk` instead of `Path.iterdir` for directory iteration
- use the new, efficient [`file_digest` method](https://github.com/python/cpython/blob/0ba07b2108d4763273f3fb85544dde34c5acd40a/Lib/hashlib.py#L213) (python>=3.11) for inspiration as to how to make the hashing faster
- change default `contents_size_limit` to 0 (meaning no file contents are returned) in `query`. This has no effect on `connect` speed but substantially improves `query` speed.


### Benchmarking the current state of `FileStore.connect()`

Note that `store.py` refers to [this file](https://github.com/mongomock/mongomock/blob/develop/mongomock/store.py) in `mongomock`
Note that `collection.py` refers to [this file](https://github.com/mongomock/mongomock/blob/develop/mongomock/collection.py) in `mongomock`
Note that `filtering.py` refers to [this file](https://github.com/mongomock/mongomock/blob/develop/mongomock/filtering.py) in `mongomock`

**~400 files on a 5400 rpm HDD / Windows**

```
3632275 function calls (3591986 primitive calls) in 17.807 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1163    7.660    0.007    7.665    0.007 {built-in method posix.stat}
      784    3.724    0.005    3.729    0.005 {built-in method posix.scandir}
      389    2.120    0.005    2.120    0.005 {built-in method io.open}
 1176/393    1.245    0.001    3.116    0.008 pathlib.py:586(_iterate_directories)
      779    1.234    0.002    3.108    0.004 pathlib.py:556(_select_from)
      389    0.822    0.002    0.822    0.002 {method '__exit__' of '_io._IOBase' objects}
   129670    0.184    0.000    0.395    0.000 filtering.py:78(apply)
  1367515    0.093    0.000    0.094    0.000 {built-in method builtins.isinstance}
      387    0.087    0.000    0.087    0.000 {method 'read' of '_io.BufferedReader' objects}
   129481    0.081    0.000    0.127    0.000 filtering.py:207(iter_key_candidates)
      580    0.057    0.000    0.057    0.000 collection.py:981(_expand_dots)
   167022    0.051    0.000    0.116    0.000 store.py:130(documents)
```

**~4000 files on a Macbook SSD**


```
204368376 function calls (204169823 primitive calls) in 61.781 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  9037689   18.300    0.000   41.360    0.000 filtering.py:78(apply)
 82432461    8.181    0.000    8.192    0.000 {built-in method builtins.isinstance}
  9037500    7.791    0.000   14.235    0.000 filtering.py:207(iter_key_candidates)
  9441875    5.784    0.000   10.625    0.000 store.py:130(documents)
 18883368    3.372    0.000    4.772    0.000 objectid.py:284(__hash__)
  9037689    3.362    0.000   44.722    0.000 filtering.py:46(filter_applies)
  9251506    2.439    0.000    2.439    0.000 {method 'get' of 'dict' objects}
     9068    1.835    0.000   46.556    0.005 collection.py:1275(<genexpr>)
  9082452    1.540    0.000    1.540    0.000 {method 'startswith' of 'str' objects}
  9053558    1.514    0.000    1.514    0.000 {method 'split' of 'str' objects}
 18887915    1.402    0.000    1.402    0.000 {built-in method builtins.hash}
     4155    0.952    0.000    0.952    0.000 {method 'read' of '_io.BufferedReader' objects}
```

### Benchmarking `FileStore.connect()` with changes in this PR

**~400 files on a 5400 rpm HDD / Windows**
```
       3646059 function calls (3605789 primitive calls) in 13.827 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      775    4.762    0.006    4.766    0.006 {built-in method posix.stat}
      391    2.008    0.005    2.008    0.005 {built-in method posix.lstat}
      389    1.977    0.005    1.977    0.005 {built-in method io.open}
      392    1.700    0.004    1.700    0.004 {built-in method posix.scandir}
     8977    1.127    0.000    1.137    0.000 {built-in method builtins.next}
      389    0.771    0.002    0.771    0.002 {method '__exit__' of '_io._IOBase' objects}
      921    0.462    0.001    0.462    0.001 {method 'readinto' of '_io.FileIO' objects}
   129670    0.186    0.000    0.399    0.000 filtering.py:78(apply)
  1368613    0.094    0.000    0.096    0.000 {built-in method builtins.isinstance}
   129481    0.081    0.000    0.128    0.000 filtering.py:207(iter_key_candidates)
     1308    0.076    0.000    0.076    0.000 {method 'update' of '_hashlib.HASH' objects}
      580    0.062    0.000    0.062    0.000 collection.py:981(_expand_dots)
   167022    0.052    0.000    0.117    0.000 store.py:130(documents)
```

**~4000 files on a Macbook SSD**
```
         204479184 function calls (204280642 primitive calls) in 59.599 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  9037689   17.555    0.000   39.460    0.000 filtering.py:78(apply)
 82441146    8.011    0.000    8.022    0.000 {built-in method builtins.isinstance}
  9037500    7.591    0.000   13.311    0.000 filtering.py:207(iter_key_candidates)
  9441875    5.551    0.000   10.317    0.000 store.py:130(documents)
 18883368    3.345    0.000    4.700    0.000 objectid.py:284(__hash__)
  9037689    3.198    0.000   42.658    0.000 filtering.py:46(filter_applies)
     9068    1.821    0.000   44.479    0.005 collection.py:1275(<genexpr>)
  9251504    1.816    0.000    1.816    0.000 {method 'get' of 'dict' objects}
  9086999    1.507    0.000    1.507    0.000 {method 'startswith' of 'str' objects}
  9057714    1.488    0.000    1.488    0.000 {method 'split' of 'str' objects}
 18883368    1.354    0.000    1.354    0.000 {built-in method builtins.hash}
     8459    1.161    0.000    1.161    0.000 {method 'readinto' of '_io.FileIO' objects}
```