### PR TITLE
creating PandasMemoryStore for use by OpenDataStore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "montydb": ["montydb>=2.3.12"],
         "notebook_runner": ["IPython>=8.11", "nbformat>=5.0", "regex>=2020.6"],
         "azure": ["azure-storage-blob>=12.16.0", "azure-identity>=1.12.0"],
+        "open_data": ["pandas>=2.1.4"],
         "testing": [
             "pytest",
             "pytest-cov",

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -1,17 +1,17 @@
 import gzip
+from datetime import datetime
 from io import BytesIO
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import orjson
+import pandas as pd
 from boto3 import Session
 from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from bson import json_util
-from datetime import datetime
-import pandas as pd
-from maggma.core.store import Sort, Store
 
+from maggma.core.store import Sort, Store
 from maggma.stores.aws import S3Store
 
 
@@ -44,7 +44,7 @@ class PandasMemoryStore(Store):
         """
         Return a string representing this data source
         """
-        return f"imem://"
+        return "imem://"
 
     def connect(self, force_reset: bool = False):
         """
@@ -54,14 +54,14 @@ class PandasMemoryStore(Store):
         Args:
             force_reset: whether to reset the connection or not
         """
-        pass
+        return
 
     def close(self):
         """
         Closes any connections
         Not necessary for this type of store but here for compatibility.
         """
-        pass
+        return
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
@@ -259,8 +259,7 @@ class PandasMemoryStore(Store):
         """
         criteria = criteria or {}
 
-        results = [key for key, _ in self.groupby(field, properties=[field], criteria=criteria)]
-        return results
+        return [key for key, _ in self.groupby(field, properties=[field], criteria=criteria)]
 
     def groupby(
         self,

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -1,6 +1,6 @@
 import gzip
 from io import BytesIO
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import orjson
 from boto3 import Session
@@ -8,12 +8,318 @@ from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from bson import json_util
+from datetime import datetime
+import pandas as pd
+from maggma.core.store import Sort, Store
 
 from maggma.stores.aws import S3Store
-from maggma.stores.mongolike import MemoryStore
 
 
-class S3IndexStore(MemoryStore):
+class PandasMemoryStore(Store):
+    """
+    A store that is backed by Pandas DataFrame.
+
+    """
+
+    def __init__(
+        self,
+        **kwargs,
+    ):
+        self._data = None
+        self.kwargs = kwargs
+        super().__init__(**kwargs)
+
+    @property
+    def _collection(self):
+        """
+        Returns a handle to the pymongo collection object
+
+        Raises:
+            NotImplementedError: always as this concept does not make sense for this type of store
+        """
+        raise NotImplementedError("Index memory store cannot be used with this property")
+
+    @property
+    def name(self) -> str:
+        """
+        Return a string representing this data source
+        """
+        return f"imem://"
+
+    def connect(self, force_reset: bool = False):
+        """
+        Connect to the source data.
+        Not necessary for this type of store but here for compatibility.
+
+        Args:
+            force_reset: whether to reset the connection or not
+        """
+        pass
+
+    def close(self):
+        """
+        Closes any connections
+        Not necessary for this type of store but here for compatibility.
+        """
+        pass
+
+    def count(self, criteria: Optional[Dict] = None) -> int:
+        """
+        Counts the number of documents matching the query criteria
+
+        Returns:
+            int: the number of documents matching the query criteria
+
+        Args:
+            criteria: the value of the `query` key will be used as the string expression to filter;
+                NotImplmentedError will be thrown if it's not None and this key/value pair does not exist
+        """
+        query_string = None
+        if criteria and "query" not in criteria:
+            raise NotImplementedError("Pandas memory store cannot handle PyMongo filters")
+        if criteria:
+            query_string = criteria["query"]
+
+        if self._data is None:
+            return 0
+        if query_string is None:
+            return len(self._data)
+        return len(self._data.query(query_string))
+
+    def _query(
+        self,
+        criteria: Optional[Dict] = None,
+        properties: Union[Dict, List, None] = None,
+        sort: Optional[Dict[str, Union[Sort, int]]] = None,
+        skip: int = 0,
+        limit: int = 0,
+    ) -> pd.DataFrame:
+        query_string = ""
+        if criteria and "query" not in criteria:
+            raise AttributeError("Pandas memory store cannot handle PyMongo filters")
+        if criteria:
+            query_string = criteria["query"]
+
+        if isinstance(properties, dict):
+            properties = [key for key, value in properties.items() if value == 1]
+
+        if self._data is None:
+            return iter([])
+
+        ret = self._data
+
+        if query_string:
+            ret = ret.query(query_string)
+
+        if properties:
+            ret = ret[properties]
+
+        if sort:
+            sort_keys, sort_ascending = zip(*[(k, v == 1) for k, v in sort.items()])
+            ret = ret.sort_values(by=list(sort_keys), ascending=list(sort_ascending))
+
+        ret = ret[skip:]
+        if limit > 0:
+            ret = ret[:limit]
+        return ret
+
+    def query(
+        self,
+        criteria: Optional[Dict] = None,
+        properties: Union[Dict, List, None] = None,
+        sort: Optional[Dict[str, Union[Sort, int]]] = None,
+        skip: int = 0,
+        limit: int = 0,
+    ) -> Iterator[Dict]:
+        """
+        Queries the Store for a set of documents
+
+        Args:
+            criteria: the value of the `query` key will be used as the Pandas string expression to query with;
+                all other data will be ignored
+            properties: properties to return in grouped documents
+            sort: Dictionary of sort order for fields. Keys are field names and
+                values are 1 for ascending or -1 for descending.
+            skip: number documents to skip (from the start of the result set)
+            limit: limit on total number of documents returned
+
+        Returns:
+            Iterator[Dict]: an iterator over the documents that match the query paramaters
+
+        Raises:
+            AttributeError: if criteria exists and does not include a query key
+        """
+        ret = self._query(criteria=criteria, properties=properties, sort=sort, skip=skip, limit=limit)
+        return (row.to_dict() for _, row in ret.iterrows())
+
+    def update(self, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None, clear_first: bool = False):
+        """
+        Update documents into the Store
+
+        Args:
+            docs: the document or list of documents to update
+            key: field name(s) to determine uniqueness for a
+                 document, can be a list of multiple fields,
+                 a single field, or None if the Store's key
+                 field is to be used
+            clear_first: if True clears the underlying data first, fully replacing the data with docs;
+                if False performs an upsert based on the parameters
+        """
+        df = pd.DataFrame(docs)
+        if self._data is None or clear_first:
+            if not df.empty:
+                self._data = df
+            return
+
+        if key is None:
+            key = self.key
+
+        merged = self._data.merge(df, on=key, how="left", suffixes=("", "_B"))
+        for column in df.columns:
+            if column not in key:
+                merged[column] = merged[column + "_B"].combine_first(merged[column])
+        merged = merged[self._data.columns]
+        non_matching = df[~df.set_index(key).index.isin(self._data.set_index(key).index)]
+        self._data = pd.concat([merged, non_matching], ignore_index=True)
+
+    def ensure_index(self, key: str, unique: bool = False) -> bool:
+        """
+        Tries to create an index and return true if it succeeded
+
+        Raises:
+            NotImplementedError: always as this concept does not make sense for this type of store
+        """
+        raise NotImplementedError("Pandas memory store does not support this function")
+
+    def _field_exists(self, key: str) -> bool:
+        return key in self._data
+
+    def newer_in(self, target: "Store", criteria: Optional[Dict] = None, exhaustive: bool = False) -> List[str]:
+        """
+        Returns the keys of documents that are newer in the target
+        Store than this Store.
+
+        Args:
+            target: target Store to compare with
+            criteria: the value of the `query` key will be used as the Pandas string expression to query with;
+                all other data will be ignored; only valid when exhaustive is True
+            exhaustive: triggers an item-by-item check vs. checking
+                        the last_updated of the target Store and using
+                        that to filter out new items in
+
+        Returns:
+            List[str]: if no criteria is provided a list of the keys of documents in the target store
+                whose last updated field value is greater than the 'newest' document in this store;
+                otherwise a list of the keys of documents in the target store that additionally meet the criteria
+
+        Raises:
+            AttributeError: if the key and last updated fields are not both present in this store or
+                if criteria is provided when exhaustive is not set to True
+        """
+        if not (self._field_exists(self.key) and self._field_exists(self.last_updated_field)):
+            raise AttributeError("This index store does not contain data with both key and last updated fields")
+
+        if criteria is not None and not exhaustive:
+            raise AttributeError("Criteria is only considered when doing an item-by-item check")
+
+        if exhaustive:
+            # Get our current last_updated dates for each key value
+            props = {self.key: 1, self.last_updated_field: 1, "_id": 0}
+            dates = {
+                d[self.key]: self._lu_func[0](d.get(self.last_updated_field, datetime.max))
+                for d in self.query(properties=props)
+            }
+
+            # Get the last_updated for the store we're comparing with
+            props = {target.key: 1, target.last_updated_field: 1, "_id": 0}
+            target_dates = {
+                d[target.key]: target._lu_func[0](d.get(target.last_updated_field, datetime.min))
+                for d in target.query(criteria=criteria, properties=props)
+            }
+
+            new_keys = set(target_dates.keys()) - set(dates.keys())
+            updated_keys = {key for key, date in dates.items() if target_dates.get(key, datetime.min) > date}
+
+            return list(new_keys | updated_keys)
+
+        criteria = {"query": f"{self.last_updated_field} > '{self._lu_func[1](self.last_updated)}'"}
+        return target.distinct(field=self.key, criteria=criteria)
+
+    def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
+        """
+        Get all distinct values for a field
+
+        Args:
+            field: the field(s) to get distinct values for
+            criteria: the value of the `query` key will be used as the Pandas string expression to query with;
+                all other data will be ignored
+
+        Returns:
+            List: a list of all the distinct values for the provided field (after filtering by the provided criteria)
+        """
+        criteria = criteria or {}
+
+        results = [key for key, _ in self.groupby(field, properties=[field], criteria=criteria)]
+        return results
+
+    def groupby(
+        self,
+        keys: Union[List[str], str],
+        criteria: Optional[Dict] = None,
+        properties: Union[Dict, List, None] = None,
+        sort: Optional[Dict[str, Union[Sort, int]]] = None,
+        skip: int = 0,
+        limit: int = 0,
+    ) -> Iterator[Tuple[Dict, List[Dict]]]:
+        """
+        Simple grouping function that will group documents
+        by keys.
+
+        Args:
+            keys: fields to group documents
+            criteria: PyMongo filter for documents to search in
+            properties: properties to return in grouped documents
+            sort: Dictionary of sort order for fields. Keys are field names and
+                values are 1 for ascending or -1 for descending.
+            skip: number documents to skip
+            limit: limit on total number of documents returned
+
+        Returns:
+            Iterator[Tuple[Dict, List[Dict]]]: iterator returning tuples of (dict, list of docs)
+        """
+        ret = self._query(criteria=criteria, properties=properties, sort=sort, skip=skip, limit=limit)
+        grouped_tuples = [(name, group) for name, group in ret.groupby(keys)]
+        return iter(grouped_tuples)
+
+    def remove_docs(self, criteria: Dict):
+        """
+        Remove docs matching the query dictionary
+
+        Args:
+            criteria: query dictionary to match
+
+        Raises:
+            NotImplementedError: always as this concept is not used
+        """
+        raise NotImplementedError("Not implemented for this store")
+
+    def __hash__(self):
+        """Hash for the store"""
+        return hash((self.key, self.last_updated_field))
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Check equality for PandasMemoryStore
+        other: other PandasMemoryStore to compare with
+        """
+        if not isinstance(other, PandasMemoryStore):
+            return False
+
+        fields = ["key", "last_updated_field"]
+        return all(getattr(self, f) == getattr(other, f) for f in fields)
+
+
+class S3IndexStore(PandasMemoryStore):
     """
     A store that loads the index of the collection from an S3 file.
 
@@ -50,15 +356,15 @@ class S3IndexStore(MemoryStore):
         self.session: Any = None
         self.s3_session_kwargs = {}
         self.manifest_key = manifest_key
+        self.kwargs = kwargs
 
-        kwargs["collection_name"] = collection_name
         super().__init__(**kwargs)
 
     def _get_full_key_path(self) -> str:
         """Produces the full path for the index."""
         return f"{self.prefix}{self.manifest_key}"
 
-    def _retrieve_manifest(self) -> List[Dict]:
+    def _retrieve_manifest(self) -> pd.DataFrame:
         """Retrieves the contents of the index stored in S3.
 
         Returns:
@@ -66,8 +372,7 @@ class S3IndexStore(MemoryStore):
         """
         try:
             response = self.client.get_object(Bucket=self.bucket, Key=self._get_full_key_path())
-            json_data = orjson.loads(response["Body"].read().decode("utf-8"))
-            return json_data if isinstance(json_data, list) else [json_data]
+            return pd.read_json(response["Body"], orient="records")
         except ClientError as ex:
             if ex.response["Error"]["Code"] == "NoSuchKey":
                 return []
@@ -79,8 +384,7 @@ class S3IndexStore(MemoryStore):
         Args:
             force_reset: whether to force a reset of the memory store prior to load
         """
-        super().connect(force_reset=force_reset)
-        super().update(self._retrieve_manifest())
+        super().update(self._retrieve_manifest(), clear_first=True)
 
     def store_manifest(self, data: List[Dict]) -> None:
         """Stores the provided data into the index stored in S3.
@@ -95,8 +399,7 @@ class S3IndexStore(MemoryStore):
             Body=orjson.dumps(data, default=json_util.default),
             Key=self._get_full_key_path(),
         )
-        super().connect(force_reset=True)
-        super().update(data)
+        super().update(data, clear_first=True)
 
     def connect(self, force_reset: bool = False):
         """
@@ -190,6 +493,7 @@ class OpenDataStore(S3Store):
         kwargs["key"] = key
         kwargs["searchable_fields"] = searchable_fields
         kwargs["unpack_data"] = True
+        self.kwargs = kwargs
         super().__init__(**kwargs)
 
     def _get_full_key_path(self, id: str) -> str:

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -26,7 +26,6 @@ class PandasMemoryStore(Store):
         **kwargs,
     ):
         self._data = None
