### PR TITLE
allow HEAD method for `/heartbeat`

### DIFF
--- a/src/maggma/api/API.py
+++ b/src/maggma/api/API.py
@@ -91,6 +91,7 @@ class API(MSONable):
         app.add_middleware(GZipMiddleware, minimum_size=1000)
 
         @app.get("/heartbeat", include_in_schema=False)
+        @app.head("/heartbeat", include_in_schema=False)
         def heartbeat():
             """API Heartbeat for Load Balancing"""
 


### PR DESCRIPTION
@munrojm it would good for cloudflare healthchecks to also allow the `/heartbeat` endpoint to be pinged with a HEAD request. I'm not sure whether adding another `@app.head()` is the right approach or we should instead use

```
@app.api_route("/heartbeat", methods=["GET", "HEAD", "OPTIONS"])
```