### PR TITLE
Ensure sort stage is after match in agg pipeline

### DIFF
--- a/src/maggma/api/resource/utils.py
+++ b/src/maggma/api/resource/utils.py
@@ -54,7 +54,6 @@ def generate_query_pipeline(query: dict, store: Store):
         projection_dict.update({p: 1 for p in query["properties"]})
 
     if sorting:
-        pipeline.append({"$project": {**projection_dict, store.key: 1}})
         pipeline.append(sort_dict)
 
     pipeline.append({"$project": projection_dict})


### PR DESCRIPTION
## Summary

Ensure the sort stage is before the project stage in the aggregation pipeline so that all MongoDB indexes are properly used.
