### PR TITLE
fixing OpenDataStore to pickle correctly

### DIFF
--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -284,12 +284,10 @@ class OpenDataStore(S3Store):
     def __hash__(self):
         return hash(
             (
-                self.index.__hash__,
                 self.bucket,
                 self.compress,
                 self.endpoint_url,
                 self.key,
-                self.searchable_fields,
                 self.sub_dir,
             )
         )

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime
 
+import pickle
 import boto3
 import pytest
 import orjson
@@ -397,3 +398,12 @@ def test_no_bucket():
         store = OpenDataStore(index=index, bucket="bucket2")
         with pytest.raises(RuntimeError, match=r".*Bucket not present.*"):
             store.connect()
+
+
+def test_pickle(s3store_w_subdir):
+    sobj = pickle.dumps(s3store_w_subdir.index)
+    dobj = pickle.loads(sobj)
+    assert dobj == s3store_w_subdir.index
+    sobj = pickle.dumps(s3store_w_subdir)
+    dobj = pickle.loads(sobj)
+    assert dobj == s3store_w_subdir

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -289,7 +289,7 @@ def test_aws_error(s3store):
 
 def test_eq(memstore, s3store):
     assert s3store == s3store
-    assert memstore != s3store
+    assert s3store != memstore
 
 
 def test_count_subdir(s3store_w_subdir):
@@ -403,7 +403,9 @@ def test_no_bucket():
 def test_pickle(s3store_w_subdir):
     sobj = pickle.dumps(s3store_w_subdir.index)
     dobj = pickle.loads(sobj)
+    assert hash(dobj) == hash(s3store_w_subdir.index)
     assert dobj == s3store_w_subdir.index
     sobj = pickle.dumps(s3store_w_subdir)
     dobj = pickle.loads(sobj)
+    assert hash(dobj) == hash(s3store_w_subdir)
     assert dobj == s3store_w_subdir


### PR DESCRIPTION
## Summary

OpenDataStore was erroring out on the load part of pickling. It was not originally implemented with the Store framework approach to pickle in mind. Modified it to work correctly within the Store framework.

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
