### PR TITLE
special casing for thermo, xas and synth_descriptions collections in OpenData

### DIFF
--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -196,13 +196,12 @@ class OpenDataStore(S3Store):
         if self.index.collection_name == "thermo" and self.key == "thermo_id":
             material_id, thermo_type = id.split("_", 1)
             return f"{self.sub_dir}{thermo_type}/{material_id}{self.object_file_extension}"
-        elif self.index.collection_name == "xas" and self.key == "spectrum_id":
+        if self.index.collection_name == "xas" and self.key == "spectrum_id":
             material_id, spectrum_type, absorbing_element, edge = id.rsplit("-", 3)
             return f"{self.sub_dir}{edge}/{spectrum_type}/{absorbing_element}/{material_id}{self.object_file_extension}"
-        elif self.index.collection_name == "synth_descriptions" and self.key == "doi":
+        if self.index.collection_name == "synth_descriptions" and self.key == "doi":
             return f"{self.sub_dir}{id.replace('/', '_')}{self.object_file_extension}"
-        else:
-            return f"{self.sub_dir}{id}{self.object_file_extension}"
+        return f"{self.sub_dir}{id}{self.object_file_extension}"
 
     def _get_compression_function(self) -> Callable:
         return gzip.compress


### PR DESCRIPTION
## Summary

Adding special casing for thermo, xas and synth_descriptions collections in OpenData.

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
