### PR TITLE
Remove tests for Python 3.7 since it reached its end-of-life

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,7 +47,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7","3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 # Maggma
 
-[![linting](https://github.com/materialsproject/maggma/workflows/linting/badge.svg)](https://github.com/materialsproject/maggma/actions?query=workflow%3Alinting) [![testing](https://github.com/materialsproject/maggma/workflows/testing/badge.svg)](https://github.com/materialsproject/maggma/actions?query=workflow%3Atesting) [![codecov](https://codecov.io/gh/materialsproject/maggma/branch/main/graph/badge.svg)](https://codecov.io/gh/materialsproject/maggma) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/materialsproject/maggma.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/materialsproject/maggma/context:python)
+[![testing](https://github.com/materialsproject/maggma/workflows/testing/badge.svg)](https://github.com/materialsproject/maggma/actions?query=workflow%3Atesting) [![codecov](https://codecov.io/gh/materialsproject/maggma/branch/main/graph/badge.svg)](https://codecov.io/gh/materialsproject/maggma)
 
 ## What is Maggma
 
 Maggma is a framework to build data pipelines from files on disk all the way to a REST API in scientific environments. Maggma has been developed by the Materials Project (MP) team at Lawrence Berkeley National Laboratory.
 
-Maggma is written in [Python](http://docs.python-guide.org/en/latest/) and supports Python 3.7+.
+Maggma is written in [Python](http://docs.python-guide.org/en/latest/) and supports Python 3.8+.
 
 ## Installation from PyPI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ version_scheme = "no-guess-dev"
 line-length = 120
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py38"
 line-length = 120
 select = [
   "B",    # flake8-bugbear

--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,5 @@ setup(
     ],
     entry_points={"console_scripts": ["mrun = maggma.cli:run"]},
     tests_require=["pytest"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Python 3.7 reached its [end-of-life](https://devguide.python.org/versions/) on 06-27-2023. As such, I removed it from the test matrix and from the classifiers list in `setup.py`. I didn't change the `python_requires` minimum version in `setup.py` though to allow for some flexibility for those that are slow to upgrade.