### PR TITLE
Update CI pipeline so repeated commits don't cause concurrent tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "11 19 * * 6"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ ignore = [
 ]
 pydocstyle.convention = "google"
 isort.split-on-trailing-comma = false
+src = ["src"]
+
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
         "Intended Audience :: System Administrators",
         "Intended Audience :: Information Technology",


### PR DESCRIPTION
I updated the CI pipeline such that if multiple commits have been made in relatively quick succession, the prior commit's in progress tests will be cancelled. Since the maggma tests take a fair bit of time, this is a nice convenience feature in my opinion.

I also updated the classifier for the production status to "Development Status :: 5 - Production/Stable" and added a missing `src` line in the `ruff` spec for `pyproject.toml`.

Note: I first learned about this from `repo-review` and have been using it for all my projects. You might be interested in some of [the items flagged for maggma](https://scientific-python.github.io/repo-review/?repo=materialsproject%2Fmaggma&branch=main), although a fair number of them are quite subjective.