### PR TITLE
JSONStore: enabled reading of MongoDB extended JSON files

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -18,6 +18,7 @@ except ImportError:
 
     from typing_extensions import Literal
 
+import bson
 import mongomock
 import orjson
 from monty.dev import requires
@@ -767,7 +768,7 @@ class JSONStore(MemoryStore):
         with zopen(path) as f:
             data = f.read()
             data = data.decode() if isinstance(data, bytes) else data
-            objects = orjson.loads(data)
+            objects = bson.json_util.loads(data) if "$oid" in data else orjson.loads(data)
             objects = [objects] if not isinstance(objects, list) else objects
             # datetime objects deserialize to str. Try to convert the last_updated
             # field back to datetime.

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -8,6 +8,7 @@ import mongomock.collection
 import orjson
 import pymongo.collection
 import pytest
+from bson.objectid import ObjectId
 from maggma.core import StoreError
 from maggma.stores import JSONStore, MemoryStore, MongoStore, MongoURIStore, MontyStore
 from maggma.validators import JSONSchemaValidator
@@ -423,6 +424,12 @@ def test_json_store_load(jsonstore, test_dir):
     with pytest.warns(DeprecationWarning, match="file_writable is deprecated"):
         jsonstore = JSONStore("a.json", file_writable=False)
         assert jsonstore.read_only is True
+
+    # test loading an extended JSON file exported from MongoDB
+    js2 = JSONStore(test_dir / "test_set" / "extended_json.json")
+    js2.connect()
+    assert js2.count() == 1
+    assert js2.query_one()["_id"] == ObjectId("64ebee18bd0b1265fe418be2")
 
 
 def test_json_store_writeable(test_dir):

--- a/tests/test_files/test_set/extended_json.json
+++ b/tests/test_files/test_set/extended_json.json
@@ -1,0 +1,7 @@
+[{
+  "_id": {
+    "$oid": "64ebee18bd0b1265fe418be2"
+  },
+  "hello": "world",
+  "task_id": "1"
+}]


### PR DESCRIPTION
## Summary

When exporting a MongoDB collection to JSON, the resulting format is [extended JSON](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/#bson.ObjectId). Trying to load such a JSON file into `JSONStore` currently fails due to the way extended JSON serializes `ObjectID`, with an error similar to

```
bson.errors.InvalidDocument: key '$oid' must not start with '$'
```

This PR modifies `JSONStore.read_json` to use the [`bson.json_util.loads`](https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html#bson.json_util.loads) method if `$oid` is detected in the file, which allows loading extended JSON files into a `JSONStore`. If `$oid` is not there, the current `orjson.loads()` is used instead.

Unfortunately. `orjson.loads` does not support BSON types. This was [requested before](https://github.com/ijl/orjson/issues/70), although it isn't clear if the maintainer understood the request.

Happy to hear opinions if there are better ways to accomplish this, e.g. by leveraging `serialization_helper`, `MontyDecoder`, etc. and/or opening another `orjson` issue with a more specific request about how to handle these types.
