### PR TITLE
Enhancement/open data store

### DIFF
--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -184,7 +184,7 @@ class S3Store(Store):
             else:
                 try:
                     # TODO: This is ugly and unsafe, do some real checking before pulling data
-                    data = self.s3_bucket.Object(self.sub_dir + str(doc[self.key])).get()["Body"].read()
+                    data = self.s3_bucket.Object(self._get_full_key_path(doc[self.key])).get()["Body"].read()
                 except botocore.exceptions.ClientError as e:
                     # If a client error is thrown, then check that it was a NoSuchKey or NoSuchBucket error.
                     # If it was a NoSuchKey error, then the object does not exist.
@@ -199,12 +199,15 @@ class S3Store(Store):
                         raise e
 
                 if self.unpack_data:
-                    data = self._unpack(data=data, compressed=doc.get("compression", "") == "zlib")
+                    data = self._read_data(data=data, compress_header=doc.get("compression", ""))
 
                     if self.last_updated_field in doc:
                         data[self.last_updated_field] = doc[self.last_updated_field]
 
                 yield data
+
+    def _read_data(self, data: bytes, compress_header: str):
+        return self._unpack(data=data, compressed=compress_header == "zlib")
 
     @staticmethod
     def _unpack(data: bytes, compressed: bool):
@@ -307,6 +310,9 @@ class S3Store(Store):
         else:
             additional_metadata = list(additional_metadata)
 