-        self.kwargs = kwargs
         super().__init__(**kwargs)
 
     @property
@@ -144,7 +143,7 @@ class PandasMemoryStore(Store):
             limit: limit on total number of documents returned
 
         Returns:
-            Iterator[Dict]: an iterator over the documents that match the query paramaters
+            Iterator[Dict]: an iterator over the documents that match the query parameters
 
         Raises:
             AttributeError: if criteria exists and does not include a query key

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -275,7 +275,9 @@ class PandasMemoryStore(Store):
 
         Args:
             keys: fields to group documents
-            criteria: PyMongo filter for documents to search in
+            criteria: the value of the `query` key will be used as the
+                Pandas string expression to query with;
+                all other data will be ignored
             properties: properties to return in grouped documents
             sort: Dictionary of sort order for fields. Keys are field names and
                 values are 1 for ascending or -1 for descending.

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -9,16 +9,14 @@ from botocore.exceptions import ClientError
 from bson import json_util
 from moto import mock_s3
 
-from maggma.stores.open_data import PandasMemoryStore, OpenDataStore, S3IndexStore
-
-import pandas as pd
+from maggma.stores.open_data import OpenDataStore, PandasMemoryStore, S3IndexStore
 
 
 @pytest.fixture()
 def memstore():
     store = PandasMemoryStore(key="task_id")
     store.connect()
