### PR TITLE
Remove key from sorting by default

### DIFF
--- a/src/maggma/api/resource/utils.py
+++ b/src/maggma/api/resource/utils.py
@@ -46,7 +46,6 @@ def generate_query_pipeline(query: dict, store: Store):
     if sorting:
         sort_dict = {"$sort": {}}  # type: dict
         sort_dict["$sort"].update(query["sort"])
-        sort_dict["$sort"].update({store.key: 1})  # Ensures sort by key is last in dict to fix determinacy
 
     projection_dict = {"_id": 0}  # Do not return _id by default
 


### PR DESCRIPTION
Ensure the aggregation pipelines generated in the API do not automatically sort by the main key as well.