### PR TITLE
Some cleanup: `isort`, updated classifiers, remove unused kwarg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,10 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Science/Research",
         "Intended Audience :: System Administrators",

--- a/src/maggma/api/resource/__init__.py
+++ b/src/maggma/api/resource/__init__.py
@@ -8,8 +8,8 @@ from maggma.api.resource.core import HeaderProcessor
 from maggma.api.resource.aggregation import AggregationResource
 from maggma.api.resource.post_resource import PostOnlyResource
 from maggma.api.resource.read_resource import ReadOnlyResource, attach_query_ops
-from maggma.api.resource.submission import SubmissionResource
 from maggma.api.resource.s3_url import S3URLResource
+from maggma.api.resource.submission import SubmissionResource
 
 __all__ = [
     "Resource",

--- a/src/maggma/api/resource/aggregation.py
+++ b/src/maggma/api/resource/aggregation.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Type
 
-from fastapi import HTTPException, Response, Request
+from fastapi import HTTPException, Request, Response
 from pydantic import BaseModel
 from pymongo import timeout as query_timeout
 from pymongo.errors import NetworkTimeout, PyMongoError
@@ -8,7 +8,7 @@ from pymongo.errors import NetworkTimeout, PyMongoError
 from maggma.api.models import Meta
 from maggma.api.models import Response as ResponseModel
 from maggma.api.query_operator import QueryOperator
-from maggma.api.resource import Resource, HeaderProcessor
+from maggma.api.resource import HeaderProcessor, Resource
 from maggma.api.resource.utils import attach_query_ops
 from maggma.api.utils import STORE_PARAMS, merge_queries
 from maggma.core import Store

--- a/src/maggma/api/resource/core.py
+++ b/src/maggma/api/resource/core.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from typing import Dict, Type
 
-from fastapi import APIRouter, FastAPI, Response, Request
+from fastapi import APIRouter, FastAPI, Request, Response
 from monty.json import MontyDecoder, MSONable
 from pydantic import BaseModel
 from starlette.responses import RedirectResponse

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -1,8 +1,8 @@
 from inspect import signature
 from typing import Any, Dict, List, Optional, Type, Union
 
-from fastapi import Depends, HTTPException, Path, Request
-from fastapi import Response
+import orjson
+from fastapi import Depends, HTTPException, Path, Request, Response
 from pydantic import BaseModel
 from pymongo import timeout as query_timeout
 from pymongo.errors import NetworkTimeout, PyMongoError
@@ -10,13 +10,11 @@ from pymongo.errors import NetworkTimeout, PyMongoError
 from maggma.api.models import Meta
 from maggma.api.models import Response as ResponseModel
 from maggma.api.query_operator import PaginationQuery, QueryOperator, SparseFieldsQuery
-from maggma.api.resource import Resource, HintScheme, HeaderProcessor
+from maggma.api.resource import HeaderProcessor, HintScheme, Resource
 from maggma.api.resource.utils import attach_query_ops, generate_query_pipeline
 from maggma.api.utils import STORE_PARAMS, merge_queries, serialization_helper
 from maggma.core import Store
 from maggma.stores import MongoStore, S3Store
-
-import orjson
 
 
 class ReadOnlyResource(Resource):

--- a/src/maggma/api/resource/s3_url.py
+++ b/src/maggma/api/resource/s3_url.py
@@ -1,17 +1,15 @@
 from datetime import datetime, timedelta
 from typing import List, Optional
-from botocore.exceptions import ClientError
-
-from fastapi import HTTPException, Path, Request
-from fastapi import Response
-
-from maggma.api.models import S3URLDoc
-from maggma.api.models import Response as ResponseModel
-from maggma.api.resource import Resource, HeaderProcessor
-from maggma.api.utils import serialization_helper
-from maggma.stores.aws import S3Store
 
 import orjson
+from botocore.exceptions import ClientError
+from fastapi import HTTPException, Path, Request, Response
+
+from maggma.api.models import Response as ResponseModel
+from maggma.api.models import S3URLDoc
+from maggma.api.resource import HeaderProcessor, Resource
+from maggma.api.utils import serialization_helper
+from maggma.stores.aws import S3Store
 
 
 class S3URLResource(Resource):

--- a/src/maggma/api/utils.py
+++ b/src/maggma/api/utils.py
@@ -1,9 +1,9 @@
+import base64
 import inspect
 import sys
 from typing import Any, Callable, Dict, List, Optional, Type
-from bson.objectid import ObjectId
-import base64
 
+from bson.objectid import ObjectId
 from monty.json import MSONable
 from pydantic import BaseModel
 from pydantic.schema import get_flat_models_from_model

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -5,8 +5,8 @@
 import asyncio
 import logging
 import sys
-from itertools import chain
 from datetime import datetime
+from itertools import chain
 
 import click
 from monty.serialization import loadfn
@@ -14,10 +14,9 @@ from monty.serialization import loadfn
 from maggma.cli.distributed import find_port
 from maggma.cli.multiprocessing import multi
 from maggma.cli.serial import serial
-from maggma.cli.source_loader import ScriptFinder, load_builder_from_source
 from maggma.cli.settings import CLISettings
+from maggma.cli.source_loader import ScriptFinder, load_builder_from_source
 from maggma.utils import ReportingHandler, TqdmLoggingHandler
-
 
 sys.meta_path.append(ScriptFinder())
 
@@ -130,7 +129,7 @@ def run(
 ):
     # Import profiler and setup directories to dump profiler output
     if memray:
-        from memray import Tracker, FileDestination
+        from memray import FileDestination, Tracker
 
         if memray_dir:
             import os

--- a/src/maggma/cli/distributed.py
+++ b/src/maggma/cli/distributed.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 # coding utf-8
 
-import json
-from logging import getLogger
-import socket as pysocket
-from typing import List
-import numpy as np
-from time import perf_counter
 import asyncio
+import json
+import socket as pysocket
+from logging import getLogger
 from random import randint
+from time import perf_counter
+from typing import List
 
+import numpy as np
+import zmq
 from monty.json import jsanitize
 from monty.serialization import MontyDecoder
 
@@ -17,8 +18,6 @@ from maggma.cli.multiprocessing import multi
 from maggma.cli.settings import CLISettings
 from maggma.core import Builder
 from maggma.utils import tqdm
-
-import zmq
 
 settings = CLISettings()
 

--- a/src/maggma/cli/multiprocessing.py
+++ b/src/maggma/cli/multiprocessing.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python
 # coding utf-8
 
-from asyncio import (
-    BoundedSemaphore,
-    Queue,
-    gather,
-    get_event_loop,
-)
+from asyncio import BoundedSemaphore, Queue, gather, get_event_loop
 from concurrent.futures import ProcessPoolExecutor
 from logging import getLogger
 from types import GeneratorType

--- a/src/maggma/cli/rabbitmq.py
+++ b/src/maggma/cli/rabbitmq.py
@@ -3,20 +3,20 @@
 
 import asyncio
 import json
-from logging import getLogger
 import socket as pysocket
-from typing import List, Literal
-import numpy as np
-from time import perf_counter
+from logging import getLogger
 from random import randint
+from time import perf_counter
+from typing import List, Literal
 
+import numpy as np
 from monty.json import jsanitize
 from monty.serialization import MontyDecoder
 
 from maggma.cli.multiprocessing import multi
 from maggma.cli.settings import CLISettings
 from maggma.core import Builder
-from maggma.utils import tqdm, Timeout
+from maggma.utils import Timeout, tqdm
 
 try:
     import pika

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -8,8 +8,8 @@ import zlib
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
 from hashlib import sha1
-from typing import Dict, Iterator, List, Optional, Tuple, Union
 from json import dumps
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import msgpack  # type: ignore
 from monty.msgpack import default as monty_default

--- a/src/maggma/stores/azure.py
+++ b/src/maggma/stores/azure.py
@@ -2,15 +2,15 @@
 """
 Advanced Stores for connecting to Microsoft Azure data
 """
+import os
 import threading
 import warnings
 import zlib
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
 from hashlib import sha1
-from typing import Dict, Iterator, List, Optional, Tuple, Union
 from json import dumps
-import os
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import msgpack  # type: ignore
 from monty.msgpack import default as monty_default
@@ -19,11 +19,11 @@ from maggma.core import Sort, Store
 from maggma.utils import grouper, to_isoformat_ceil_ms
 
 try:
-    import azure.storage.blob as azure_blob
-    from azure.storage.blob import BlobServiceClient, ContainerClient
-    from azure.identity import DefaultAzureCredential
-    from azure.core.exceptions import ResourceExistsError
     import azure
+    import azure.storage.blob as azure_blob
+    from azure.core.exceptions import ResourceExistsError
+    from azure.identity import DefaultAzureCredential
+    from azure.storage.blob import BlobServiceClient, ContainerClient
 except (ImportError, ModuleNotFoundError):
     azure_blob = None  # type: ignore
     ContainerClient = None

--- a/src/maggma/stores/file_store.py
+++ b/src/maggma/stores/file_store.py
@@ -4,20 +4,20 @@ Module defining a FileStore that enables accessing files in a local directory
 using typical maggma access patterns.
 """
 
+import fnmatch
 import hashlib
 import os
-import fnmatch
 import re
-
 import warnings
-from pathlib import Path
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Union, Iterator, Callable
+from pathlib import Path
+from typing import Callable, Dict, Iterator, List, Optional, Union
 
-from pymongo import UpdateOne
 from monty.io import zopen
-from maggma.core import StoreError, Sort
-from maggma.stores.mongolike import MemoryStore, JSONStore
+from pymongo import UpdateOne
+
+from maggma.core import Sort, StoreError
+from maggma.stores.mongolike import JSONStore, MemoryStore
 
 # These keys are automatically populated by the FileStore.read() method and
 # hence are not allowed to be manually overwritten
@@ -264,7 +264,7 @@ class FileStore(MemoryStore):
             self.key: file_id,
         }
 
-    def connect(self, force_reset: bool = False):
+    def connect(self):
         """
         Connect to the source data
 
@@ -273,9 +273,6 @@ class FileStore(MemoryStore):
 
         If there is a metadata .json file in the directory, read its
         contents into the MemoryStore
-
-        Args:
-            force_reset: whether to reset the connection or not
         """
         # read all files and place them in the MemoryStore
         # use super.update to bypass the read_only guard statement

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -8,15 +8,15 @@ various utilities
 import copy
 import json
 import zlib
-from ruamel import yaml
 from datetime import datetime
-from pymongo.errors import ConfigurationError
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import gridfs
 from monty.json import jsanitize
 from pydash import get, has
 from pymongo import MongoClient, uri_parser
+from pymongo.errors import ConfigurationError
+from ruamel import yaml
 
 from maggma.core import Sort, Store, StoreError
 from maggma.stores.mongolike import MongoStore, SSHTunnel

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -5,23 +5,24 @@ Stores are a default access pattern to data and provide
 various utilities
 """
 
-from pathlib import Path
-from ruamel import yaml
-from itertools import chain, groupby
-from socket import socket
 import warnings
+from itertools import chain, groupby
+from pathlib import Path
+from socket import socket
+
+from ruamel import yaml
 
 try:
     from typing import (
+        Any,
+        Callable,
         Dict,
         Iterator,
         List,
+        Literal,
         Optional,
         Tuple,
         Union,
-        Any,
-        Callable,
-        Literal,
     )
 except ImportError:
     from typing import Dict, Iterator, List, Optional, Tuple, Union, Any, Callable

--- a/src/maggma/stores/shared_stores.py
+++ b/src/maggma/stores/shared_stores.py
@@ -1,9 +1,11 @@
-from monty.json import MontyDecoder
-from threading import Lock
-from maggma.core.store import Store, Sort
-from typing import Dict, Iterator, List, Optional, Tuple, Union, Callable, Any
 from functools import partial
 from multiprocessing.managers import BaseManager
+from threading import Lock
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+
+from monty.json import MontyDecoder
+
+from maggma.core.store import Sort, Store
 
 
 class StoreFacade(Store):

--- a/src/maggma/utils.py
+++ b/src/maggma/utils.py
@@ -7,11 +7,11 @@ import logging
 import signal
 import uuid
 from datetime import datetime, timedelta
-from dateutil import parser
 from importlib import import_module
 from typing import Dict, Iterable, Optional, Union
 
 from bson.json_util import ObjectId
+from dateutil import parser
 from pydash.objects import get, has, set_
 from pydash.objects import unset as _unset
 from pydash.utilities import to_path

--- a/tests/api/test_aggregation_resource.py
+++ b/tests/api/test_aggregation_resource.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from random import randint
 
 import pytest
@@ -5,11 +6,8 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 from starlette.testclient import TestClient
 
-from datetime import datetime
 from maggma.api.query_operator.core import QueryOperator
-
 from maggma.api.resource import AggregationResource
-
 from maggma.stores import MemoryStore
 
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from random import choice, randint
+from typing import Any, Tuple
 from urllib.parse import urlencode
-from typing import Tuple, Any
 
 import pytest
 from fastapi.encoders import jsonable_encoder
@@ -11,10 +11,10 @@ from starlette.testclient import TestClient
 
 from maggma.api.API import API
 from maggma.api.query_operator import (
-    StringQueryOperator,
     NumericQuery,
-    SparseFieldsQuery,
     PaginationQuery,
+    SparseFieldsQuery,
+    StringQueryOperator,
 )
 from maggma.api.resource import ReadOnlyResource
 from maggma.stores import MemoryStore

--- a/tests/api/test_post_resource.py
+++ b/tests/api/test_post_resource.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from random import randint
 
 import pytest
@@ -5,10 +6,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 from starlette.testclient import TestClient
 
-from datetime import datetime
-
 from maggma.api.resource import PostOnlyResource
-
 from maggma.stores import MemoryStore
 
 

--- a/tests/api/test_query_operators.py
+++ b/tests/api/test_query_operators.py
@@ -1,19 +1,18 @@
-import pytest
+from datetime import datetime
 from enum import Enum
+
+import pytest
+from fastapi import HTTPException
+from monty.serialization import dumpfn, loadfn
+from monty.tempfile import ScratchDir
+from pydantic import BaseModel, Field
+
 from maggma.api.query_operator import (
     NumericQuery,
     PaginationQuery,
-    SparseFieldsQuery,
     SortQuery,
+    SparseFieldsQuery,
 )
-
-from pydantic import BaseModel, Field
-from fastapi import HTTPException
-from datetime import datetime
-
-from monty.serialization import loadfn, dumpfn
-from monty.tempfile import ScratchDir
-
 from maggma.api.query_operator.submission import SubmissionQuery
 
 

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -1,3 +1,4 @@
+import inspect
 from datetime import datetime
 from random import randint
 from urllib.parse import urlencode
@@ -14,11 +15,8 @@ from maggma.api.query_operator import (
     StringQueryOperator,
 )
 from maggma.api.resource import ReadOnlyResource
-from maggma.stores import MemoryStore, AliasingStore
-
-import inspect
-
 from maggma.api.resource.core import HintScheme
+from maggma.stores import AliasingStore, MemoryStore
 
 
 class Owner(BaseModel):

--- a/tests/api/test_s3_url_resource.py
+++ b/tests/api/test_s3_url_resource.py
@@ -1,6 +1,7 @@
 import pytest
-from maggma.stores import MemoryStore
+
 from maggma.api.resource import S3URLResource
+from maggma.stores import MemoryStore
 
 
 @pytest.fixture

--- a/tests/api/test_submission_resource.py
+++ b/tests/api/test_submission_resource.py
@@ -1,16 +1,15 @@
-from random import randint
 import json
+from datetime import datetime
+from random import randint
+
 import pytest
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
 from starlette.testclient import TestClient
 
-from datetime import datetime
-from maggma.api.query_operator.core import QueryOperator
-
-from maggma.api.resource import SubmissionResource
 from maggma.api.query_operator import PaginationQuery
-
+from maggma.api.query_operator.core import QueryOperator
+from maggma.api.resource import SubmissionResource
 from maggma.stores import MemoryStore
 
 

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,14 +1,13 @@
 from datetime import datetime
 from enum import Enum
+from typing import Union
 
 import pytest
+from bson import ObjectId
 from monty.json import MSONable
 from pydantic import BaseModel, Field
 
 from maggma.api.utils import api_sanitize, serialization_helper
-from typing import Union
-
-from bson import ObjectId
 
 
 class SomeEnum(Enum):

--- a/tests/cli/test_distributed.py
+++ b/tests/cli/test_distributed.py
@@ -1,15 +1,14 @@
 import asyncio
 import json
+import socket as pysocket
 import threading
 
 import pytest
+import zmq.asyncio as zmq
+from zmq import REP, REQ
 
 from maggma.cli.distributed import find_port, manager, worker
 from maggma.core import Builder
-
-from zmq import REP, REQ
-import zmq.asyncio as zmq
-import socket as pysocket
 
 # TODO: Timeout errors?
 

--- a/tests/stores/test_azure.py
+++ b/tests/stores/test_azure.py
@@ -7,11 +7,12 @@ docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite azurite-blob -
 """
 
 import time
-from datetime import datetime
 from contextlib import contextmanager
+from datetime import datetime
+
 import pytest
 
-from maggma.stores import MemoryStore, MongoStore, AzureBlobStore
+from maggma.stores import AzureBlobStore, MemoryStore, MongoStore
 
 try:
     import azure.storage.blob as azure_blob

--- a/tests/stores/test_file_store.py
+++ b/tests/stores/test_file_store.py
@@ -19,11 +19,12 @@ Desired behavior
   remain intact.
 """
 
+import hashlib
 from datetime import datetime, timezone
 from distutils.dir_util import copy_tree
 from pathlib import Path
+
 import pytest
-import hashlib
 
 from maggma.core import StoreError
 from maggma.stores.file_store import FileStore

--- a/tests/stores/test_gridfs.py
+++ b/tests/stores/test_gridfs.py
@@ -1,16 +1,15 @@
-import os
-
 import json
+import os
 from datetime import datetime
 
 import numpy as np
 import numpy.testing.utils as nptu
 import pytest
-from maggma.core import StoreError
-
-from maggma.stores import GridFSStore, MongoStore
-from maggma.stores.gridfs import files_collection_fields, GridFSURIStore
 from pymongo.errors import ConfigurationError
+
+from maggma.core import StoreError
+from maggma.stores import GridFSStore, MongoStore
+from maggma.stores.gridfs import GridFSURIStore, files_collection_fields
 
 
 @pytest.fixture

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -1,14 +1,14 @@
-import orjson
 import os
 import shutil
 from datetime import datetime
-from unittest import mock
 from pathlib import Path
+from unittest import mock
 
 import mongomock.collection
-from monty.tempfile import ScratchDir
+import orjson
 import pymongo.collection
 import pytest
+from monty.tempfile import ScratchDir
 from pymongo.errors import ConfigurationError, DocumentTooLarge, OperationFailure
 
 from maggma.core import StoreError

--- a/tests/stores/test_shared_stores.py
+++ b/tests/stores/test_shared_stores.py
@@ -1,8 +1,8 @@
+import pymongo
 import pytest
 from pymongo.errors import DocumentTooLarge, OperationFailure
-import pymongo
 
-from maggma.stores import GridFSStore, MongoStore, MemoryStore
+from maggma.stores import GridFSStore, MemoryStore, MongoStore
 from maggma.stores.shared_stores import MultiStore, StoreFacade
 from maggma.validators import JSONSchemaValidator
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ from time import sleep
 
 import pytest
 
+from maggma.utils import Timeout  # dt_to_isoformat_ceil_ms,; isostr_to_dt,
 from maggma.utils import (
     dynamic_import,
     grouper,
@@ -15,8 +16,6 @@ from maggma.utils import (
     to_dt,
     to_isoformat_ceil_ms,
 )
-
-from maggma.utils import Timeout  # dt_to_isoformat_ceil_ms,; isostr_to_dt,
 
 
 def test_recursiveupdate():


### PR DESCRIPTION
This PR accomplishes three and only three things:

1. I applied `isort .` on the repo.
2. I updated the Python classifiers in `setup.py` to include 3.7 through 3.11 instead of just 3.7.
3. I removed an unused kwarg from `maggma.stores.file_store.FileStore.connect()`.