-    yield store
+    return store
 
 
 @pytest.fixture()

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -9,16 +9,16 @@ from botocore.exceptions import ClientError
 from bson import json_util
 from moto import mock_s3
 
-from maggma.stores import MemoryStore
-from maggma.stores.open_data import OpenDataStore, S3IndexStore
+from maggma.stores.open_data import PandasMemoryStore, OpenDataStore, S3IndexStore
+
+import pandas as pd
 
 
 @pytest.fixture()
 def memstore():
-    store = MemoryStore("maggma_test", key="task_id")
+    store = PandasMemoryStore(key="task_id")
     store.connect()
     yield store
-    store._collection.drop()
 
 
 @pytest.fixture()
@@ -59,8 +59,8 @@ def s3store_w_subdir():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
-        index = MemoryStore("index")
-        store = OpenDataStore(index=index, bucket="bucket1", sub_dir="subdir1", s3_workers=1)
+        index = S3IndexStore(collection_name="index", bucket="bucket1", key="task_id")
+        store = OpenDataStore(index=index, bucket="bucket1", key="task_id", sub_dir="subdir1", s3_workers=1)
         store.connect()
 
         yield store
@@ -72,8 +72,8 @@ def s3store_multi():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
-        index = MemoryStore("index")
-        store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4)
+        index = S3IndexStore(collection_name="index", bucket="bucket1", key="task_id")
+        store = OpenDataStore(index=index, bucket="bucket1", key="task_id", s3_workers=4)
         store.connect()
 
         yield store
