### PR TITLE
Allow maggma to be used without Azure

### DIFF
--- a/src/maggma/stores/azure.py
+++ b/src/maggma/stores/azure.py
@@ -25,7 +25,7 @@ try:
     from azure.storage.blob import BlobServiceClient, ContainerClient
 except (ImportError, ModuleNotFoundError):
     azure_blob = None  # type: ignore
-    # ContainerClient = None
+    ContainerClient = None
 
 
 AZURE_KEY_SANITIZE = {"-": "_", ".": "_"}


### PR DESCRIPTION
Currently, 0.52.0 raises an error

```
../../../local/Caskroom/miniconda/base/envs/mp/lib/python3.9/site-packages/maggma/stores/azure.py:368: in AzureBlobStore
    def _get_container(self) -> Optional[ContainerClient]:
E   NameError: name 'ContainerClient' is not defined
```