### PR TITLE
Patch s3 kwarg

### DIFF
--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -80,13 +80,13 @@ class S3Store(Store):
         """
         if boto3 is None:
             raise RuntimeError("boto3 and botocore are required for S3Store")
-        if index_store_kwargs is not None:
+        self.index_store_kwargs = index_store_kwargs or {}
+        if index_store_kwargs:
             d_ = index.as_dict()
             d_.update(index_store_kwargs)
             self.index = index.__class__.from_dict(d_)
         else:
             self.index = index
-
         self.bucket = bucket
         self.s3_profile = s3_profile
         self.compress = compress

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -48,6 +48,7 @@ class S3Store(Store):
         store_hash: bool = True,
         unpack_data: bool = True,
         searchable_fields: Optional[List[str]] = None,
+        index_store_kwargs: Optional[dict] = None,
         **kwargs,
     ):
         """
@@ -74,10 +75,17 @@ class S3Store(Store):
             unpack_data: whether to decompress and unpack byte data when querying from
                 the bucket.
             searchable_fields: fields to keep in the index store.
+            index_store_kwargs: kwargs to pass to the index store. Allows the user to 
+                use kwargs here to update the index store.
         """
         if boto3 is None:
             raise RuntimeError("boto3 and botocore are required for S3Store")
-        self.index = index
+        if index_store_kwargs is not None:
+            d_ = index.as_dict()
+            d_.update(index_store_kwargs)
+            self.index = index.__class__.from_dict(d_)
+        else:
+            self.index = index
 
         self.bucket = bucket
         self.s3_profile = s3_profile

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -75,7 +75,7 @@ class S3Store(Store):
             unpack_data: whether to decompress and unpack byte data when querying from
                 the bucket.
             searchable_fields: fields to keep in the index store.
-            index_store_kwargs: kwargs to pass to the index store. Allows the user to 
+            index_store_kwargs: kwargs to pass to the index store. Allows the user to
                 use kwargs here to update the index store.
         """
         if boto3 is None:
@@ -369,9 +369,8 @@ class S3Store(Store):
     def _get_endpoint_url(self):
         if self.ssh_tunnel is None:
             return self.endpoint_url
-        else:
-            host, port = self.ssh_tunnel.local_address
-            return f"http://{host}:{port}"
+        host, port = self.ssh_tunnel.local_address
+        return f"http://{host}:{port}"
 
     def _get_bucket(self):
         """If on the main thread return the bucket created above, else create a new
@@ -393,7 +392,7 @@ class S3Store(Store):
         try:
             resource.meta.client.head_bucket(Bucket=self.bucket)
         except ClientError:
-            raise RuntimeError(f"Bucket not present on AWS")
+            raise RuntimeError("Bucket not present on AWS")
         bucket = resource.Bucket(self.bucket)
 
         return resource, bucket

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -169,7 +169,6 @@ class OpenDataStore(S3Store):
             access_as_public_bucket (bool, optional): If True, the S3 bucket will be accessed without signing, ie as if it's a public bucket.
                 This is useful for end users. Defaults to False.
         """
-        self.index = index
         self.bucket = bucket
         self.compress = compress
         self.endpoint_url = endpoint_url
@@ -190,7 +189,7 @@ class OpenDataStore(S3Store):
         kwargs["key"] = key
         kwargs["searchable_fields"] = searchable_fields
         kwargs["unpack_data"] = True
-        super().__init__(**kwargs)
+        super().__init__(index=index, **kwargs)
 
     def _get_full_key_path(self, id: str) -> str:
         return f"{self.sub_dir}{id}{self.object_file_extension}"

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -166,14 +166,11 @@ class OpenDataStore(S3Store):
             key: main key to index on.
             searchable_fields: fields to keep in the index store.
             object_file_extension (str, optional): The extension used for the data stored in S3. Defaults to ".json.gz".
-            access_as_public_bucket (bool, optional): If True, the S3 bucket will be accessed without signing, ie as if it's a public bucket.
+            access_as_public_bucket (bool, optional): If True, the S3 bucket will be accessed without signing,
+            ie as if it's a public bucket.
                 This is useful for end users. Defaults to False.
         """
-        self.bucket = bucket
-        self.compress = compress
-        self.endpoint_url = endpoint_url
         self.sub_dir = sub_dir.strip("/") + "/" if sub_dir else ""
-        self.key = key
         self.searchable_fields = searchable_fields if searchable_fields is not None else []
         self.object_file_extension = object_file_extension
         self.access_as_public_bucket = access_as_public_bucket
@@ -189,7 +186,7 @@ class OpenDataStore(S3Store):
         kwargs["key"] = key
         kwargs["searchable_fields"] = searchable_fields
         kwargs["unpack_data"] = True
-        super().__init__(index=index, **kwargs)
+        super().__init__(**kwargs)
 
     def _get_full_key_path(self, id: str) -> str:
         return f"{self.sub_dir}{id}{self.object_file_extension}"

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -4,10 +4,11 @@ from datetime import datetime
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from maggma.stores import MemoryStore, MongoStore, S3Store
-from maggma.stores.ssh_tunnel import SSHTunnel
 from moto import mock_s3
 from sshtunnel import BaseSSHTunnelForwarderError
+
+from maggma.stores import MemoryStore, MongoStore, S3Store
+from maggma.stores.ssh_tunnel import SSHTunnel
 
 
 @pytest.fixture()
@@ -444,6 +445,7 @@ def test_ssh_tunnel_2():
             yield store
 
     get_store()
+
 
 def test_index_store_kwargs(mongostore):
     index = MongoStore("db", collection_name="index", key="task_id")

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -444,3 +444,8 @@ def test_ssh_tunnel_2():
             yield store
 
     get_store()
+
+def test_index_store_kwargs(mongostore):
+    index = MongoStore("db", collection_name="index", key="task_id")
+    store = S3Store(index, "bucket1", key="task_id", index_store_kwargs={"port": 12345})
+    assert store.index.port == 12345


### PR DESCRIPTION
## Allow the Indexstore in S3 to be updated through Kwargs

Some programs like atomate1 uses the Kwargs for s3 during the configuration for the store.
As such there is no easy way to pass lesser used kwargs like ssl setting to the index store.
This gives a option for user to do that.


Also removed some of re-definitions of kwargs in the open data object that should just be piped to the S3Store parent class that was caught by codeQL