@@ -121,25 +121,25 @@ def test_index_eq(memstore, s3indexstore):
 
 def test_index_load_manifest(s3indexstore):
     assert s3indexstore.count() == 1
-    assert s3indexstore.query_one({"task_id": "mp-1"}) is not None
+    assert s3indexstore.query_one({"query": "task_id == 'mp-1'"}) is not None
 
 
 def test_index_store_manifest(s3indexstore):
     data = [{"task_id": "mp-2", "last_updated": datetime.utcnow()}]
     s3indexstore.store_manifest(data)
     assert s3indexstore.count() == 1
-    assert s3indexstore.query_one({"task_id": "mp-1"}) is None
-    assert s3indexstore.query_one({"task_id": "mp-2"}) is not None
+    assert s3indexstore.query_one({"query": "task_id == 'mp-1'"}) is None
+    assert s3indexstore.query_one({"query": "task_id == 'mp-2'"}) is not None
 
 
 def test_keys():
     with mock_s3():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
-        index = MemoryStore("index", key=1)
+        index = PandasMemoryStore(key=1)
         with pytest.raises(AssertionError, match=r"Since we are.*"):
             store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4, key=1)
-        index = MemoryStore("index", key="key1")
+        index = S3IndexStore(collection_name="test", bucket="bucket1", key="key1")
         with pytest.warns(UserWarning, match=r"The desired S3Store.*$"):
             store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4, key="key2")
         store.connect()
