### PR TITLE
rm deprecated pkg_resources

### DIFF
--- a/src/maggma/__init__.py
+++ b/src/maggma/__init__.py
@@ -1,8 +1,8 @@
 """ Primary Maggma module """
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: no cover
+    __version__ = version('maggma')
+except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     pass

--- a/src/maggma/__init__.py
+++ b/src/maggma/__init__.py
@@ -1,8 +1,8 @@
-""" Primary Maggma module """
-from importlib.metadata import version, PackageNotFoundError
+"""Primary Maggma module."""
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version('maggma')
+    __version__ = version("maggma")
 except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     pass


### PR DESCRIPTION
Remove deprecated `pkg_resources` in favor of `importlib`

Closes #903 