### PR TITLE
Make get by key default false

### DIFF
--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -34,7 +34,7 @@ class ReadOnlyResource(Resource):
         hint_scheme: Optional[HintScheme] = None,
         header_processor: Optional[HeaderProcessor] = None,
         timeout: Optional[int] = None,
-        enable_get_by_key: bool = True,
+        enable_get_by_key: bool = False,
         enable_default_search: bool = True,
         disable_validation: bool = False,
         query_disk_use: bool = False,
@@ -53,7 +53,7 @@ class ReadOnlyResource(Resource):
                 before raising a timeout error
             key_fields: List of fields to always project. Default uses SparseFieldsQuery
                 to allow user to define these on-the-fly.
-            enable_get_by_key: Enable default key route for endpoint.
+            enable_get_by_key: Enable get by key route for endpoint.
             enable_default_search: Enable default endpoint search behavior.
             query_disk_use: Whether to use temporary disk space in large MongoDB queries.
             disable_validation: Whether to use ORJSON and provide a direct FastAPI response.

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -41,13 +41,13 @@ def owner_store():
 
 
 def test_init(owner_store):
-    resource = ReadOnlyResource(store=owner_store, model=Owner)
+    resource = ReadOnlyResource(store=owner_store, model=Owner, enable_get_by_key=True)
     assert len(resource.router.routes) == 3
 
     resource = ReadOnlyResource(store=owner_store, model=Owner, enable_get_by_key=False)
     assert len(resource.router.routes) == 2
 
-    resource = ReadOnlyResource(store=owner_store, model=Owner, enable_default_search=False)
+    resource = ReadOnlyResource(store=owner_store, model=Owner, enable_default_search=False, enable_get_by_key=True)
     assert len(resource.router.routes) == 2
 
 
@@ -63,7 +63,7 @@ def test_msonable(owner_store):
 
 
 def test_get_by_key(owner_store):
-    endpoint = ReadOnlyResource(owner_store, Owner, disable_validation=True)
+    endpoint = ReadOnlyResource(owner_store, Owner, disable_validation=True, enable_get_by_key=True)
     app = FastAPI()
     app.include_router(endpoint.router)
 
@@ -76,7 +76,7 @@ def test_get_by_key(owner_store):
 
 
 def test_key_fields(owner_store):
-    endpoint = ReadOnlyResource(owner_store, Owner, key_fields=["name"])
+    endpoint = ReadOnlyResource(owner_store, Owner, key_fields=["name"], enable_get_by_key=True)
     app = FastAPI()
     app.include_router(endpoint.router)
 


### PR DESCRIPTION
Ensure `enable_get_by_key` is defaulted to False. This default disables the get by key GET endpoint created by `ReadOnlyResource`.