@@ -180,13 +180,13 @@ def test_multi_update(s3store, s3store_multi):
 
 def test_count(s3store):
     assert s3store.count() == 2
-    assert s3store.count({"task_id": "mp-3"}) == 1
+    assert s3store.count({"query": "task_id == 'mp-3'"}) == 1
 
 
 def test_qeuery(s3store):
-    assert s3store.query_one(criteria={"task_id": "mp-2"}) is None
-    assert s3store.query_one(criteria={"task_id": "mp-1"})["data"] == "asd"
-    assert s3store.query_one(criteria={"task_id": "mp-3"})["data"] == "sdf"
+    assert s3store.query_one(criteria={"query": "task_id == 'mp-2'"}) is None
+    assert s3store.query_one(criteria={"query": "task_id == 'mp-1'"})["data"] == "asd"
+    assert s3store.query_one(criteria={"query": "task_id == 'mp-3'"})["data"] == "sdf"
 
     assert len(list(s3store.query())) == 2
 
@@ -201,10 +201,10 @@ def test_update(s3store):
             }
         ]
     )
-    assert s3store.query_one({"task_id": "mp-199999"}) is not None
+    assert s3store.query_one({"query": "task_id == 'mp-199999'"}) is not None
 
     s3store.update([{"task_id": "mp-4", "data": "asd"}])