+        self._write_to_s3_and_index(docs, key, additional_metadata)
+
+    def _write_to_s3_and_index(self, docs, key, additional_metadata):
         with ThreadPoolExecutor(max_workers=self.s3_workers) as pool:
             fs = {
                 pool.submit(
@@ -366,6 +372,15 @@ class S3Store(Store):
 
         return resource, bucket
 
+    def _get_full_key_path(self, id):
+        return self.sub_dir + str(id)
+
+    def _get_compression_function(self):
+        return zlib.compress
+
+    def _get_decompression_function(self):
+        return zlib.decompress
+
     def write_doc_to_s3(self, doc: Dict, search_keys: List[str]):
         """
         Write the data to s3 and return the metadata to be inserted into the index db.
@@ -393,11 +408,7 @@ class S3Store(Store):
         if self.compress:
             # Compress with zlib if chosen
             search_doc["compression"] = "zlib"
-            data = zlib.compress(data)
-
-        if self.last_updated_field in doc:
-            # need this conversion for aws metadata insert
-            search_doc[self.last_updated_field] = str(to_isoformat_ceil_ms(doc[self.last_updated_field]))
+            data = self._get_compression_function()(data)
 
         # keep a record of original keys, in case these are important for the individual researcher
         # it is not expected that this information will be used except in disaster recovery
@@ -407,7 +418,7 @@ class S3Store(Store):
         search_doc["s3-to-mongo-keys"] = dumps(s3_to_mongo_keys)
         s3_bucket.upload_fileobj(
             Fileobj=BytesIO(data),
-            Key=self.sub_dir + str(doc[self.key]),
+            Key=self._get_full_key_path(str(doc[self.key])),
             ExtraArgs={"Metadata": {s3_to_mongo_keys[k]: str(v) for k, v in search_doc.items()}},
         )
 
@@ -452,7 +463,7 @@ class S3Store(Store):
             # Can remove up to 1000 items at a time via boto
             to_remove_chunks = list(grouper(to_remove, n=1000))
             for chunk_to_remove in to_remove_chunks:
-                objlist = [{"Key": f"{self.sub_dir}{obj}"} for obj in chunk_to_remove]
+                objlist = [{"Key": self._get_full_key_path(obj)} for obj in chunk_to_remove]
                 self.s3_bucket.delete_objects(Delete={"Objects": objlist})
 
     @property
@@ -486,11 +497,11 @@ class S3Store(Store):
         bucket = self.s3_bucket
         objects = bucket.objects.filter(Prefix=self.sub_dir)
         for obj in objects:
-            key_ = self.sub_dir + obj.key
+            key_ = self._get_full_key_path(obj.key)
             data = self.s3_bucket.Object(key_).get()["Body"].read()
 
             if self.compress:
-                data = zlib.decompress(data)
+                data = self._get_decompression_function()(data)
             unpacked_data = msgpack.unpackb(data, raw=False)
             self.update(unpacked_data, **kwargs)
 
@@ -504,7 +515,7 @@ class S3Store(Store):
         """
         qq = {} if index_query is None else index_query
         for index_doc in self.index.query(qq):
-            key_ = self.sub_dir + index_doc[self.key]
+            key_ = self._get_full_key_path(index_doc[self.key])
             s3_object = self.s3_bucket.Object(key_)
             new_meta = {self._sanitize_key(k): v for k, v in s3_object.metadata.items()}
             for k, v in index_doc.items():

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -1,0 +1,217 @@
+import gzip
+from io import BytesIO
+from typing import Any, Dict, List, Optional
+
+import orjson
+from boto3 import Session
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from bson import json_util
+
+from maggma.stores.aws import S3Store
+from maggma.stores.mongolike import MemoryStore
+
+
+class S3IndexStore(MemoryStore):
+    """
+    A store that loads the index of the collection from an S3 file.
+
+    S3IndexStore can still apply MongoDB-like writable operations
+    (e.g. an update) because it behaves like a MemoryStore,
+    but it will not write those changes to S3.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str = "",
+        endpoint_url: Optional[str] = None,
+        manifest_key: str = "manifest.json",
+        **kwargs,
+    ):
+        self.bucket = bucket
+        self.prefix = prefix
+        self.endpoint_url = endpoint_url
+        self.client: Any = None
+        self.session: Any = None
+        self.s3_session_kwargs = {}
+        self.manifest_key = manifest_key
+
+        super().__init__(**kwargs)
+
+    def _get_full_key_path(self) -> str:
+        return f"{self.prefix}{self.manifest_key}"
+
+    def _retrieve_manifest(self) -> List:
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=self._get_full_key_path())
+            json_data = orjson.loads(response["Body"].read().decode("utf-8"))
+            return json_data if isinstance(json_data, list) else [json_data]
+        except ClientError as ex:
+            if ex.response["Error"]["Code"] == "NoSuchKey":
+                return []
+            raise
+
+    def _load_index(self) -> None:
+        super().connect()
+        super().update(self._retrieve_manifest())
+
+    def store_manifest(self, data) -> None:
+        self.client.put_object(
+            Bucket=self.bucket,
+            Body=orjson.dumps(data, default=json_util.default),
+            Key=self._get_full_key_path(),
+        )
+
+    def connect(self):
+        """
+        Loads the files into the collection in memory
+        """
+        # set up the S3 client
+        if not self.session:
+            self.session = Session(**self.s3_session_kwargs)
+
+        self.client = self.session.client("s3", endpoint_url=self.endpoint_url)
+
+        try:
+            self.client.head_bucket(Bucket=self.bucket)
+        except ClientError:
+            raise RuntimeError(f"Bucket not present on AWS: {self.bucket}")
+
+        # load index
+        self._load_index()
+
+    def __hash__(self):
+        return hash((self.collection_name, self.bucket, self.prefix))
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Check equality for S3Store
+        other: other S3Store to compare with.
+        """
+        if not isinstance(other, S3IndexStore):
+            return False
+
+        fields = ["collection_name", "bucket", "prefix", "last_updated_field"]
+        return all(getattr(self, f) == getattr(other, f) for f in fields)
+
+
+class OpenDataStore(S3Store):
+    """
+    Data is stored on S3 compatible storage using the format used by Materials Project on OpenData.
+    The index is loaded from S3 compatible storage into memory.
+
+    Note that updates will only affect the in-memory representation of the index - they will not be persisted.
+    This Store should not be used for applications that are distributed and rely on reading updated
+    values from the index as data inconsistencied will arise.
+    """
+
+    def __init__(
+        self,
+        index: S3IndexStore,
+        object_file_extension: str = ".json.gz",
+        access_as_public_bucket: bool = False,
+        **kwargs,
+    ):
+        """
+        Initializes an OpenData S3 Store.
+        """
+        self.index = index
+        self.object_file_extension = object_file_extension
+        self.access_as_public_bucket = access_as_public_bucket
+        if access_as_public_bucket:
+            kwargs["s3_resource_kwargs"] = kwargs["s3_resource_kwargs"] if "s3_resource_kwargs" in kwargs else {}
+            kwargs["s3_resource_kwargs"]["config"] = Config(signature_version=UNSIGNED)
+
+        kwargs["index"] = index
+        kwargs["unpack_data"] = True
+        super().__init__(**kwargs)
+
+    def _get_full_key_path(self, id) -> str:
+        return f"{self.sub_dir}{id}{self.object_file_extension}"
+
+    def _get_id_from_full_key_path(self, key):
+        prefix, suffix = self.sub_dir, self.object_file_extension
+        if prefix in key and suffix in key:
+            start_idx = key.index(prefix) + len(prefix)
+            end_idx = key.index(suffix, start_idx)
+            return key[start_idx:end_idx]
+        return ""
+
+    def _get_compression_function(self):
+        return gzip.compress
+
+    def _get_decompression_function(self):
+        return gzip.decompress
+
+    def _read_data(self, data: bytes, compress_header: str = "gzip"):
+        if compress_header is not None:
+            data = self._get_decompression_function()(data)
+        return orjson.loads(data)
+
+    def _gather_indexable_data(self, doc: Dict, search_keys: List[str]):
+        index_doc = {k: doc[k] for k in search_keys}
+        index_doc[self.key] = doc[self.key]  # Ensure key is in metadata
+        # Ensure last updated field is in metada if it's present in the data
+        if self.last_updated_field in doc:
+            index_doc[self.last_updated_field] = doc[self.last_updated_field]
+        return index_doc
+
+    def write_doc_to_s3(self, doc: Dict, search_keys: List[str]):
+        """
+        Write the data to s3 and return the metadata to be inserted into the index db.
+
+        Args:
+            doc: the document
+            search_keys: list of keys to pull from the docs and be inserted into the
+            index db (these will be only added to the volatile index)
+        """
+        search_doc = self._gather_indexable_data(doc, search_keys)
+
+        data = orjson.dumps(doc, default=json_util.default)
+        data = self._get_compression_function()(data)
+        self._get_bucket().upload_fileobj(
+            Fileobj=BytesIO(data),
+            Key=self._get_full_key_path(str(doc[self.key])),
+        )
+        return search_doc
+
+    def _index_for_doc_from_s3(self, bucket, key):
+        response = bucket.Object(key).get()
+        doc = self._read_data(response["Body"].read())
+        return self._gather_indexable_data(doc, self.searchable_fields)
+
+    def rebuild_index_from_s3_data(self):
+        """
+        Rebuilds the index Store from the data in S3
+        Stores only the key and searchable fields in the index.
+        """
+        bucket = self._get_bucket()
+        paginator = bucket.meta.client.get_paginator("list_objects_v2")
+
+        # Create a PageIterator from the Paginator
+        page_iterator = paginator.paginate(Bucket=self.bucket, Prefix=self.sub_dir.strip("/"))
+
+        all_index_docs = []
+        for page in page_iterator:
+            for file in page["Contents"]:
+                key = file["Key"]
+                if key != self.index._get_full_key_path():
+                    index_doc = self._index_for_doc_from_s3(bucket, key)
+                    all_index_docs.append(index_doc)
+        self.index.store_manifest(all_index_docs)
+        return all_index_docs
+
+    def rebuild_index_from_data(self, docs):
+        """
+        Rebuilds the index Store from the provided data.
+        The provided data needs to include all of the documents in this data set.
+        Stores only the key and searchable fields in the index.
+        """
+        all_index_docs = []
+        for doc in docs:
+            index_doc = self._gather_indexable_data(doc, self.searchable_fields)
+            all_index_docs.append(index_doc)
+        self.index.store_manifest(all_index_docs)
+        return all_index_docs

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -69,9 +69,13 @@ class S3IndexStore(MemoryStore):
                 return []
             raise
 
-    def _load_index(self) -> None:
-        """Load the contents of the index stored in S3 into memory."""
-        super().connect()
+    def _load_index(self, force_reset: bool = False) -> None:
+        """Load the contents of the index stored in S3 into memory.
+
+        Args:
+            force_reset: whether to force a reset of the memory store prior to load
+        """
+        super().connect(force_reset=force_reset)
         super().update(self._retrieve_manifest())
 
     def store_manifest(self, data: List[Dict]) -> None:
@@ -90,9 +94,12 @@ class S3IndexStore(MemoryStore):
         super().connect(force_reset=True)
         super().update(data)
 
-    def connect(self):
+    def connect(self, force_reset: bool = False):
         """
         Sets up the S3 client and loads the contents of the index stored in S3 into memory.
+
+        Args:
+            force_reset: whether to force a reset of the memory store prior to load
         """
         # set up the S3 client
         if not self.session:
@@ -106,7 +113,7 @@ class S3IndexStore(MemoryStore):
             raise RuntimeError(f"Bucket not present on AWS: {self.bucket}")
 
         # load index
-        self._load_index()
+        self._load_index(force_reset=force_reset)
 
     def __hash__(self):
         return hash((self.collection_name, self.bucket, self.prefix))

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -77,6 +77,7 @@ class S3IndexStore(MemoryStore):
     def store_manifest(self, data: List[Dict]) -> None:
         """Stores the provided data into the index stored in S3.
         This overwrites and fully replaces all of the contents of the previous index stored in S3.
+        It also rewrites the memory index with the provided data.
 
         Args:
             data (List[Dict]): The data to store in the index.
@@ -86,6 +87,8 @@ class S3IndexStore(MemoryStore):
             Body=orjson.dumps(data, default=json_util.default),
             Key=self._get_full_key_path(),
         )
+        super().connect(force_reset=True)
+        super().update(data)
 
     def connect(self):
         """

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -157,7 +157,7 @@ def test_rebuild_index_from_s3_data(s3store):
     assert len(index_docs) == 3
     for doc in index_docs:
         for key in doc.keys():
-            assert key == "task_id"
+            assert key == "task_id" or key == "last_updated"
 
 
 def tests_msonable_read_write(s3store):

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -1,0 +1,334 @@
+import time
+from datetime import datetime
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from maggma.stores import MemoryStore
+from maggma.stores.open_data import OpenDataStore, S3IndexStore
+from moto import mock_s3
+
+
+@pytest.fixture()
+def memstore():
+    store = MemoryStore("maggma_test", key="task_id")
+    store.connect()
+    yield store
+    store._collection.drop()
+
+
+@pytest.fixture()
+def s3store():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+
+        index = S3IndexStore(collection_name="index", bucket="bucket1", key="task_id")
+        store = OpenDataStore(index=index, bucket="bucket1", key="task_id")
+        store.connect()
+
+        store.update(
+            [
+                {
+                    "task_id": "mp-1",
+                    "data": "asd",
+                    store.last_updated_field: datetime.utcnow(),
+                }
+            ]
+        )
+        store.update(
+            [
+                {
+                    "task_id": "mp-3",
+                    "data": "sdf",
+                    store.last_updated_field: datetime.utcnow(),
+                }
+            ]
+        )
+
+        yield store
+
+
+@pytest.fixture()
+def s3store_w_subdir():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+
+        index = MemoryStore("index")
+        store = OpenDataStore(index=index, bucket="bucket1", sub_dir="subdir1", s3_workers=1)
+        store.connect()
+
+        yield store
+
+
+@pytest.fixture()
+def s3store_multi():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+
+        index = MemoryStore("index")
+        store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4)
+        store.connect()
+
+        yield store
+
+
+def test_keys():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+        index = MemoryStore("index", key=1)
+        with pytest.raises(AssertionError, match=r"Since we are.*"):
+            store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4, key=1)
+        index = MemoryStore("index", key="key1")
+        with pytest.warns(UserWarning, match=r"The desired S3Store.*$"):
+            store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4, key="key2")
+        store.connect()
+        store.update({"key1": "mp-1", "data": "1234"})
+        with pytest.raises(KeyError):
+            store.update({"key2": "mp-2", "data": "1234"})
+        assert store.key == store.index.key == "key1"
+
+
+def test_multi_update(s3store, s3store_multi):
+    data = [
+        {
+            "task_id": str(j),
+            "data": "DATA",
+            s3store_multi.last_updated_field: datetime.utcnow(),
+        }
+        for j in range(32)
+    ]
+
+    def fake_writing(doc, search_keys):
+        time.sleep(0.20)
+        return {k: doc[k] for k in search_keys}
+
+    s3store.write_doc_to_s3 = fake_writing
+    s3store_multi.write_doc_to_s3 = fake_writing
+
+    start = time.time()
+    s3store_multi.update(data, key=["task_id"])
+    end = time.time()
+    time_multi = end - start
+
+    start = time.time()
+    s3store.update(data, key=["task_id"])
+    end = time.time()
+    time_single = end - start
+    assert time_single > time_multi * (s3store_multi.s3_workers - 1) / (s3store.s3_workers)
+
+
+def test_count(s3store):
+    assert s3store.count() == 2
+    assert s3store.count({"task_id": "mp-3"}) == 1
+
+
+def test_qeuery(s3store):
+    assert s3store.query_one(criteria={"task_id": "mp-2"}) is None
+    assert s3store.query_one(criteria={"task_id": "mp-1"})["data"] == "asd"
+    assert s3store.query_one(criteria={"task_id": "mp-3"})["data"] == "sdf"
+
+    assert len(list(s3store.query())) == 2
+
+
+def test_update(s3store):
+    s3store.update(
+        [
+            {
+                "task_id": "mp-199999",
+                "data": "asd",
+                s3store.last_updated_field: datetime.utcnow(),
+            }
+        ]
+    )
+    assert s3store.query_one({"task_id": "mp-199999"}) is not None
+
+    s3store.update([{"task_id": "mp-4", "data": "asd"}])
+    assert s3store.query_one({"task_id": "mp-4"})["data"] == "asd"
+    assert s3store.s3_bucket.Object(s3store._get_full_key_path("mp-4")).key == "mp-4.json.gz"
+
+
+def test_rebuild_index_from_s3_data(s3store):
+    s3store.update([{"task_id": "mp-2", "data": "asd"}])
+    index_docs = s3store.rebuild_index_from_s3_data()
+    assert len(index_docs) == 3
+    for doc in index_docs:
+        for key in doc.keys():
+            assert key == "task_id"
+
+
+def tests_msonable_read_write(s3store):
+    dd = s3store.as_dict()
+    s3store.update([{"task_id": "mp-2", "data": dd}])
+    res = s3store.query_one({"task_id": "mp-2"})
+    assert res["data"]["@module"] == "maggma.stores.open_data"
+
+
+def test_remove(s3store):
+    def objects_in_bucket(key):
+        objs = list(s3store.s3_bucket.objects.filter(Prefix=key))
+        return key in [o.key for o in objs]
+
+    s3store.update([{"task_id": "mp-2", "data": "asd"}])
+    s3store.update([{"task_id": "mp-4", "data": "asd"}])
+    s3store.update({"task_id": "mp-5", "data": "aaa"})
+    assert s3store.query_one({"task_id": "mp-2"}) is not None
+    assert s3store.query_one({"task_id": "mp-4"}) is not None
+    assert objects_in_bucket("mp-2.json.gz")
+    assert objects_in_bucket("mp-4.json.gz")
+
+    s3store.remove_docs({"task_id": "mp-2"})
+    s3store.remove_docs({"task_id": "mp-4"}, remove_s3_object=True)
+
+    assert objects_in_bucket("mp-2.json.gz")
+    assert not objects_in_bucket("mp-4.json.gz")
+
+    assert s3store.query_one({"task_id": "mp-5"}) is not None
+
+
+def test_close(s3store):
+    list(s3store.query())
+    s3store.close()
+    with pytest.raises(AttributeError):
+        list(s3store.query())
+
+
+def test_bad_import(mocker):
+    mocker.patch("maggma.stores.aws.boto3", None)
+    index = MemoryStore("index")
+    with pytest.raises(RuntimeError):
+        OpenDataStore(index=index, bucket="bucket1")
+
+
+def test_aws_error(s3store):
+    def raise_exception_NoSuchKey(data):
+        error_response = {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}}
+        raise ClientError(error_response, "raise_exception")
+
+    def raise_exception_other(data):
+        error_response = {"Error": {"Code": 405}}
+        raise ClientError(error_response, "raise_exception")
+
+    s3store.s3_bucket.Object = raise_exception_other
+    with pytest.raises(ClientError):
+        s3store.query_one()
+
+    # Should just pass
+    s3store.s3_bucket.Object = raise_exception_NoSuchKey
+    s3store.query_one()
+
+
+def test_eq(memstore, s3store):
+    assert s3store == s3store
+    assert memstore != s3store
+
+
+def test_count_subdir(s3store_w_subdir):
+    s3store_w_subdir.update([{"task_id": "mp-1", "data": "asd"}])
+    s3store_w_subdir.update([{"task_id": "mp-2", "data": "asd"}])
+
+    assert s3store_w_subdir.count() == 2
+    assert s3store_w_subdir.count({"task_id": "mp-2"}) == 1
+
+
+def test_subdir_storage(s3store_w_subdir):
+    def objects_in_bucket(key):
+        objs = list(s3store_w_subdir.s3_bucket.objects.filter(Prefix=key))
+        return key in [o.key for o in objs]
+
+    s3store_w_subdir.update([{"task_id": "mp-1", "data": "asd"}])
+    s3store_w_subdir.update([{"task_id": "mp-2", "data": "asd"}])
+
+    assert objects_in_bucket("subdir1/mp-1.json.gz")
+    assert objects_in_bucket("subdir1/mp-2.json.gz")
+
+
+def test_remove_subdir(s3store_w_subdir):
+    s3store_w_subdir.update([{"task_id": "mp-2", "data": "asd"}])
+    s3store_w_subdir.update([{"task_id": "mp-4", "data": "asd"}])
+
+    assert s3store_w_subdir.query_one({"task_id": "mp-2"}) is not None
+    assert s3store_w_subdir.query_one({"task_id": "mp-4"}) is not None
+
+    s3store_w_subdir.remove_docs({"task_id": "mp-2"})
+
+    assert s3store_w_subdir.query_one({"task_id": "mp-2"}) is None
+    assert s3store_w_subdir.query_one({"task_id": "mp-4"}) is not None
+
+
+def test_searchable_fields(s3store):
+    tic = datetime(2018, 4, 12, 16)
+
+    data = [{"task_id": f"mp-{i}", "a": i, s3store.last_updated_field: tic} for i in range(4)]
+
+    s3store.searchable_fields = ["task_id"]
+    s3store.update(data, key="a")
+
+    # This should only work if the searchable field was put into the index store
+    assert set(s3store.distinct("task_id")) == {"mp-0", "mp-1", "mp-2", "mp-3"}
+
+
+def test_newer_in(s3store):
+    with mock_s3():
+        tic = datetime(2018, 4, 12, 16)
+        tic2 = datetime.utcnow()
+        conn = boto3.client("s3")
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket")
+
+        index_old = S3IndexStore(collection_name="index_old", bucket="bucket")
+        old_store = OpenDataStore(index=index_old, bucket="bucket")
+        old_store.connect()
+        old_store.update([{"task_id": "mp-1", "last_updated": tic}])
+        old_store.update([{"task_id": "mp-2", "last_updated": tic}])
+
+        index_new = S3IndexStore(collection_name="index_new", bucket="bucket", prefix="new")
+        new_store = OpenDataStore(index=index_new, bucket="bucket", sub_dir="new")
+        new_store.connect()
+        new_store.update([{"task_id": "mp-1", "last_updated": tic2}])
+        new_store.update([{"task_id": "mp-2", "last_updated": tic2}])
+
+        assert len(old_store.newer_in(new_store)) == 2
+        assert len(new_store.newer_in(old_store)) == 0
+
+        assert len(old_store.newer_in(new_store.index)) == 2
+        assert len(new_store.newer_in(old_store.index)) == 0
+
+
+def test_additional_metadata(s3store):
+    tic = datetime(2018, 4, 12, 16)
+
+    data = [{"task_id": f"mp-{i}", "a": i, s3store.last_updated_field: tic} for i in range(4)]
+
+    s3store.update(data, key="a", additional_metadata="task_id")
+
+    # This should only work if the searchable field was put into the index store
+    assert set(s3store.distinct("task_id")) == {"mp-0", "mp-1", "mp-2", "mp-3"}
+
+
+def test_get_session(s3store):
+    index = MemoryStore("index")
+    store = OpenDataStore(
+        index=index,
+        bucket="bucket1",
+        s3_profile={
+            "aws_access_key_id": "ACCESS_KEY",
+            "aws_secret_access_key": "SECRET_KEY",
+        },
+    )
+    assert store._get_session().get_credentials().access_key == "ACCESS_KEY"
+    assert store._get_session().get_credentials().secret_key == "SECRET_KEY"
+
+
+def test_no_bucket():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+
+        index = MemoryStore("index")
+        store = OpenDataStore(index=index, bucket="bucket2")
+        with pytest.raises(RuntimeError, match=r".*Bucket not present.*"):
+            store.connect()


### PR DESCRIPTION
## Summary

Major changes:

- add S3IndexStore: a store that loads the index of the collection from an S3 file.
- add OpenDataStore: a store whose data is stored on S3 compatible storage using the format used by Materials Project on OpenData. It utilizes an index that is loaded from S3 compatible storage into memory (S3IndexStore).
- refactor of S3Store to make it extensible, ie allow OpenDataStore to build on top of it

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
