### PR TITLE
Store.connect: fix force_reset kwarg implementations

### DIFF
--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -66,26 +66,27 @@ class JointStore(Store):
 
     def connect(self, force_reset: bool = False):
         """
-        Connects the underlying Mongo database and
-        all collection connections
+        Connects the underlying Mongo database and all collection connections
 
         Args:
-            force_reset: whether to forcibly reset the connection
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
-        conn: MongoClient = (
-            MongoClient(
-                host=self.host,
-                port=self.port,
-                username=self.username,
-                password=self.password,
-                **self.mongoclient_kwargs,
+        if not self._coll or force_reset:
+            conn: MongoClient = (
+                MongoClient(
+                    host=self.host,
+                    port=self.port,
+                    username=self.username,
+                    password=self.password,
+                    **self.mongoclient_kwargs,
+                )
+                if self.username != ""
+                else MongoClient(self.host, self.port, **self.mongoclient_kwargs)
             )
-            if self.username != ""
-            else MongoClient(self.host, self.port, **self.mongoclient_kwargs)
-        )
-        db = conn[self.database]
-        self._coll = db[self.main]
-        self._has_merge_objects = self._collection.database.client.server_info()["version"] > "3.6"
+            db = conn[self.database]
+            self._coll = db[self.main]
+            self._has_merge_objects = self._collection.database.client.server_info()["version"] > "3.6"
 
     def close(self):
         """

--- a/src/maggma/stores/file_store.py
+++ b/src/maggma/stores/file_store.py
@@ -263,7 +263,7 @@ class FileStore(MemoryStore):
             self.key: file_id,
         }
 
-    def connect(self):
+    def connect(self, force_reset: bool = False):
         """
         Connect to the source data
 
@@ -272,16 +272,20 @@ class FileStore(MemoryStore):
 
         If there is a metadata .json file in the directory, read its
         contents into the MemoryStore
+
+        Args:
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
         # read all files and place them in the MemoryStore
         # use super.update to bypass the read_only guard statement
         # because we want the file data to be populated in memory
-        super().connect()
+        super().connect(force_reset=force_reset)
         super().update(self.read())
 
         # now read any metadata from the .json file
         try:
-            self.metadata_store.connect()
+            self.metadata_store.connect(force_reset=force_reset)
             metadata = list(self.metadata_store.query())
         except FileNotFoundError:
             metadata = []

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -132,14 +132,14 @@ class GridFSStore(Store):
             force_reset: whether to reset the connection or not when the Store is
                 already connected.
         """
-        if self.ssh_tunnel is None:
-            host = self.host
-            port = self.port
-        else:
-            self.ssh_tunnel.start()
-            host, port = self.ssh_tunnel.local_address
-
         if not self._coll or force_reset:
