### PR TITLE
Enhancement/add s3 backed mongolike store

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [project]
 name = "maggma"
-dynamic = ["version", "readme", "scripts", "classifiers", "dependencies","optional-dependencies"]
+dynamic = ["version", "readme", "scripts", "classifiers", "dependencies","optional-dependencies", "license"]
 requires-python = ">=3.8"
-license = "LICENSE"
 description="Framework to develop datapipelines from files on disk to full dissemenation API"
 authors =[
     {name = "The Materials Project", email = "feedback@materialsproject.org"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "maggma"
-dynamic = ["version", "readme"]
+dynamic = ["version", "readme", "scripts", "classifiers", "dependencies","optional-dependencies"]
 requires-python = ">=3.8"
+license = "modified BSD"
 description="Framework to develop datapipelines from files on disk to full dissemenation API"
 authors =[
     {name = "The Materials Project", email = "feedback@materialsproject.org"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "maggma"
 dynamic = ["version", "readme", "scripts", "classifiers", "dependencies","optional-dependencies"]
 requires-python = ">=3.8"
-license = "modified BSD"
+license = "LICENSE"
 description="Framework to develop datapipelines from files on disk to full dissemenation API"
 authors =[
     {name = "The Materials Project", email = "feedback@materialsproject.org"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "maggma"
-dynamic = ["version", "readme", "requires-python", "license", "classifiers", "scripts", "dependencies", "optional-dependencies"]
+dynamic = ["version", "readme"]
+requires-python = >=3.8
 description="Framework to develop datapipelines from files on disk to full dissemenation API"
 authors =[
     {name = "The Materials Project", email = "feedback@materialsproject.org"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "maggma"
 dynamic = ["version", "readme"]
-requires-python = >=3.8
+requires-python = ">=3.8"
 description="Framework to develop datapipelines from files on disk to full dissemenation API"
 authors =[
     {name = "The Materials Project", email = "feedback@materialsproject.org"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maggma"
-dynamic = ["version", "readme"]
+dynamic = ["version", "readme", "requires-python", "license", "classifiers", "scripts", "dependencies", "optional-dependencies"]
 description="Framework to develop datapipelines from files on disk to full dissemenation API"
 authors =[
     {name = "The Materials Project", email = "feedback@materialsproject.org"}

--- a/requirements/macos-latest_py3.10.txt
+++ b/requirements/macos-latest_py3.10.txt
@@ -20,13 +20,13 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via maggma (setup.py)
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -65,9 +65,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via maggma (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 markupsafe==2.1.3
     # via
@@ -91,14 +91,14 @@ paramiko==3.3.1
     # via sshtunnel
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
@@ -116,13 +116,13 @@ python-dotenv==1.0.0
     # via pydantic-settings
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via mongogrant
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing

--- a/requirements/macos-latest_py3.10_extras.txt
+++ b/requirements/macos-latest_py3.10_extras.txt
@@ -35,16 +35,16 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via
     #   maggma (setup.py)
     #   moto
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -61,6 +61,7 @@ click==8.1.7
     # via
     #   flask
     #   mkdocs
+    #   mkdocstrings
     #   mongogrant
     #   uvicorn
 colorama==0.4.6
@@ -100,7 +101,7 @@ executing==2.0.1
     # via stack-data
 fastapi==0.104.1
     # via maggma (setup.py)
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via virtualenv
@@ -108,7 +109,7 @@ flask==3.0.0
     # via mongogrant
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
 h11==0.14.0
     # via
@@ -122,7 +123,7 @@ httpx==0.25.1
     # via starlette
 hvac==2.0.0
     # via maggma (setup.py)
-identify==2.5.31
+identify==2.5.32
     # via pre-commit
 idna==3.4
     # via
@@ -157,11 +158,11 @@ jmespath==1.0.1
     #   botocore
 jsmin==3.0.1
     # via mkdocs-minify-plugin
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via
     #   maggma (setup.py)
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-core==5.5.0
     # via nbformat
@@ -197,13 +198,13 @@ mkdocs==1.5.3
     #   mkdocstrings
 mkdocs-autorefs==0.5.0
     # via mkdocstrings
-mkdocs-material==9.4.8
+mkdocs-material==9.4.10
     # via maggma (setup.py)
 mkdocs-material-extensions==1.3
     # via mkdocs-material
 mkdocs-minify-plugin==0.7.1
     # via maggma (setup.py)
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   maggma (setup.py)
     #   mkdocstrings
@@ -218,7 +219,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.8
+moto==4.2.9
     # via maggma (setup.py)
 msal==1.25.0
     # via
@@ -255,6 +256,7 @@ platformdirs==3.11.0
     # via
     #   jupyter-core
     #   mkdocs
+    #   mkdocstrings
     #   virtualenv
 pluggy==1.3.0
     # via pytest
@@ -262,7 +264,7 @@ portalocker==2.8.2
     # via msal-extensions
 pre-commit==3.5.0
     # via maggma (setup.py)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -270,18 +272,18 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
-pygments==2.16.1
+pygments==2.17.1
     # via
     #   ipython
     #   mkdocs-material
@@ -336,7 +338,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -357,9 +359,9 @@ responses==0.21.0
     # via
     #   maggma (setup.py)
     #   moto
-rich==13.6.0
+rich==13.7.0
     # via memray
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -367,7 +369,7 @@ ruamel-yaml==0.17.40
     # via maggma (setup.py)
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.5
+ruff==0.1.6
     # via maggma (setup.py)
 s3transfer==0.7.0
     # via boto3
@@ -429,7 +431,7 @@ virtualenv==20.24.6
     # via pre-commit
 watchdog==3.0.0
     # via mkdocs
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 werkzeug==3.0.1
     # via

--- a/requirements/macos-latest_py3.11.txt
+++ b/requirements/macos-latest_py3.11.txt
@@ -20,13 +20,13 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via maggma (setup.py)
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -63,9 +63,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via maggma (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 markupsafe==2.1.3
     # via
@@ -89,14 +89,14 @@ paramiko==3.3.1
     # via sshtunnel
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
@@ -114,13 +114,13 @@ python-dotenv==1.0.0
     # via pydantic-settings
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via mongogrant
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing

--- a/requirements/macos-latest_py3.11_extras.txt
+++ b/requirements/macos-latest_py3.11_extras.txt
@@ -35,16 +35,16 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via
     #   maggma (setup.py)
     #   moto
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -61,6 +61,7 @@ click==8.1.7
     # via
     #   flask
     #   mkdocs
+    #   mkdocstrings
     #   mongogrant
     #   uvicorn
 colorama==0.4.6
@@ -95,7 +96,7 @@ executing==2.0.1
     # via stack-data
 fastapi==0.104.1
     # via maggma (setup.py)
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via virtualenv
@@ -103,7 +104,7 @@ flask==3.0.0
     # via mongogrant
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
 h11==0.14.0
     # via
@@ -117,7 +118,7 @@ httpx==0.25.1
     # via starlette
 hvac==2.0.0
     # via maggma (setup.py)
-identify==2.5.31
+identify==2.5.32
     # via pre-commit
 idna==3.4
     # via
@@ -152,11 +153,11 @@ jmespath==1.0.1
     #   botocore
 jsmin==3.0.1
     # via mkdocs-minify-plugin
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via
     #   maggma (setup.py)
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-core==5.5.0
     # via nbformat
@@ -192,13 +193,13 @@ mkdocs==1.5.3
     #   mkdocstrings
 mkdocs-autorefs==0.5.0
     # via mkdocstrings
-mkdocs-material==9.4.8
+mkdocs-material==9.4.10
     # via maggma (setup.py)
 mkdocs-material-extensions==1.3
     # via mkdocs-material
 mkdocs-minify-plugin==0.7.1
     # via maggma (setup.py)
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   maggma (setup.py)
     #   mkdocstrings
@@ -213,7 +214,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.8
+moto==4.2.9
     # via maggma (setup.py)
 msal==1.25.0
     # via
@@ -250,6 +251,7 @@ platformdirs==3.11.0
     # via
     #   jupyter-core
     #   mkdocs
+    #   mkdocstrings
     #   virtualenv
 pluggy==1.3.0
     # via pytest
@@ -257,7 +259,7 @@ portalocker==2.8.2
     # via msal-extensions
 pre-commit==3.5.0
     # via maggma (setup.py)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -265,18 +267,18 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
-pygments==2.16.1
+pygments==2.17.1
     # via
     #   ipython
     #   mkdocs-material
@@ -331,7 +333,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -352,9 +354,9 @@ responses==0.21.0
     # via
     #   maggma (setup.py)
     #   moto
-rich==13.6.0
+rich==13.7.0
     # via memray
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -362,7 +364,7 @@ ruamel-yaml==0.17.40
     # via maggma (setup.py)
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.5
+ruff==0.1.6
     # via maggma (setup.py)
 s3transfer==0.7.0
     # via boto3
@@ -419,7 +421,7 @@ virtualenv==20.24.6
     # via pre-commit
 watchdog==3.0.0
     # via mkdocs
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 werkzeug==3.0.1
     # via

--- a/requirements/macos-latest_py3.8.txt
+++ b/requirements/macos-latest_py3.8.txt
@@ -20,13 +20,13 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via maggma (setup.py)
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -71,9 +71,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via maggma (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 markupsafe==2.1.3
     # via
@@ -99,14 +99,14 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
@@ -124,13 +124,13 @@ python-dotenv==1.0.0
     # via pydantic-settings
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via mongogrant
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing

--- a/requirements/macos-latest_py3.8_extras.txt
+++ b/requirements/macos-latest_py3.8_extras.txt
@@ -37,16 +37,16 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via
     #   maggma (setup.py)
     #   moto
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -63,6 +63,7 @@ click==8.1.7
     # via
     #   flask
     #   mkdocs
+    #   mkdocstrings
     #   mongogrant
     #   uvicorn
 colorama==0.4.6
@@ -101,7 +102,7 @@ executing==2.0.1
     # via stack-data
 fastapi==0.104.1
     # via maggma (setup.py)
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via virtualenv
@@ -109,7 +110,7 @@ flask==3.0.0
     # via mongogrant
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
 h11==0.14.0
     # via
@@ -123,7 +124,7 @@ httpx==0.25.1
     # via starlette
 hvac==2.0.0
     # via maggma (setup.py)
-identify==2.5.31
+identify==2.5.32
     # via pre-commit
 idna==3.4
     # via
@@ -168,11 +169,11 @@ jmespath==1.0.1
     #   botocore
 jsmin==3.0.1
     # via mkdocs-minify-plugin
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via
     #   maggma (setup.py)
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-core==5.5.0
     # via nbformat
@@ -208,13 +209,13 @@ mkdocs==1.5.3
     #   mkdocstrings
 mkdocs-autorefs==0.5.0
     # via mkdocstrings
-mkdocs-material==9.4.8
+mkdocs-material==9.4.10
     # via maggma (setup.py)
 mkdocs-material-extensions==1.3
     # via mkdocs-material
 mkdocs-minify-plugin==0.7.1
     # via maggma (setup.py)
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   maggma (setup.py)
     #   mkdocstrings
@@ -229,7 +230,7 @@ monty==2023.9.25
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.8
+moto==4.2.9
     # via maggma (setup.py)
 msal==1.25.0
     # via
@@ -270,6 +271,7 @@ platformdirs==3.11.0
     # via
     #   jupyter-core
     #   mkdocs
+    #   mkdocstrings
     #   virtualenv
 pluggy==1.3.0
     # via pytest
@@ -277,7 +279,7 @@ portalocker==2.8.2
     # via msal-extensions
 pre-commit==3.5.0
     # via maggma (setup.py)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -285,18 +287,18 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
-pygments==2.16.1
+pygments==2.17.1
     # via
     #   ipython
     #   mkdocs-material
@@ -353,7 +355,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -374,9 +376,9 @@ responses==0.21.0
     # via
     #   maggma (setup.py)
     #   moto
-rich==13.6.0
+rich==13.7.0
     # via memray
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -384,7 +386,7 @@ ruamel-yaml==0.17.40
     # via maggma (setup.py)
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.5
+ruff==0.1.6
     # via maggma (setup.py)
 s3transfer==0.7.0
     # via boto3
@@ -452,7 +454,7 @@ virtualenv==20.24.6
     # via pre-commit
 watchdog==3.0.0
     # via mkdocs
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 werkzeug==3.0.1
     # via

--- a/requirements/macos-latest_py3.9.txt
+++ b/requirements/macos-latest_py3.9.txt
@@ -20,13 +20,13 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via maggma (setup.py)
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -67,9 +67,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via maggma (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 markupsafe==2.1.3
     # via
@@ -93,14 +93,14 @@ paramiko==3.3.1
     # via sshtunnel
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
@@ -118,13 +118,13 @@ python-dotenv==1.0.0
     # via pydantic-settings
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via mongogrant
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing

--- a/requirements/macos-latest_py3.9_extras.txt
+++ b/requirements/macos-latest_py3.9_extras.txt
@@ -35,16 +35,16 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via
     #   maggma (setup.py)
     #   moto
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -61,6 +61,7 @@ click==8.1.7
     # via
     #   flask
     #   mkdocs
+    #   mkdocstrings
     #   mongogrant
     #   uvicorn
 colorama==0.4.6
@@ -100,7 +101,7 @@ executing==2.0.1
     # via stack-data
 fastapi==0.104.1
     # via maggma (setup.py)
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via virtualenv
@@ -108,7 +109,7 @@ flask==3.0.0
     # via mongogrant
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
 h11==0.14.0
     # via
@@ -122,7 +123,7 @@ httpx==0.25.1
     # via starlette
 hvac==2.0.0
     # via maggma (setup.py)
-identify==2.5.31
+identify==2.5.32
     # via pre-commit
 idna==3.4
     # via
@@ -163,11 +164,11 @@ jmespath==1.0.1
     #   botocore
 jsmin==3.0.1
     # via mkdocs-minify-plugin
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via
     #   maggma (setup.py)
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-core==5.5.0
     # via nbformat
@@ -203,13 +204,13 @@ mkdocs==1.5.3
     #   mkdocstrings
 mkdocs-autorefs==0.5.0
     # via mkdocstrings
-mkdocs-material==9.4.8
+mkdocs-material==9.4.10
     # via maggma (setup.py)
 mkdocs-material-extensions==1.3
     # via mkdocs-material
 mkdocs-minify-plugin==0.7.1
     # via maggma (setup.py)
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   maggma (setup.py)
     #   mkdocstrings
@@ -224,7 +225,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.8
+moto==4.2.9
     # via maggma (setup.py)
 msal==1.25.0
     # via
@@ -261,6 +262,7 @@ platformdirs==3.11.0
     # via
     #   jupyter-core
     #   mkdocs
+    #   mkdocstrings
     #   virtualenv
 pluggy==1.3.0
     # via pytest
@@ -268,7 +270,7 @@ portalocker==2.8.2
     # via msal-extensions
 pre-commit==3.5.0
     # via maggma (setup.py)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -276,18 +278,18 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
-pygments==2.16.1
+pygments==2.17.1
     # via
     #   ipython
     #   mkdocs-material
@@ -342,7 +344,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -363,9 +365,9 @@ responses==0.21.0
     # via
     #   maggma (setup.py)
     #   moto
-rich==13.6.0
+rich==13.7.0
     # via memray
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -373,7 +375,7 @@ ruamel-yaml==0.17.40
     # via maggma (setup.py)
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.5
+ruff==0.1.6
     # via maggma (setup.py)
 s3transfer==0.7.0
     # via boto3
@@ -439,7 +441,7 @@ virtualenv==20.24.6
     # via pre-commit
 watchdog==3.0.0
     # via mkdocs
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 werkzeug==3.0.1
     # via

--- a/requirements/ubuntu-latest_py3.10.txt
+++ b/requirements/ubuntu-latest_py3.10.txt
@@ -20,13 +20,13 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via maggma (setup.py)
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -65,9 +65,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via maggma (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 markupsafe==2.1.3
     # via
@@ -91,14 +91,14 @@ paramiko==3.3.1
     # via sshtunnel
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
@@ -116,13 +116,13 @@ python-dotenv==1.0.0
     # via pydantic-settings
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via mongogrant
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing

--- a/requirements/ubuntu-latest_py3.10_extras.txt
+++ b/requirements/ubuntu-latest_py3.10_extras.txt
@@ -33,16 +33,16 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via
     #   maggma (setup.py)
     #   moto
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -59,6 +59,7 @@ click==8.1.7
     # via
     #   flask
     #   mkdocs
+    #   mkdocstrings
     #   mongogrant
     #   uvicorn
 colorama==0.4.6
@@ -98,7 +99,7 @@ executing==2.0.1
     # via stack-data
 fastapi==0.104.1
     # via maggma (setup.py)
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via virtualenv
@@ -106,7 +107,7 @@ flask==3.0.0
     # via mongogrant
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
 h11==0.14.0
     # via
@@ -120,7 +121,7 @@ httpx==0.25.1
     # via starlette
 hvac==2.0.0
     # via maggma (setup.py)
-identify==2.5.31
+identify==2.5.32
     # via pre-commit
 idna==3.4
     # via
@@ -155,11 +156,11 @@ jmespath==1.0.1
     #   botocore
 jsmin==3.0.1
     # via mkdocs-minify-plugin
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via
     #   maggma (setup.py)
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-core==5.5.0
     # via nbformat
@@ -195,13 +196,13 @@ mkdocs==1.5.3
     #   mkdocstrings
 mkdocs-autorefs==0.5.0
     # via mkdocstrings
-mkdocs-material==9.4.8
+mkdocs-material==9.4.10
     # via maggma (setup.py)
 mkdocs-material-extensions==1.3
     # via mkdocs-material
 mkdocs-minify-plugin==0.7.1
     # via maggma (setup.py)
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   maggma (setup.py)
     #   mkdocstrings
@@ -216,7 +217,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.8
+moto==4.2.9
     # via maggma (setup.py)
 msal==1.25.0
     # via
@@ -253,6 +254,7 @@ platformdirs==3.11.0
     # via
     #   jupyter-core
     #   mkdocs
+    #   mkdocstrings
     #   virtualenv
 pluggy==1.3.0
     # via pytest
@@ -260,7 +262,7 @@ portalocker==2.8.2
     # via msal-extensions
 pre-commit==3.5.0
     # via maggma (setup.py)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -268,18 +270,18 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
-pygments==2.16.1
+pygments==2.17.1
     # via
     #   ipython
     #   mkdocs-material
@@ -334,7 +336,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -355,9 +357,9 @@ responses==0.21.0
     # via
     #   maggma (setup.py)
     #   moto
-rich==13.6.0
+rich==13.7.0
     # via memray
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -365,7 +367,7 @@ ruamel-yaml==0.17.40
     # via maggma (setup.py)
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.5
+ruff==0.1.6
     # via maggma (setup.py)
 s3transfer==0.7.0
     # via boto3
@@ -427,7 +429,7 @@ virtualenv==20.24.6
     # via pre-commit
 watchdog==3.0.0
     # via mkdocs
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 werkzeug==3.0.1
     # via

--- a/requirements/ubuntu-latest_py3.11.txt
+++ b/requirements/ubuntu-latest_py3.11.txt
@@ -20,13 +20,13 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via maggma (setup.py)
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -63,9 +63,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via maggma (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 markupsafe==2.1.3
     # via
@@ -89,14 +89,14 @@ paramiko==3.3.1
     # via sshtunnel
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
@@ -114,13 +114,13 @@ python-dotenv==1.0.0
     # via pydantic-settings
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via mongogrant
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing

--- a/requirements/ubuntu-latest_py3.11_extras.txt
+++ b/requirements/ubuntu-latest_py3.11_extras.txt
@@ -33,16 +33,16 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via
     #   maggma (setup.py)
     #   moto
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -59,6 +59,7 @@ click==8.1.7
     # via
     #   flask
     #   mkdocs
+    #   mkdocstrings
     #   mongogrant
     #   uvicorn
 colorama==0.4.6
@@ -93,7 +94,7 @@ executing==2.0.1
     # via stack-data
 fastapi==0.104.1
     # via maggma (setup.py)
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via virtualenv
@@ -101,7 +102,7 @@ flask==3.0.0
     # via mongogrant
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
 h11==0.14.0
     # via
@@ -115,7 +116,7 @@ httpx==0.25.1
     # via starlette
 hvac==2.0.0
     # via maggma (setup.py)
-identify==2.5.31
+identify==2.5.32
     # via pre-commit
 idna==3.4
     # via
@@ -150,11 +151,11 @@ jmespath==1.0.1
     #   botocore
 jsmin==3.0.1
     # via mkdocs-minify-plugin
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via
     #   maggma (setup.py)
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-core==5.5.0
     # via nbformat
@@ -190,13 +191,13 @@ mkdocs==1.5.3
     #   mkdocstrings
 mkdocs-autorefs==0.5.0
     # via mkdocstrings
-mkdocs-material==9.4.8
+mkdocs-material==9.4.10
     # via maggma (setup.py)
 mkdocs-material-extensions==1.3
     # via mkdocs-material
 mkdocs-minify-plugin==0.7.1
     # via maggma (setup.py)
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   maggma (setup.py)
     #   mkdocstrings
@@ -211,7 +212,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.8
+moto==4.2.9
     # via maggma (setup.py)
 msal==1.25.0
     # via
@@ -248,6 +249,7 @@ platformdirs==3.11.0
     # via
     #   jupyter-core
     #   mkdocs
+    #   mkdocstrings
     #   virtualenv
 pluggy==1.3.0
     # via pytest
@@ -255,7 +257,7 @@ portalocker==2.8.2
     # via msal-extensions
 pre-commit==3.5.0
     # via maggma (setup.py)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -263,18 +265,18 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
-pygments==2.16.1
+pygments==2.17.1
     # via
     #   ipython
     #   mkdocs-material
@@ -329,7 +331,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -350,9 +352,9 @@ responses==0.21.0
     # via
     #   maggma (setup.py)
     #   moto
-rich==13.6.0
+rich==13.7.0
     # via memray
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -360,7 +362,7 @@ ruamel-yaml==0.17.40
     # via maggma (setup.py)
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.5
+ruff==0.1.6
     # via maggma (setup.py)
 s3transfer==0.7.0
     # via boto3
@@ -417,7 +419,7 @@ virtualenv==20.24.6
     # via pre-commit
 watchdog==3.0.0
     # via mkdocs
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 werkzeug==3.0.1
     # via

--- a/requirements/ubuntu-latest_py3.8.txt
+++ b/requirements/ubuntu-latest_py3.8.txt
@@ -20,13 +20,13 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via maggma (setup.py)
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -71,9 +71,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via maggma (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 markupsafe==2.1.3
     # via
@@ -99,14 +99,14 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
@@ -124,13 +124,13 @@ python-dotenv==1.0.0
     # via pydantic-settings
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via mongogrant
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing

--- a/requirements/ubuntu-latest_py3.8_extras.txt
+++ b/requirements/ubuntu-latest_py3.8_extras.txt
@@ -35,16 +35,16 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via
     #   maggma (setup.py)
     #   moto
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -61,6 +61,7 @@ click==8.1.7
     # via
     #   flask
     #   mkdocs
+    #   mkdocstrings
     #   mongogrant
     #   uvicorn
 colorama==0.4.6
@@ -99,7 +100,7 @@ executing==2.0.1
     # via stack-data
 fastapi==0.104.1
     # via maggma (setup.py)
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via virtualenv
@@ -107,7 +108,7 @@ flask==3.0.0
     # via mongogrant
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
 h11==0.14.0
     # via
@@ -121,7 +122,7 @@ httpx==0.25.1
     # via starlette
 hvac==2.0.0
     # via maggma (setup.py)
-identify==2.5.31
+identify==2.5.32
     # via pre-commit
 idna==3.4
     # via
@@ -166,11 +167,11 @@ jmespath==1.0.1
     #   botocore
 jsmin==3.0.1
     # via mkdocs-minify-plugin
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via
     #   maggma (setup.py)
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-core==5.5.0
     # via nbformat
@@ -206,13 +207,13 @@ mkdocs==1.5.3
     #   mkdocstrings
 mkdocs-autorefs==0.5.0
     # via mkdocstrings
-mkdocs-material==9.4.8
+mkdocs-material==9.4.10
     # via maggma (setup.py)
 mkdocs-material-extensions==1.3
     # via mkdocs-material
 mkdocs-minify-plugin==0.7.1
     # via maggma (setup.py)
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   maggma (setup.py)
     #   mkdocstrings
@@ -227,7 +228,7 @@ monty==2023.9.25
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.8
+moto==4.2.9
     # via maggma (setup.py)
 msal==1.25.0
     # via
@@ -268,6 +269,7 @@ platformdirs==3.11.0
     # via
     #   jupyter-core
     #   mkdocs
+    #   mkdocstrings
     #   virtualenv
 pluggy==1.3.0
     # via pytest
@@ -275,7 +277,7 @@ portalocker==2.8.2
     # via msal-extensions
 pre-commit==3.5.0
     # via maggma (setup.py)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -283,18 +285,18 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
-pygments==2.16.1
+pygments==2.17.1
     # via
     #   ipython
     #   mkdocs-material
@@ -351,7 +353,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -372,9 +374,9 @@ responses==0.21.0
     # via
     #   maggma (setup.py)
     #   moto
-rich==13.6.0
+rich==13.7.0
     # via memray
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -382,7 +384,7 @@ ruamel-yaml==0.17.40
     # via maggma (setup.py)
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.5
+ruff==0.1.6
     # via maggma (setup.py)
 s3transfer==0.7.0
     # via boto3
@@ -450,7 +452,7 @@ virtualenv==20.24.6
     # via pre-commit
 watchdog==3.0.0
     # via mkdocs
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 werkzeug==3.0.1
     # via

--- a/requirements/ubuntu-latest_py3.9.txt
+++ b/requirements/ubuntu-latest_py3.9.txt
@@ -20,13 +20,13 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via maggma (setup.py)
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.16.0
     # via
@@ -67,9 +67,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via maggma (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 markupsafe==2.1.3
     # via
@@ -93,14 +93,14 @@ paramiko==3.3.1
     # via sshtunnel
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
@@ -118,13 +118,13 @@ python-dotenv==1.0.0
     # via pydantic-settings
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via mongogrant
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing

--- a/requirements/ubuntu-latest_py3.9_extras.txt
+++ b/requirements/ubuntu-latest_py3.9_extras.txt
@@ -33,16 +33,16 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.7.0
     # via flask
-boto3==1.28.84
+boto3==1.29.3
     # via
     #   maggma (setup.py)
     #   moto
-botocore==1.31.84
+botocore==1.32.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -59,6 +59,7 @@ click==8.1.7
     # via
     #   flask
     #   mkdocs
+    #   mkdocstrings
     #   mongogrant
     #   uvicorn
 colorama==0.4.6
@@ -98,7 +99,7 @@ executing==2.0.1
     # via stack-data
 fastapi==0.104.1
     # via maggma (setup.py)
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via virtualenv
@@ -106,7 +107,7 @@ flask==3.0.0
     # via mongogrant
 ghp-import==2.1.0
     # via mkdocs
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
 h11==0.14.0
     # via
@@ -120,7 +121,7 @@ httpx==0.25.1
     # via starlette
 hvac==2.0.0
     # via maggma (setup.py)
-identify==2.5.31
+identify==2.5.32
     # via pre-commit
 idna==3.4
     # via
@@ -161,11 +162,11 @@ jmespath==1.0.1
     #   botocore
 jsmin==3.0.1
     # via mkdocs-minify-plugin
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via
     #   maggma (setup.py)
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-core==5.5.0
     # via nbformat
@@ -201,13 +202,13 @@ mkdocs==1.5.3
     #   mkdocstrings
 mkdocs-autorefs==0.5.0
     # via mkdocstrings
-mkdocs-material==9.4.8
+mkdocs-material==9.4.10
     # via maggma (setup.py)
 mkdocs-material-extensions==1.3
     # via mkdocs-material
 mkdocs-minify-plugin==0.7.1
     # via maggma (setup.py)
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   maggma (setup.py)
     #   mkdocstrings
@@ -222,7 +223,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.8
+moto==4.2.9
     # via maggma (setup.py)
 msal==1.25.0
     # via
@@ -259,6 +260,7 @@ platformdirs==3.11.0
     # via
     #   jupyter-core
     #   mkdocs
+    #   mkdocstrings
     #   virtualenv
 pluggy==1.3.0
     # via pytest
@@ -266,7 +268,7 @@ portalocker==2.8.2
     # via msal-extensions
 pre-commit==3.5.0
     # via maggma (setup.py)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -274,18 +276,18 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydantic==2.4.2
+pydantic==2.5.1
     # via
     #   fastapi
     #   maggma (setup.py)
     #   pydantic-settings
-pydantic-core==2.10.1
+pydantic-core==2.14.3
     # via pydantic
-pydantic-settings==2.0.3
+pydantic-settings==2.1.0
     # via maggma (setup.py)
 pydash==7.0.6
     # via maggma (setup.py)
-pygments==2.16.1
+pygments==2.17.1
     # via
     #   ipython
     #   mkdocs-material
@@ -340,7 +342,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 pyzmq==25.1.1
     # via maggma (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -361,9 +363,9 @@ responses==0.21.0
     # via
     #   maggma (setup.py)
     #   moto
-rich==13.6.0
+rich==13.7.0
     # via memray
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -371,7 +373,7 @@ ruamel-yaml==0.17.40
     # via maggma (setup.py)
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.5
+ruff==0.1.6
     # via maggma (setup.py)
 s3transfer==0.7.0
     # via boto3
@@ -437,7 +439,7 @@ virtualenv==20.24.6
     # via pre-commit
 watchdog==3.0.0
     # via mkdocs
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 werkzeug==3.0.1
     # via

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     url="https://github.com/materialsproject/maggma",
     author="The Materials Project",
     author_email="feedback@materialsproject.org",
-    license="modified BSD",
     packages=find_packages("src"),
     package_dir={"": "src"},
     package_data={"maggma": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     package_data={"maggma": ["py.typed"]},
     zip_safe=False,
     include_package_data=True,
-    python_requires=">=3.8",
     install_requires=[
         "setuptools",
         "ruamel.yaml<0.18",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     url="https://github.com/materialsproject/maggma",
     author="The Materials Project",
     author_email="feedback@materialsproject.org",
+    license="modified BSD",
     packages=find_packages("src"),
     package_dir={"": "src"},
     package_data={"maggma": ["py.typed"]},

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -379,10 +379,6 @@ class S3Store(Store):
             search_doc["compression"] = "zlib"
             data = self._get_compression_function()(data)
 
-        if self.last_updated_field in doc:
-            # need this conversion for aws metadata insert
-            search_doc[self.last_updated_field] = str(to_isoformat_ceil_ms(doc[self.last_updated_field]))
-
         # keep a record of original keys, in case these are important for the individual researcher
         # it is not expected that this information will be used except in disaster recovery
         s3_to_mongo_keys = {k: self._sanitize_key(k) for k in search_doc}

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -203,7 +203,7 @@ class S3Store(Store):
                 yield data
 
     def _read_data(self, data: bytes, compress_header: str):
-        self._unpack(data=data, compressed=compress_header == "zlib")
+        return self._unpack(data=data, compressed=compress_header == "zlib")
 
     @staticmethod
     def _unpack(data: bytes, compressed: bool):

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -308,6 +308,9 @@ class S3Store(Store):
         else:
             additional_metadata = list(additional_metadata)
 
+        self._write_to_s3_and_index(docs, key, additional_metadata)
+
+    def _write_to_s3_and_index(self, docs, key, additional_metadata):
         with ThreadPoolExecutor(max_workers=self.s3_workers) as pool:
             fs = {
                 pool.submit(

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -1,0 +1,196 @@
+import gzip
+import orjson
+from bson import json_util
+from io import BytesIO
+from typing import Any, Dict, List, Optional, Union
+
+from maggma.stores.mongolike import MemoryStore
+from maggma.stores.aws import S3Store
+
+from boto3 import Session
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+
+class S3IndexStore(MemoryStore):
+    """
+    A store that loads the index of the collection from an S3 file.
+
+    S3IndexStore can still apply MongoDB-like writable operations
+    (e.g. an update) because it behaves like a MemoryStore,
+    but it will not write those changes to S3.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str = "",
+        endpoint_url: Optional[str] = None,
+        manifest_key: str = "manifest.json",
+        **kwargs,
+    ):
+        self.bucket = bucket
+        self.prefix = prefix
+        self.endpoint_url = endpoint_url
+        self.client: Any = None
+        self.session: Any = None
+        self.s3_session_kwargs = {}
+        self.manifest_key = manifest_key
+
+        super().__init__(**kwargs)
+
+    def _get_full_key_path(self) -> str:
+        return f"{self.prefix}{self.manifest_key}"
+
+    def _retrieve_manifest(self) -> List:
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=self._get_full_key_path())
+            return orjson.loads(response["Body"].read().decode("utf-8"))
+        except ClientError as ex:
+            if ex.response["Error"]["Code"] == "NoSuchKey":
+                return []
+            else:
+                raise
+
+    def _load_index(self) -> None:
+        super().connect()
+        super().update(self._retrieve_manifest())
+
+    def store_manifest(self, data) -> None:
+        self.client.put_object(
+            Bucket=self.bucket,
+            Body=orjson.dumps(data, default=json_util.default),
+            Key=self._get_full_key_path(),
+        )
+
+    def connect(self):
+        """
+        Loads the files into the collection in memory
+        """
+        # set up the S3 client
+        if not self.session:
+            self.session = Session(**self.s3_session_kwargs)
+
+        self.client = self.session.client("s3", endpoint_url=self.endpoint_url)
+
+        try:
+            self.client.head_bucket(Bucket=self.bucket)
+        except ClientError:
+            raise RuntimeError(f"Bucket not present on AWS: {self.bucket}")
+
+        # load index
+        self._load_index()
+
+    def __hash__(self):
+        return hash((self.collection_name, self.bucket, self.prefix))
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Check equality for S3Store
+        other: other S3Store to compare with.
+        """
+        if not isinstance(other, S3IndexStore):
+            return False
+
+        fields = ["collection_name", "bucket", "prefix", "last_updated_field"]
+        return all(getattr(self, f) == getattr(other, f) for f in fields)
+
+
+class OpenDataStore(S3Store):
+    """
+    Data is stored on S3 compatible storage using the format used by Materials Project on OpenData.
+    The index is loaded from S3 compatible storage into memory.
+
+    Note that updates will only affect the in-memory represenation of the index - they will not be persisted.
+    This Store should not be used for applications that are distributed and rely on reading updated
+    values from the index as data inconsistencied will arise.
+    """
+
+    def __init__(
+        self,
+        index: S3IndexStore,
+        object_file_extension: str = ".json.gz",
+        access_as_public_bucket: bool = False,
+        **kwargs,
+    ):
+        """
+        Initializes an OpenData S3 Store.
+        """
+        self.index = index
+        self.object_file_extension = object_file_extension
+        self.access_as_public_bucket = access_as_public_bucket
+        if access_as_public_bucket:
+            kwargs["s3_resource_kwargs"] = kwargs["s3_resource_kwargs"] if "s3_resource_kwargs" in kwargs else {}
+            kwargs["s3_resource_kwargs"]["config"] = Config(signature_version=UNSIGNED)
+
+        kwargs["index"] = index
+        kwargs["unpack_data"] = True
+        super().__init__(**kwargs)
+
+    def _get_full_key_path(self, id) -> str:
+        return f"{self.sub_dir}{id}{self.object_file_extension}"
+
+    def _get_id_from_full_key_path(self, key):
+        prefix, suffix = self.sub_dir, self.object_file_extension
+        if prefix in key and suffix in key:
+            start_idx = key.index(prefix) + len(prefix)
+            end_idx = key.index(suffix, start_idx)
+            return key[start_idx:end_idx]
+        else:
+            return None
+
+    def _get_compression_function(self):
+        return gzip.compress
+
+    def _get_decompression_function(self):
+        return gzip.decompress
+
+    def _read_data(self, data: bytes, compress_header: str = "gzip"):
+        if compress_header is not None:
+            data = self._get_decompression_function()(data)
+        return orjson.loads(data)
+
+    def write_doc_to_s3(self, doc: Dict, search_keys: List[str]):
+        """
+        Write the data to s3 and return the metadata to be inserted into the index db.
+
+        Args:
+            doc: the document
+            search_keys: list of keys to pull from the docs and be inserted into the
+            index db (these will be only added to the volatile index)
+        """
+        search_doc = {k: doc[k] for k in search_keys}
+        search_doc[self.key] = doc[self.key]  # Ensure key is in metadata
+
+        data = orjson.dumps(doc, default=json_util.default)
+        data = self._get_compression_function()(data)
+        self._get_bucket().upload_fileobj(
+            Fileobj=BytesIO(data),
+            Key=self._get_full_key_path(str(doc[self.key])),
+        )
+        return search_doc
+
+    def rebuild_index_from_s3_data(self):
+        """
+        Rebuilds the index Store from the data in S3
+        Stores only the key and searchable fields in the index.
+        """
+        bucket = self._get_bucket()
+        paginator = bucket.meta.client.get_paginator("list_objects_v2")
+
+        # Create a PageIterator from the Paginator
+        page_iterator = paginator.paginate(Bucket=self.bucket, Prefix=self.sub_dir.strip("/"))
+
+        all_index_docs = []
+        for page in page_iterator:
+            for file in page["Contents"]:
+                key = file["Key"]
+                if key != self.index._get_full_key_path():
+                    response = bucket.Object(key).get()
+                    doc = self._read_data(response["Body"].read())
+                    index_doc = {k: doc[k] for k in self.searchable_fields}
+                    index_doc[self.key] = self._get_id_from_full_key_path(key)
+                    all_index_docs.append(index_doc)
+        self.index.store_manifest(all_index_docs)
+        return all_index_docs

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -199,3 +199,16 @@ class OpenDataStore(S3Store):
                     all_index_docs.append(index_doc)
         self.index.store_manifest(all_index_docs)
         return all_index_docs
+
+    def rebuild_index_from_data(self, docs):
+        """
+        Rebuilds the index Store from the provided data.
+        The provided data needs to include all of the documents in this data set.
+        Stores only the key and searchable fields in the index.
+        """
+        all_index_docs = []
+        for doc in docs:
+            index_doc = self._gather_indexable_data(doc, self.searchable_fields)
+            all_index_docs.append(index_doc)
+        self.index.store_manifest(all_index_docs)
+        return all_index_docs

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -162,6 +162,9 @@ class OpenDataStore(S3Store):
         """
         search_doc = {k: doc[k] for k in search_keys}
         search_doc[self.key] = doc[self.key]  # Ensure key is in metadata
+        # Ensure last updated field is in metada if it's present in the data
+        if self.last_updated_field in doc:
+            search_doc[self.last_updated_field] = doc[self.last_updated_field]
 
         data = orjson.dumps(doc, default=json_util.default)
         data = self._get_compression_function()(data)

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -1,0 +1,334 @@
+import time
+from datetime import datetime
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from maggma.stores import MemoryStore
+from maggma.stores.open_data import OpenDataStore, S3IndexStore
+from moto import mock_s3
+
+
+@pytest.fixture()
+def memstore():
+    store = MemoryStore("maggma_test", key="task_id")
+    store.connect()
+    yield store
+    store._collection.drop()
+
+
+@pytest.fixture()
+def s3store():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+
+        index = S3IndexStore(collection_name="index", bucket="bucket1", key="task_id")
+        store = OpenDataStore(index=index, bucket="bucket1", key="task_id")
+        store.connect()
+
+        store.update(
+            [
+                {
+                    "task_id": "mp-1",
+                    "data": "asd",
+                    store.last_updated_field: datetime.utcnow(),
+                }
+            ]
+        )
+        store.update(
+            [
+                {
+                    "task_id": "mp-3",
+                    "data": "sdf",
+                    store.last_updated_field: datetime.utcnow(),
+                }
+            ]
+        )
+
+        yield store
+
+
+@pytest.fixture()
+def s3store_w_subdir():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+
+        index = MemoryStore("index")
+        store = OpenDataStore(index=index, bucket="bucket1", sub_dir="subdir1", s3_workers=1)
+        store.connect()
+
+        yield store
+
+
+@pytest.fixture()
+def s3store_multi():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+
+        index = MemoryStore("index")
+        store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4)
+        store.connect()
+
+        yield store
+
+
+def test_keys():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+        index = MemoryStore("index", key=1)
+        with pytest.raises(AssertionError, match=r"Since we are.*"):
+            store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4, key=1)
+        index = MemoryStore("index", key="key1")
+        with pytest.warns(UserWarning, match=r"The desired S3Store.*$"):
+            store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4, key="key2")
+        store.connect()
+        store.update({"key1": "mp-1", "data": "1234"})
+        with pytest.raises(KeyError):
+            store.update({"key2": "mp-2", "data": "1234"})
+        assert store.key == store.index.key == "key1"
+
+
+def test_multi_update(s3store, s3store_multi):
+    data = [
+        {
+            "task_id": str(j),
+            "data": "DATA",
+            s3store_multi.last_updated_field: datetime.utcnow(),
+        }
+        for j in range(32)
+    ]
+
+    def fake_writing(doc, search_keys):
+        time.sleep(0.20)
+        return {k: doc[k] for k in search_keys}
+
+    s3store.write_doc_to_s3 = fake_writing
+    s3store_multi.write_doc_to_s3 = fake_writing
+
+    start = time.time()
+    s3store_multi.update(data, key=["task_id"])
+    end = time.time()
+    time_multi = end - start
+
+    start = time.time()
+    s3store.update(data, key=["task_id"])
+    end = time.time()
+    time_single = end - start
+    assert time_single > time_multi * (s3store_multi.s3_workers - 1) / (s3store.s3_workers)
+
+
+def test_count(s3store):
+    assert s3store.count() == 2
+    assert s3store.count({"task_id": "mp-3"}) == 1
+
+
+def test_qeuery(s3store):
+    assert s3store.query_one(criteria={"task_id": "mp-2"}) is None
+    assert s3store.query_one(criteria={"task_id": "mp-1"})["data"] == "asd"
+    assert s3store.query_one(criteria={"task_id": "mp-3"})["data"] == "sdf"
+
+    assert len(list(s3store.query())) == 2
+
+
+def test_update(s3store):
+    s3store.update(
+        [
+            {
+                "task_id": "mp-199999",
+                "data": "asd",
+                s3store.last_updated_field: datetime.utcnow(),
+            }
+        ]
+    )
+    assert s3store.query_one({"task_id": "mp-199999"}) is not None
+
+    s3store.update([{"task_id": "mp-4", "data": "asd"}])
+    assert s3store.query_one({"task_id": "mp-4"})["data"] == "asd"
+    assert s3store.s3_bucket.Object(s3store._get_full_key_path("mp-4")).key == "mp-4.json.gz"
+
+
+def test_rebuild_index_from_s3_data(s3store):
+    s3store.update([{"task_id": "mp-2", "data": "asd"}])
+    index_docs = s3store.rebuild_index_from_s3_data()
+    assert len(index_docs) == 3
+    for doc in index_docs:
+        for key in doc.keys():
+            assert key == "task_id"
+
+
+def tests_msonable_read_write(s3store):
+    dd = s3store.as_dict()
+    s3store.update([{"task_id": "mp-2", "data": dd}])
+    res = s3store.query_one({"task_id": "mp-2"})
+    assert res["data"]["@module"] == "maggma.stores.open_data"
+
+
+def test_remove(s3store):
+    def objects_in_bucket(key):
+        objs = list(s3store.s3_bucket.objects.filter(Prefix=key))
+        return key in [o.key for o in objs]
+
+    s3store.update([{"task_id": "mp-2", "data": "asd"}])
+    s3store.update([{"task_id": "mp-4", "data": "asd"}])
+    s3store.update({"task_id": "mp-5", "data": "aaa"})
+    assert s3store.query_one({"task_id": "mp-2"}) is not None
+    assert s3store.query_one({"task_id": "mp-4"}) is not None
+    assert objects_in_bucket("mp-2.json.gz")
+    assert objects_in_bucket("mp-4.json.gz")
+
+    s3store.remove_docs({"task_id": "mp-2"})
+    s3store.remove_docs({"task_id": "mp-4"}, remove_s3_object=True)
+
+    assert objects_in_bucket("mp-2.json.gz")
+    assert not objects_in_bucket("mp-4.json.gz")
+
+    assert s3store.query_one({"task_id": "mp-5"}) is not None
+
+
+def test_close(s3store):
+    list(s3store.query())
+    s3store.close()
+    with pytest.raises(AttributeError):
+        list(s3store.query())
+
+
+def test_bad_import(mocker):
+    mocker.patch("maggma.stores.aws.boto3", None)
+    index = MemoryStore("index")
+    with pytest.raises(RuntimeError):
+        OpenDataStore(index=index, bucket="bucket1")
+
+
+def test_aws_error(s3store):
+    def raise_exception_NoSuchKey(data):
+        error_response = {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}}
+        raise ClientError(error_response, "raise_exception")
+
+    def raise_exception_other(data):
+        error_response = {"Error": {"Code": 405}}
+        raise ClientError(error_response, "raise_exception")
+
+    s3store.s3_bucket.Object = raise_exception_other
+    with pytest.raises(ClientError):
+        s3store.query_one()
+
+    # Should just pass
+    s3store.s3_bucket.Object = raise_exception_NoSuchKey
+    s3store.query_one()
+
+
+def test_eq(memstore, s3store):
+    assert s3store == s3store
+    assert memstore != s3store
+
+
+def test_count_subdir(s3store_w_subdir):
+    s3store_w_subdir.update([{"task_id": "mp-1", "data": "asd"}])
+    s3store_w_subdir.update([{"task_id": "mp-2", "data": "asd"}])
+
+    assert s3store_w_subdir.count() == 2
+    assert s3store_w_subdir.count({"task_id": "mp-2"}) == 1
+
+
+def test_subdir_storage(s3store_w_subdir):
+    def objects_in_bucket(key):
+        objs = list(s3store_w_subdir.s3_bucket.objects.filter(Prefix=key))
+        return key in [o.key for o in objs]
+
+    s3store_w_subdir.update([{"task_id": "mp-1", "data": "asd"}])
+    s3store_w_subdir.update([{"task_id": "mp-2", "data": "asd"}])
+
+    assert objects_in_bucket("subdir1/mp-1.json.gz")
+    assert objects_in_bucket("subdir1/mp-2.json.gz")
+
+
+def test_remove_subdir(s3store_w_subdir):
+    s3store_w_subdir.update([{"task_id": "mp-2", "data": "asd"}])
+    s3store_w_subdir.update([{"task_id": "mp-4", "data": "asd"}])
+
+    assert s3store_w_subdir.query_one({"task_id": "mp-2"}) is not None
+    assert s3store_w_subdir.query_one({"task_id": "mp-4"}) is not None
+
+    s3store_w_subdir.remove_docs({"task_id": "mp-2"})
+
+    assert s3store_w_subdir.query_one({"task_id": "mp-2"}) is None
+    assert s3store_w_subdir.query_one({"task_id": "mp-4"}) is not None
+
+
+def test_searchable_fields(s3store):
+    tic = datetime(2018, 4, 12, 16)
+
+    data = [{"task_id": f"mp-{i}", "a": i, s3store.last_updated_field: tic} for i in range(4)]
+
+    s3store.searchable_fields = ["task_id"]
+    s3store.update(data, key="a")
+
+    # This should only work if the searchable field was put into the index store
+    assert set(s3store.distinct("task_id")) == {"mp-0", "mp-1", "mp-2", "mp-3"}
+
+
+def test_newer_in(s3store):
+    with mock_s3():
+        tic = datetime(2018, 4, 12, 16)
+        tic2 = datetime.utcnow()
+        conn = boto3.client("s3")
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket")
+
+        index_old = S3IndexStore(collection_name="index_old", bucket="bucket")
+        old_store = OpenDataStore(index=index_old, bucket="bucket", searchable_fields=["last_updated"])
+        old_store.connect()
+        old_store.update([{"task_id": "mp-1", "last_updated": tic}])
+        old_store.update([{"task_id": "mp-2", "last_updated": tic}])
+
+        index_new = S3IndexStore(collection_name="index_new", bucket="bucket", prefix="new")
+        new_store = OpenDataStore(index=index_new, bucket="bucket", sub_dir="new", searchable_fields=["last_updated"])
+        new_store.connect()
+        new_store.update([{"task_id": "mp-1", "last_updated": tic2}])
+        new_store.update([{"task_id": "mp-2", "last_updated": tic2}])
+
+        assert len(old_store.newer_in(new_store)) == 2
+        assert len(new_store.newer_in(old_store)) == 0
+
+        assert len(old_store.newer_in(new_store.index)) == 2
+        assert len(new_store.newer_in(old_store.index)) == 0
+
+
+def test_additional_metadata(s3store):
+    tic = datetime(2018, 4, 12, 16)
+
+    data = [{"task_id": f"mp-{i}", "a": i, s3store.last_updated_field: tic} for i in range(4)]
+
+    s3store.update(data, key="a", additional_metadata="task_id")
+
+    # This should only work if the searchable field was put into the index store
+    assert set(s3store.distinct("task_id")) == {"mp-0", "mp-1", "mp-2", "mp-3"}
+
+
+def test_get_session(s3store):
+    index = MemoryStore("index")
+    store = OpenDataStore(
+        index=index,
+        bucket="bucket1",
+        s3_profile={
+            "aws_access_key_id": "ACCESS_KEY",
+            "aws_secret_access_key": "SECRET_KEY",
+        },
+    )
+    assert store._get_session().get_credentials().access_key == "ACCESS_KEY"
+    assert store._get_session().get_credentials().secret_key == "SECRET_KEY"
+
+
+def test_no_bucket():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+
+        index = MemoryStore("index")
+        store = OpenDataStore(index=index, bucket="bucket2")
+        with pytest.raises(RuntimeError, match=r".*Bucket not present.*"):
+            store.connect()

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -280,13 +280,13 @@ def test_newer_in(s3store):
         conn.create_bucket(Bucket="bucket")
 
         index_old = S3IndexStore(collection_name="index_old", bucket="bucket")
-        old_store = OpenDataStore(index=index_old, bucket="bucket", searchable_fields=["last_updated"])
+        old_store = OpenDataStore(index=index_old, bucket="bucket")
         old_store.connect()
         old_store.update([{"task_id": "mp-1", "last_updated": tic}])
         old_store.update([{"task_id": "mp-2", "last_updated": tic}])
 
         index_new = S3IndexStore(collection_name="index_new", bucket="bucket", prefix="new")
-        new_store = OpenDataStore(index=index_new, bucket="bucket", sub_dir="new", searchable_fields=["last_updated"])
+        new_store = OpenDataStore(index=index_new, bucket="bucket", sub_dir="new")
         new_store.connect()
         new_store.update([{"task_id": "mp-1", "last_updated": tic2}])
         new_store.update([{"task_id": "mp-2", "last_updated": tic2}])


### PR DESCRIPTION
## Summary

Major changes:

- add S3IndexStore: a store that loads the index of the collection from an S3 file.
- add OpenDataStore: a store whose data is stored on S3 compatible storage using the format used by Materials Project on OpenData. It utilizes an index that is loaded from S3 compatible storage into memory (S3IndexStore).
- refactor of S3Store to make it extensible, ie allow OpenDataStore to build on top of it

## Todos

If this is work in progress, what else needs to be done?

- implement optimizations for key and last updated field storage/retrieval in S3IndexStore
- nail down package structure and imports
- remove 10 item limit set on pulling from Mongo collection that's in place for testing
- checklist items

## Checklist

- [ ] Google format doc strings added.
- [ ] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] I have run the tests locally and they passed.
<!-- - [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