-    assert s3store.query_one({"task_id": "mp-4"})["data"] == "asd"
+    assert s3store.query_one({"query": "task_id == 'mp-4'"})["data"] == "asd"
     assert s3store.s3_bucket.Object(s3store._get_full_key_path("mp-4")).key == "mp-4.json.gz"
 
 
@@ -226,47 +226,25 @@ def test_rebuild_index_from_data(s3store):
             assert key == "task_id" or key == "last_updated"
 
 
-def tests_msonable_read_write(s3store):
-    dd = s3store.as_dict()
+def tests_msonable_read_write(s3store, memstore):
+    dd = memstore.as_dict()
     s3store.update([{"task_id": "mp-2", "data": dd}])
-    res = s3store.query_one({"task_id": "mp-2"})
+    res = s3store.query_one({"query": "task_id == 'mp-2'"})
     assert res["data"]["@module"] == "maggma.stores.open_data"
 
 
 def test_remove(s3store):
-    def objects_in_bucket(key):
-        objs = list(s3store.s3_bucket.objects.filter(Prefix=key))
-        return key in [o.key for o in objs]
-
-    s3store.update([{"task_id": "mp-2", "data": "asd"}])
-    s3store.update([{"task_id": "mp-4", "data": "asd"}])
-    s3store.update({"task_id": "mp-5", "data": "aaa"})
-    assert s3store.query_one({"task_id": "mp-2"}) is not None
-    assert s3store.query_one({"task_id": "mp-4"}) is not None
-    assert objects_in_bucket("mp-2.json.gz")
-    assert objects_in_bucket("mp-4.json.gz")
-
-    s3store.remove_docs({"task_id": "mp-2"})
-    s3store.remove_docs({"task_id": "mp-4"}, remove_s3_object=True)
-
-    assert objects_in_bucket("mp-2.json.gz")
-    assert not objects_in_bucket("mp-4.json.gz")
-
-    assert s3store.query_one({"task_id": "mp-5"}) is not None
-
-
-def test_close(s3store):
-    list(s3store.query())
-    s3store.close()
-    with pytest.raises(AttributeError):
-        list(s3store.query())
+    with pytest.raises(NotImplementedError):
+        s3store.remove_docs({"query": "task_id == 'mp-2'"})
+    with pytest.raises(NotImplementedError):
+        s3store.remove_docs({"query": "task_id == 'mp-4'"}, remove_s3_object=True)
 
 
 def test_bad_import(mocker):
     mocker.patch("maggma.stores.aws.boto3", None)
-    index = MemoryStore("index")
+    index = PandasMemoryStore()
     with pytest.raises(RuntimeError):
-        OpenDataStore(index=index, bucket="bucket1")
+        OpenDataStore(index=index, bucket="bucket1", key="task_id")
 
 
 def test_aws_error(s3store):
@@ -297,7 +275,7 @@ def test_count_subdir(s3store_w_subdir):
     s3store_w_subdir.update([{"task_id": "mp-2", "data": "asd"}])
 
     assert s3store_w_subdir.count() == 2
-    assert s3store_w_subdir.count({"task_id": "mp-2"}) == 1
+    assert s3store_w_subdir.count({"query": "task_id == 'mp-2'"}) == 1
 
 
 def test_subdir_storage(s3store_w_subdir):
@@ -310,19 +288,6 @@ def test_subdir_storage(s3store_w_subdir):
 
     assert objects_in_bucket("subdir1/mp-1.json.gz")
     assert objects_in_bucket("subdir1/mp-2.json.gz")