+            if self.ssh_tunnel is None:
+                host = self.host
+                port = self.port
+            else:
+                self.ssh_tunnel.start()
+                host, port = self.ssh_tunnel.local_address
+
             conn: MongoClient = (
                 MongoClient(
                     host=host,

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -127,6 +127,10 @@ class GridFSStore(Store):
     def connect(self, force_reset: bool = False):
         """
         Connect to the source data
+
+        Args:
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
         if self.ssh_tunnel is None:
             host = self.host
@@ -135,21 +139,20 @@ class GridFSStore(Store):
             self.ssh_tunnel.start()
             host, port = self.ssh_tunnel.local_address
 
-        conn: MongoClient = (
-            MongoClient(
-                host=host,
-                port=port,
-                username=self.username,
-                password=self.password,
-                authSource=self.auth_source,
-                **self.mongoclient_kwargs,
-            )
-            if self.username != ""
-            else MongoClient(host, port, **self.mongoclient_kwargs)
-        )
         if not self._coll or force_reset:
+            conn: MongoClient = (
+                MongoClient(
+                    host=host,
+                    port=port,
+                    username=self.username,
+                    password=self.password,
+                    authSource=self.auth_source,
+                    **self.mongoclient_kwargs,
+                )
+                if self.username != ""
+                else MongoClient(host, port, **self.mongoclient_kwargs)
+            )
             db = conn[self.database]
-
             self._coll = gridfs.GridFS(db, self.collection_name)
             self._files_collection = db[f"{self.collection_name}.files"]
             self._files_store = MongoStore.from_collection(self._files_collection)
@@ -483,6 +486,10 @@ class GridFSURIStore(GridFSStore):
     def connect(self, force_reset: bool = False):
         """
         Connect to the source data
+
+        Args:
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
         if not self._coll or force_reset:  # pragma: no cover
             conn: MongoClient = MongoClient(self.uri, **self.mongoclient_kwargs)

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -936,11 +936,11 @@ class MontyStore(MemoryStore):
             force_reset: whether to reset the connection or not
         """
         if not self._coll or force_reset:
-            self._coll = client[self.database_name][self.collection_name]
             # TODO - workaround, may be obviated by a future montydb update
             if self.database_path != ":memory:":
                 set_storage(self.database_path, storage=self.storage, **self.storage_kwargs)
             client = MontyClient(self.database_path, **self.client_kwargs)
+            self._coll = client[self.database_name][self.collection_name]
 
     @property
     def name(self) -> str:

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -176,16 +176,17 @@ class MongoStore(Store):
         Connect to the source data
 
         Args:
-            force_reset: whether to reset the connection or not
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
-        if self._coll is None or force_reset:
-            if self.ssh_tunnel is None:
-                host = self.host
-                port = self.port
-            else:
-                self.ssh_tunnel.start()
-                host, port = self.ssh_tunnel.local_address
+        if self.ssh_tunnel is None:
+            host = self.host
+            port = self.port
+        else:
+            self.ssh_tunnel.start()
+            host, port = self.ssh_tunnel.local_address
 
+        if self._coll is None or force_reset:
             conn: MongoClient = (
                 MongoClient(
                     host=host,
@@ -571,7 +572,8 @@ class MongoURIStore(MongoStore):
         Connect to the source data
 
         Args:
-            force_reset: whether to reset the connection or not
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
         if self._coll is None or force_reset:  # pragma: no cover
             conn: MongoClient = MongoClient(self.uri, **self.mongoclient_kwargs)
@@ -602,9 +604,9 @@ class MemoryStore(MongoStore):
         Connect to the source data
 
         Args:
-            force_reset: whether to reset the connection or not
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
-
         if self._coll is None or force_reset:
             self._coll = mongomock.MongoClient().db[self.name]  # type: ignore
 
@@ -933,7 +935,8 @@ class MontyStore(MemoryStore):
         Connect to the database store.
 
         Args:
-            force_reset: whether to reset the connection or not
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
         if not self._coll or force_reset:
             # TODO - workaround, may be obviated by a future montydb update

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -174,6 +174,9 @@ class MongoStore(Store):
     def connect(self, force_reset: bool = False):
         """
         Connect to the source data
+
+        Args:
+            force_reset: whether to reset the connection or not
         """
         if self._coll is None or force_reset:
             if self.ssh_tunnel is None:
@@ -566,6 +569,9 @@ class MongoURIStore(MongoStore):
     def connect(self, force_reset: bool = False):
         """
         Connect to the source data
+
+        Args:
+            force_reset: whether to reset the connection or not
         """
         if self._coll is None or force_reset:  # pragma: no cover
             conn: MongoClient = MongoClient(self.uri, **self.mongoclient_kwargs)
@@ -594,6 +600,9 @@ class MemoryStore(MongoStore):
     def connect(self, force_reset: bool = False):
         """
         Connect to the source data
+
+        Args:
+            force_reset: whether to reset the connection or not
         """
 
         if self._coll is None or force_reset:
@@ -731,32 +740,37 @@ class JSONStore(MemoryStore):
 
         super().__init__(**kwargs)
 
-    def connect(self, force_reset=False):
+    def connect(self, force_reset: bool =False):
         """
         Loads the files into the collection in memory
+
+        Args:
+            force_reset: whether to reset the connection or not. If False (default) and .connect() has been called previously, the .json file will not be read in again. This can improve performance
+            on systems with slow storage when multiple connect / disconnects are performed.
         """
-        super().connect(force_reset=force_reset)
+        if self._coll is None or force_reset:
+            self._coll = mongomock.MongoClient().db[self.name]  # type: ignore
 
-        # create the .json file if it does not exist
-        if not self.read_only and not Path(self.paths[0]).exists():
-            with zopen(self.paths[0], "w") as f:
-                data: List[dict] = []
-                bytesdata = orjson.dumps(data)
-                f.write(bytesdata.decode("utf-8"))
+            # create the .json file if it does not exist
+            if not self.read_only and not Path(self.paths[0]).exists():
+                with zopen(self.paths[0], "w") as f:
+                    data: List[dict] = []
+                    bytesdata = orjson.dumps(data)
+                    f.write(bytesdata.decode("utf-8"))
 
-        for path in self.paths:
-            objects = self.read_json_file(path)
-            try:
-                self.update(objects)
-            except KeyError:
-                raise KeyError(
-                    f"""
-                    Key field '{self.key}' not found in {path.name}. This
-                    could mean that this JSONStore was initially created with a different key field.
-                    The keys found in the .json file are {list(objects[0].keys())}. Try
-                    re-initializing your JSONStore using one of these as the key arguments.
-                    """
-                )
+            for path in self.paths:
+                objects = self.read_json_file(path)
+                try:
+                    self.update(objects)
+                except KeyError:
+                    raise KeyError(
+                        f"""
+                        Key field '{self.key}' not found in {path.name}. This
+                        could mean that this JSONStore was initially created with a different key field.
+                        The keys found in the .json file are {list(objects[0].keys())}. Try
+                        re-initializing your JSONStore using one of these as the key arguments.
+                        """
+                    )
 
     def read_json_file(self, path) -> List:
         """
@@ -919,14 +933,14 @@ class MontyStore(MemoryStore):
         Connect to the database store.
 
         Args:
-            force_reset: Force connection reset.
+            force_reset: whether to reset the connection or not
         """
-        # TODO - workaround, may be obviated by a future montydb update
-        if self.database_path != ":memory:":
-            set_storage(self.database_path, storage=self.storage, **self.storage_kwargs)
-        client = MontyClient(self.database_path, **self.client_kwargs)
         if not self._coll or force_reset:
             self._coll = client[self.database_name][self.collection_name]
+            # TODO - workaround, may be obviated by a future montydb update
+            if self.database_path != ":memory:":
+                set_storage(self.database_path, storage=self.storage, **self.storage_kwargs)
+            client = MontyClient(self.database_path, **self.client_kwargs)
 
     @property
     def name(self) -> str:

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -179,14 +179,14 @@ class MongoStore(Store):
             force_reset: whether to reset the connection or not when the Store is
                 already connected.
         """
-        if self.ssh_tunnel is None:
-            host = self.host
-            port = self.port
-        else:
-            self.ssh_tunnel.start()
-            host, port = self.ssh_tunnel.local_address
-
         if self._coll is None or force_reset:
+            if self.ssh_tunnel is None:
+                host = self.host
+                port = self.port
+            else:
+                self.ssh_tunnel.start()
+                host, port = self.ssh_tunnel.local_address
+
             conn: MongoClient = (
                 MongoClient(
                     host=host,

--- a/src/maggma/stores/shared_stores.py
+++ b/src/maggma/stores/shared_stores.py
@@ -76,7 +76,8 @@ class StoreFacade(Store):
         Connect to the source data
 
         Args:
-            force_reset: whether to reset the connection or not
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
         self.multistore.connect(self.store, force_reset=force_reset)
 
@@ -352,7 +353,8 @@ class MultiStore:
 
         Args:
             store: the store to connect to the source data
-            force_reset: whether to reset the connection or not
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
         with self._multistore_lock:
             store_id = self.get_store_index(store)
@@ -374,7 +376,8 @@ class MultiStore:
         Connects to all stores
 
         Args:
-            force_reset: whether to reset the connection or not
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
         """
         with self._multistore_lock:
             for store in self._stores:


### PR DESCRIPTION
## Summary

This PR increases the consistency of `force_reset` kwarg in `Store.connect()` across `Store` classes. It was motivated by an observation that on systems with slow storage, connecting to a `JSONStore` can take a long time. If one has already connected to the `Store`, a subsequent call to `connect` (with force_reset=False) should not cause the entire connection process to repeat.

This PR enforces the paradigm that we don't need to re-instantiate clients, reset ssh tunnels, or re-read data files if a store has already connected and force_reset=False.

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