-
-
-def test_remove_subdir(s3store_w_subdir):
-    s3store_w_subdir.update([{"task_id": "mp-2", "data": "asd"}])
-    s3store_w_subdir.update([{"task_id": "mp-4", "data": "asd"}])
-
-    assert s3store_w_subdir.query_one({"task_id": "mp-2"}) is not None
-    assert s3store_w_subdir.query_one({"task_id": "mp-4"}) is not None
-
-    s3store_w_subdir.remove_docs({"task_id": "mp-2"})
-
-    assert s3store_w_subdir.query_one({"task_id": "mp-2"}) is None
-    assert s3store_w_subdir.query_one({"task_id": "mp-4"}) is not None
 
 
 def test_searchable_fields(s3store):
@@ -345,14 +310,14 @@ def test_newer_in(s3store):
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket")
 
-        index_old = S3IndexStore(collection_name="index_old", bucket="bucket")
-        old_store = OpenDataStore(index=index_old, bucket="bucket")
+        index_old = S3IndexStore(collection_name="index_old", bucket="bucket", key="task_id")
+        old_store = OpenDataStore(index=index_old, bucket="bucket", key="task_id")
         old_store.connect()
         old_store.update([{"task_id": "mp-1", "last_updated": tic}])
         old_store.update([{"task_id": "mp-2", "last_updated": tic}])
 
-        index_new = S3IndexStore(collection_name="index_new", bucket="bucket", prefix="new")
-        new_store = OpenDataStore(index=index_new, bucket="bucket", sub_dir="new")
+        index_new = S3IndexStore(collection_name="index_new", bucket="bucket", prefix="new", key="task_id")
+        new_store = OpenDataStore(index=index_new, bucket="bucket", sub_dir="new", key="task_id")
         new_store.connect()
         new_store.update([{"task_id": "mp-1", "last_updated": tic2}])
         new_store.update([{"task_id": "mp-2", "last_updated": tic2}])
@@ -362,6 +327,12 @@ def test_newer_in(s3store):
 
         assert len(old_store.newer_in(new_store.index)) == 2
         assert len(new_store.newer_in(old_store.index)) == 0
+
+        assert len(old_store.newer_in(new_store, exhaustive=True)) == 2
+        assert len(new_store.newer_in(old_store, exhaustive=True)) == 0
+
+        with pytest.raises(AttributeError):
+            old_store.newer_in(new_store, criteria={"query": "task_id == 'mp-1'"})
 
 
 def test_additional_metadata(s3store):
@@ -376,10 +347,11 @@ def test_additional_metadata(s3store):
 
 
 def test_get_session(s3store):
-    index = MemoryStore("index")
+    index = PandasMemoryStore(key="task_id")
     store = OpenDataStore(
         index=index,
         bucket="bucket1",
+        key="task_id",
         s3_profile={
             "aws_access_key_id": "ACCESS_KEY",
             "aws_secret_access_key": "SECRET_KEY",
@@ -394,8 +366,8 @@ def test_no_bucket():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
-        index = MemoryStore("index")
-        store = OpenDataStore(index=index, bucket="bucket2")
+        index = PandasMemoryStore(key="task_id")
+        store = OpenDataStore(index=index, bucket="bucket2", key="task_id")
         with pytest.raises(RuntimeError, match=r".*Bucket not present.*"):
             store.connect()
 


### PR DESCRIPTION
## Summary

In testing we discovered that `MemoryStore` was not scaling and we were hitting performance walls once we got to 3-4K documents. For our use case we need a memory store that is performant with 500K+ documents. 

- create `PandasMemoryStore` that utilized DataFrames as backing store
- utilize this new store for `S3IndexStore` (and thus `OpenDataStore`) instead of `MemoryStore`

**NOTE:** This new store is not 100% compatible with code written for existing stores. Namely, the criteria dictionaries used for querying need to be rewritten such that the queries conform to Pandas query expressions (https://pandas.pydata.org/docs/user_guide/indexing.html#the-query-method) rather than Mongo style.

**NOTE:** To utilize this new store and the OpenData related stores you will need to install the `open_data` extra.

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
