### PR TITLE
open data refactor for integration with builders

### DIFF
--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -625,10 +625,9 @@ class OpenDataStore(S3IndexStore):
                     if "$date" in obj:
                         # Return the datetime string or convert it to a datetime object
                         return datetime.fromisoformat(obj["$date"].rstrip("Z"))
-                    else:
-                        # Recursively process each key-value pair in the dictionary
-                        for key, value in obj.items():
-                            obj[key] = replace_nested_date_dict(value)
+                    # Recursively process each key-value pair in the dictionary
+                    for key, value in obj.items():
+                        obj[key] = replace_nested_date_dict(value)
                 elif isinstance(obj, list):
                     # Process each item in the list
                     return [replace_nested_date_dict(item) for item in obj]

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -363,10 +363,9 @@ class S3IndexStore(PandasMemoryStore):
         try:
             response = self.s3_client.get_object(Bucket=self.bucket, Key=self._get_manifest_full_key_path())
             df = pd.read_json(response["Body"], orient="records", lines=True)
-            df = df.map(
+            return df.map(
                 lambda x: datetime.fromisoformat(x["$date"].rstrip("Z")) if isinstance(x, dict) and "$date" in x else x
             )
-            return df
 
         except ClientError as ex:
             if ex.response["Error"]["Code"] == "NoSuchKey":
@@ -631,8 +630,7 @@ class OpenDataStore(S3IndexStore):
                     return [replace_nested_date_dict(item) for item in obj]
                 return obj
 
-            df = df.map(replace_nested_date_dict)
-            return df
+            return df.map(replace_nested_date_dict)
 
         except ClientError as ex:
             if ex.response["Error"]["Code"] == "NoSuchKey":

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -1,7 +1,7 @@
 import gzip
 from datetime import datetime
 from io import BytesIO, StringIO
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import jsonlines
 import pandas as pd
@@ -10,7 +10,6 @@ from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from bson import json_util
-from pydash import get
 
 from maggma.core.store import Sort
 from maggma.utils import LU_KEY_ISOFORMAT
@@ -272,8 +271,7 @@ class PandasMemoryStore:
         if self._data is None:
             if docs is not None and not docs.empty:
                 self._data = docs
-            return
-        key = [self.key]
+            return docs
 
         self._data = self.get_merged_items(to_dt=self._data, from_dt=docs)
         return docs

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -1,70 +1,195 @@
+import gzip
 import pickle
-from datetime import datetime
+from datetime import datetime, timedelta
 from io import BytesIO, StringIO
 
 import boto3
 import jsonlines
 import pandas as pd
 import pytest
-from botocore.exceptions import ClientError
 from bson import json_util
 from moto import mock_s3
 
 from maggma.stores.open_data import OpenDataStore, PandasMemoryStore, S3IndexStore
 
 
+# PandasMemoryStore tests
 @pytest.fixture()
 def memstore():
     store = PandasMemoryStore(key="task_id")
-    store.connect()
+    store.update(
+        pd.DataFrame(
+            [
+                {
+                    store.key: "mp-1",
+                    store.last_updated_field: datetime.utcnow(),
+                    "data": "asd",
+                },
+                {
+                    store.key: "mp-3",
+                    store.last_updated_field: datetime.utcnow(),
+                    "data": "sdf",
+                },
+            ]
+        )
+    )
     return store
 
 
+def test_pdmems_pickle(memstore):
+    sobj = pickle.dumps(memstore)
+    dobj = pickle.loads(sobj)
+    assert hash(dobj) == hash(memstore)
+    assert dobj == memstore
+
+
+def test_pdmems_query(memstore):
+    # bad criteria
+    with pytest.raises(AttributeError, match=r".*only support query or is_in"):
+        memstore.query(criteria={"boo": "hoo"})
+    with pytest.raises(AttributeError, match=r".*please just use one or the other"):
+        memstore.query(
+            criteria={
+                "query": f"{memstore.key} == 'mp-1'",
+                "is_in": ("data", ["sdf", "fdr"]),
+                "boo": "hoo",
+            }
+        )
+    # all
+    pd = memstore.query()
+    assert len(pd) == 2
+    # query criteria
+    pd = memstore.query(criteria={"query": f"{memstore.key} == 'mp-1'"})
+    assert len(pd) == 1
+    assert pd[memstore.key].iloc[0] == "mp-1"
+    assert pd["data"].iloc[0] == "asd"
+    # is_in criteria
+    pd = memstore.query(criteria={"is_in": ("data", ["sdf", "fdr"]), "boo": "hoo"})
+    assert len(pd) == 1
+    assert pd[memstore.key].iloc[0] == "mp-3"
+    assert pd["data"].iloc[0] == "sdf"
+    # properties
+    pd = memstore.query(properties=[memstore.key, memstore.last_updated_field])
+    assert len(pd) == 2
+    assert len(pd[memstore.key]) == 2
+    with pytest.raises(KeyError):
+        assert pd["data"]
+    with pytest.raises(KeyError):
+        memstore.query(properties=["fake"])
+    # sort
+    pd = memstore.query(sort={memstore.key: -1})
+    assert len(pd) == 2
+    assert pd[memstore.key].iloc[0] == "mp-3"
+    # skip
+    pd = memstore.query(sort={memstore.key: -1}, skip=1)
+    assert len(pd) == 1
+    assert pd[memstore.key].iloc[0] == "mp-1"
+    # limit
+    pd = memstore.query(sort={memstore.key: -1}, limit=1)
+    assert len(pd) == 1
+    assert pd[memstore.key].iloc[0] == "mp-3"
+    # all
+    pd = memstore.query(
+        criteria={
+            "is_in": ("data", ["sdf", "fdr", "asd"]),
+            "boo": "hoo",
+        },
+        properties=[memstore.key],
+        sort={"data": -1},
+        skip=1,
+        limit=1,
+    )
+    assert len(pd) == 1
+    assert pd[memstore.key].iloc[0] == "mp-1"
+    with pytest.raises(KeyError):
+        assert pd["data"]
+
+
+def test_pdmems_count(memstore):
+    assert memstore.count() == 2
+    assert memstore.count(criteria={"query": f"{memstore.key} == 'mp-1'"}) == 1
+    assert memstore.count(criteria={"is_in": ("data", ["sdf", "fdr"]), "boo": "hoo"}) == 1
+    assert PandasMemoryStore(key="task_id").count() == 0
+
+
 @pytest.fixture()
-def s3store():
-    with mock_s3():
-        conn = boto3.resource("s3", region_name="us-east-1")
-        conn.create_bucket(Bucket="bucket1")
-
-        index = S3IndexStore(collection_name="index", bucket="bucket1", key="task_id")
-        store = OpenDataStore(index=index, bucket="bucket1", key="task_id", object_grouping=["task_id"])
-        store.connect()
-
-        store.update(
+def memstore2():
+    store = PandasMemoryStore(key="task_id")
+    store.update(
+        pd.DataFrame(
             [
                 {
-                    "task_id": "mp-1",
+                    store.key: "mp-1",
+                    store.last_updated_field: datetime.utcnow() - timedelta(hours=1),
                     "data": "asd",
-                    store.last_updated_field: datetime.utcnow(),
-                }
-            ]
-        )
-        store.update(
-            [
+                },
                 {
-                    "task_id": "mp-3",
+                    store.key: "mp-2",
+                    store.last_updated_field: datetime.utcnow() + timedelta(hours=1),
+                    "data": "asd",
+                },
+                {
+                    store.key: "mp-3",
+                    store.last_updated_field: datetime.utcnow() + timedelta(hours=1),
                     "data": "sdf",
-                    store.last_updated_field: datetime.utcnow(),
-                }
+                },
             ]
         )
+    )
+    return store
 
-        yield store
+
+def test_pdmems_distinct(memstore2):
+    assert len(memstore2.distinct(field=memstore2.key)) == len(memstore2._data)
+    assert len(memstore2.distinct(field="data")) == 2
+    assert len(memstore2.distinct(field=memstore2.key, criteria={"query": "data == 'asd'"})) == 2
 
 
-@pytest.fixture()
-def s3store_w_subdir():
-    with mock_s3():
-        conn = boto3.resource("s3", region_name="us-east-1")
-        conn.create_bucket(Bucket="bucket1")
+def test_pdmems_last_updated(memstore2):
+    assert memstore2._data[memstore2.last_updated_field].iloc[2] == memstore2.last_updated
+    store = PandasMemoryStore(key="task_id")
+    assert store.last_updated == datetime.min
 
-        index = S3IndexStore(collection_name="index", bucket="bucket1", key="task_id")
-        store = OpenDataStore(
-            index=index, bucket="bucket1", key="task_id", sub_dir="subdir1", s3_workers=1, object_grouping=["task_id"]
-        )
-        store.connect()
 
-        yield store
+def test_pdmems_newer_in(memstore, memstore2):
+    s = memstore.newer_in(memstore2)
+    assert len(s) == 2
+    assert "mp-2" in s.unique()
+    assert "mp-3" in s.unique()
+    s = memstore.newer_in(target=memstore2, criteria={"query": "data == 'asd'"}, exhaustive=True)
+    assert len(s) == 1
+    assert "mp-2" in s.unique()
+    with pytest.raises(AttributeError):
+        memstore.newer_in(target=memstore2, criteria={"query": "data == 'asd'"}, exhaustive=False)
+
+
+def test_pdmems_update(memstore):
+    df = pd.DataFrame(
+        [
+            {
+                memstore.key: "mp-1",
+                memstore.last_updated_field: datetime.utcnow(),
+                "data": "boo",
+            }
+        ]
+    )
+    df2 = memstore.update(df)
+    assert len(memstore._data) == 2
+    assert memstore.query(criteria={"query": f"{memstore.key} == 'mp-1'"})["data"].iloc[0] == "boo"
+    assert df2.equals(df)
+    df = pd.DataFrame(
+        [
+            {
+                memstore.key: "mp-2",
+                memstore.last_updated_field: datetime.utcnow(),
+                "data": "boo",
+            }
+        ]
+    )
+    df2 = memstore.update(df)
+    assert len(memstore._data) == 3
+    assert memstore.query(criteria={"query": f"{memstore.key} == 'mp-2'"})["data"].iloc[0] == "boo"
+    assert df2.equals(df)
 
 
 @pytest.fixture()
@@ -81,7 +206,7 @@ def s3indexstore():
         client.put_object(
             Bucket="bucket1",
             Body=BytesIO(string_io.getvalue().encode("utf-8")),
-            Key="manifest.json",
+            Key="manifest.jsonl",
         )
 
         store = S3IndexStore(collection_name="index", bucket="bucket1", key="task_id")
@@ -90,94 +215,243 @@ def s3indexstore():
         yield store
 
 
-def test_missing_manifest():
+def test_s3is_pickle(s3indexstore):
+    sobj = pickle.dumps(s3indexstore)
+    dobj = pickle.loads(sobj)
+    assert hash(dobj) == hash(s3indexstore)
+    assert dobj == s3indexstore
+
+
+def test_s3is_connect_retrieve_manifest(s3indexstore):
+    assert s3indexstore.retrieve_manifest().equals(s3indexstore._data)
+    with mock_s3():
+        with pytest.raises(s3indexstore.s3_client.exceptions.NoSuchBucket):
+            S3IndexStore(collection_name="foo", bucket="bucket2", key="task_id").retrieve_manifest()
+        with pytest.raises(RuntimeError):
+            S3IndexStore(collection_name="foo", bucket="bucket2", key="task_id").connect()
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket2")
+        s3is = S3IndexStore(collection_name="foo", bucket="bucket2", key="task_id")
+        s3is.connect()
+        assert s3is._data is None
+        assert s3is.retrieve_manifest() is None
+        assert s3is.count() == 0
+
+
+def test_s3is_store_manifest(s3indexstore):
     with mock_s3():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket2")
-        store = S3IndexStore(collection_name="index", bucket="bucket2", key="task_id")
-        store.connect()
-        assert store.count() == 0
+        s3is = S3IndexStore(collection_name="foo", bucket="bucket2", key="task_id")
+        s3is.connect()
+        s3is.update(pd.DataFrame([{"task_id": "mp-2", "last_updated": "now"}]))
+        s3is.store_manifest()
+        df = s3is.retrieve_manifest()
+        assert len(df) == 1
+        assert df.equals(s3is._data)
+        s3is.update(pd.DataFrame([{"task_id": "mp-3", "last_updated": "later"}]))
+        df = s3is.retrieve_manifest()
+        assert not df.equals(s3is._data)
 
 
-def test_boto_error_index():
-    with mock_s3():
-        store = S3IndexStore(collection_name="index", bucket="bucket2", key="task_id")
-        with pytest.raises(RuntimeError):
-            store.connect()
-
-
-def test_index_eq(memstore, s3indexstore):
-    assert s3indexstore == s3indexstore
-    assert memstore != s3indexstore
-
-
-def test_index_load_manifest(s3indexstore):
-    assert s3indexstore.count() == 1
-    assert s3indexstore.query_one({"query": "task_id == 'mp-1'"}) is not None
-
-
-def test_index_store_manifest(s3indexstore):
-    data = pd.DataFrame([{"task_id": "mp-2", "last_updated": datetime.utcnow()}])
-    s3indexstore.store_manifest(data)
-    assert s3indexstore.count() == 1
-    assert s3indexstore.query_one({"query": "task_id == 'mp-1'"}) is None
-    assert s3indexstore.query_one({"query": "task_id == 'mp-2'"}) is not None
-
-
-def test_keys():
+@pytest.fixture()
+def s3store():
     with mock_s3():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
-        index = PandasMemoryStore(key=1)
-        with pytest.raises(AssertionError, match=r"Since we are.*"):
-            store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4, key=1)
-        index = S3IndexStore(collection_name="test", bucket="bucket1", key="key1")
-        with pytest.warns(UserWarning, match=r"The desired S3Store.*$"):
-            store = OpenDataStore(index=index, bucket="bucket1", s3_workers=4, key="key2", object_grouping=["key1"])
+
+        store = OpenDataStore(collection_name="index", bucket="bucket1", key="task_id", object_grouping=["task_id"])
         store.connect()
-        store.update({"key1": "mp-1", "data": "1234", store.last_updated_field: datetime.utcnow()})
-        with pytest.raises(KeyError):
-            store.update({"key2": "mp-2", "data": "1234"})
-        assert store.key == store.index.key == "key1"
+
+        store.update(
+            pd.DataFrame(
+                [
+                    {
+                        "task_id": "mp-1",
+                        "data": "asd",
+                        store.last_updated_field: datetime.utcnow(),
+                    },
+                    {
+                        "task_id": "mp-3",
+                        "data": "sdf",
+                        store.last_updated_field: datetime.utcnow(),
+                    },
+                ]
+            )
+        )
+
+        yield store
 
 
-def test_count(s3store):
-    assert s3store.count() == 2
-    assert s3store.count({"query": "task_id == 'mp-3'"}) == 1
+@pytest.fixture()
+def s3store_w_subdir():
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+        conn.create_bucket(Bucket="bucket2")
+
+        index = S3IndexStore(collection_name="index", bucket="bucket1", key="task_id")
+        store = OpenDataStore(
+            index=index,
+            collection_name=index.collection_name,
+            bucket="bucket2",
+            key=index.key,
+            prefix="subdir1",
+            object_grouping=["data_foo"],
+        )
+        store.connect()
+
+        store.update(
+            pd.DataFrame(
+                [
+                    {
+                        "task_id": "mp-1",
+                        "data": {"foo": "asd"},
+                        store.last_updated_field: datetime.utcnow(),
+                    },
+                    {
+                        "task_id": "mp-3",
+                        "data": {"foo": "sdf"},
+                        store.last_updated_field: datetime.utcnow(),
+                    },
+                ]
+            )
+        )
+
+        yield store
 
 
-def test_query(s3store):
-    assert s3store.query_one(criteria={"query": "task_id == 'mp-2'"}) is None
-    assert s3store.query_one(criteria={"query": "task_id == 'mp-1'"})["data"] == "asd"
-    assert s3store.query_one(criteria={"query": "task_id == 'mp-3'"})["data"] == "sdf"
-    assert s3store.query_one(criteria={"query": "task_id == 'mp-1'"}, properties=["task_id"])["task_id"] == "mp-1"
-    assert s3store.query_one(criteria={"query": "task_id == 'mp-1'"}, properties=["task_id", "data"])["data"] == "asd"
+def test_pickle(s3store):
+    sobj = pickle.dumps(s3store)
+    dobj = pickle.loads(sobj)
+    assert hash(dobj) == hash(s3store)
+    assert dobj == s3store
+    assert len(dobj.query(criteria={"query": "task_id == 'mp-2'"})) == 0
+    assert dobj.query(criteria={"query": "task_id == 'mp-1'"})["data"].iloc[0] == "asd"
 
-    assert len(list(s3store.query())) == 2
+
+def test_index_property(s3store, s3store_w_subdir):
+    assert s3store.index != s3store
+    assert s3store_w_subdir.index != s3store_w_subdir
+
+
+def test_read_doc_from_s3():
+    data = [
+        {"task_id": "mp-1", "last_updated": datetime.utcnow(), "group": "foo", "also_group": "boo"},
+        {"task_id": "mp-2", "last_updated": datetime.utcnow(), "group": "foo", "also_group": "boo"},
+    ]
+    with mock_s3():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket="bucket1")
+        client = boto3.client("s3", region_name="us-east-1")
+        string_io = StringIO()
+        with jsonlines.Writer(string_io, dumps=json_util.dumps) as writer:
+            for _, row in pd.DataFrame(data).iterrows():
+                writer.write(row.to_dict())
+
+        client.put_object(
+            Bucket="bucket1",
+            Body=BytesIO(gzip.compress(string_io.getvalue().encode("utf-8"))),
+            Key="group=foo/also_group=boo.jsonl.gz",
+        )
+
+        store = OpenDataStore(
+            collection_name="index", bucket="bucket1", key="task_id", object_grouping=["group", "also_group"]
+        )
+        store.connect()
+        df = store._read_doc_from_s3(file_id="group=foo/also_group=boo.jsonl.gz")
+        assert len(df) == 2
+        assert store._get_full_key_path(index=df) == "group=foo/also_group=boo.jsonl.gz"
+        assert (df["task_id"] == "mp-1").any()
+        assert (df["task_id"] == "mp-2").any()
 
 
 def test_update(s3store):
+    assert len(s3store.index_data) == 2
     s3store.update(
-        [
-            {
-                "task_id": "mp-199999",
-                "data": "asd",
-                s3store.last_updated_field: datetime.utcnow(),
-            }
-        ]
+        pd.DataFrame(
+            [
+                {
+                    "task_id": "mp-199999",
+                    "data": "asd",
+                    s3store.last_updated_field: datetime.utcnow(),
+                }
+            ]
+        )
     )
-    assert s3store.query_one({"query": "task_id == 'mp-199999'"}) is not None
+    assert len(s3store.index_data) == 3
+    with pytest.raises(KeyError):
+        assert s3store.index_data.query("task_id == 'mp-199999'")["data"].iloc[0] == "asd"
+
+    s3store.update(
+        pd.DataFrame(
+            [
+                {
+                    "task_id": "mp-199999",
+                    "data": "foo",
+                    s3store.last_updated_field: datetime.utcnow(),
+                }
+            ]
+        )
+    )
+    assert len(s3store.index_data) == 3
+    assert len(s3store.index_data.query("task_id == 'mp-199999'")) == 1
 
     mp4 = [{"task_id": "mp-4", "data": "asd", s3store.last_updated_field: datetime.utcnow()}]
-    s3store.update(mp4)
-    assert s3store.query_one({"query": "task_id == 'mp-4'"})["data"] == "asd"
-    assert s3store.s3_bucket.Object(s3store._get_full_key_path(pd.DataFrame(mp4))).key == "task_id=mp-4.jsonl.gz"
+    s3store.update(pd.DataFrame(mp4))
+    assert len(s3store.index_data) == 4
+    assert s3store._get_full_key_path(pd.DataFrame(mp4)) == "task_id=mp-4.jsonl.gz"
+    s3store.s3_client.head_object(Bucket=s3store.bucket, Key=s3store._get_full_key_path(pd.DataFrame(mp4)))
+
+
+def test_query(s3store):
+    assert len(s3store.query(criteria={"query": "task_id == 'mp-2'"})) == 0
+    assert s3store.query(criteria={"query": "task_id == 'mp-1'"})["data"].iloc[0] == "asd"
+    assert s3store.query(criteria={"query": "task_id == 'mp-3'"})["data"].iloc[0] == "sdf"
+    assert s3store.query(criteria={"query": "task_id == 'mp-1'"}, properties=["task_id"])["task_id"].iloc[0] == "mp-1"
+    assert (
+        s3store.query(criteria={"query": "task_id == 'mp-1'"}, properties=["task_id", "data"])["data"].iloc[0] == "asd"
+    )
+
+    assert len(s3store.query()) == 2
+
+    # will use optimized search
+    df = s3store.query(criteria={"query": "task_id == 'mp-1'"}, properties=["task_id"], criteria_fields=["task_id"])
+    assert len(df) == 1
+    assert df["task_id"].iloc[0] == "mp-1"
+    with pytest.raises(KeyError):
+        assert df["data"].iloc[0] == "asd"
+
+    # will use optimized search
+    df = s3store.query(properties=["task_id"], criteria_fields=[])
+    assert len(df) == 2
+
+    # will not use optimized search even with hints since data is not in the searchable_fields
+    df = s3store.query(criteria={"query": "data == 'asd'"}, properties=["task_id"], criteria_fields=["data"])
+    assert len(df) == 1
+    assert df["task_id"].iloc[0] == "mp-1"
+    with pytest.raises(KeyError):
+        assert df["data"].iloc[0] == "asd"
 
 
 def test_rebuild_index_from_s3_data(s3store):
-    s3store.update([{"task_id": "mp-2", "data": "asd", s3store.last_updated_field: datetime.utcnow()}])
+    data = [{"task_id": "mp-2", "data": "asd", s3store.last_updated_field: datetime.utcnow()}]
+    client = boto3.client("s3", region_name="us-east-1")
+    string_io = StringIO()
+    with jsonlines.Writer(string_io, dumps=json_util.dumps) as writer:
+        for _, row in pd.DataFrame(data).iterrows():
+            writer.write(row.to_dict())
+
+    client.put_object(
+        Bucket="bucket1",
+        Body=BytesIO(gzip.compress(string_io.getvalue().encode("utf-8"))),
+        Key="task_id=mp-2.jsonl.gz",
+    )
+
+    assert len(s3store.index.index_data) == 2
     index_docs = s3store.rebuild_index_from_s3_data()
     assert len(index_docs) == 3
+    assert len(s3store.index.index_data) == 3
     for key in index_docs.columns:
         assert key == "task_id" or key == "last_updated"
 
@@ -186,115 +460,47 @@ def test_rebuild_index_from_data(s3store):
     data = [{"task_id": "mp-2", "data": "asd", s3store.last_updated_field: datetime.utcnow()}]
     index_docs = s3store.rebuild_index_from_data(pd.DataFrame(data))
     assert len(index_docs) == 1
+    assert len(s3store.index.index_data) == 1
     for key in index_docs.columns:
         assert key == "task_id" or key == "last_updated"
 
 
-def tests_msonable_read_write(s3store, memstore):
-    dd = memstore.as_dict()
-    s3store.update([{"task_id": "mp-2", "data": dd, s3store.last_updated_field: datetime.utcnow()}])
-    res = s3store.query_one({"query": "task_id == 'mp-2'"})
-    assert res["data"]["@module"] == "maggma.stores.open_data"
-
-
-def test_remove(s3store):
-    with pytest.raises(NotImplementedError):
-        s3store.remove_docs({"query": "task_id == 'mp-2'"})
-    with pytest.raises(NotImplementedError):
-        s3store.remove_docs({"query": "task_id == 'mp-4'"}, remove_s3_object=True)
-
-
-def test_bad_import(mocker):
-    mocker.patch("maggma.stores.aws.boto3", None)
-    index = PandasMemoryStore()
-    with pytest.raises(RuntimeError):
-        OpenDataStore(index=index, bucket="bucket1", key="task_id")
-
-
-def test_aws_error(s3store):
-    def raise_exception_NoSuchKey(data):
-        error_response = {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}}
-        raise ClientError(error_response, "raise_exception")
-
-    def raise_exception_other(data):
-        error_response = {"Error": {"Code": 405}}
-        raise ClientError(error_response, "raise_exception")
-
-    s3store.s3_bucket.Object = raise_exception_other
-    with pytest.raises(ClientError):
-        s3store.query_one()
-
-    # Should just pass
-    s3store.s3_bucket.Object = raise_exception_NoSuchKey
-    s3store.query_one()
-
-
-def test_eq(memstore, s3store):
-    assert s3store == s3store
-    assert s3store != memstore
-
-
 def test_count_subdir(s3store_w_subdir):
     s3store_w_subdir.update(
-        [{"task_id": "mp-1", "data": "asd", s3store_w_subdir.last_updated_field: datetime.utcnow()}]
+        pd.DataFrame(
+            [{"task_id": "mp-1", "data": {"foo": "asd"}, s3store_w_subdir.last_updated_field: datetime.utcnow()}]
+        )
     )
     s3store_w_subdir.update(
-        [{"task_id": "mp-2", "data": "asd", s3store_w_subdir.last_updated_field: datetime.utcnow()}]
+        pd.DataFrame(
+            [{"task_id": "mp-2", "data": {"foo": "asd"}, s3store_w_subdir.last_updated_field: datetime.utcnow()}]
+        )
     )
 
-    assert s3store_w_subdir.count() == 2
+    assert len(s3store_w_subdir.query()) == 3
+    assert len(s3store_w_subdir.query(criteria=None)) == 3
+    assert s3store_w_subdir.count() == 3
     assert s3store_w_subdir.count({"query": "task_id == 'mp-2'"}) == 1
 
 
 def test_subdir_storage(s3store_w_subdir):
     def objects_in_bucket(key):
-        objs = list(s3store_w_subdir.s3_bucket.objects.filter(Prefix=key))
-        return key in [o.key for o in objs]
+        objs = s3store_w_subdir.s3_client.list_objects_v2(Bucket=s3store_w_subdir.bucket, Prefix=key)
+        return key in [o["Key"] for o in objs["Contents"]]
 
     s3store_w_subdir.update(
-        [{"task_id": "mp-1", "data": "asd", s3store_w_subdir.last_updated_field: datetime.utcnow()}]
-    )
-    s3store_w_subdir.update(
-        [{"task_id": "mp-2", "data": "asd", s3store_w_subdir.last_updated_field: datetime.utcnow()}]
-    )
-
-    assert objects_in_bucket("subdir1/task_id=mp-1.jsonl.gz")
-    assert objects_in_bucket("subdir1/task_id=mp-2.jsonl.gz")
-
-
-def test_newer_in(s3store):
-    with mock_s3():
-        tic = datetime(2018, 4, 12, 16)
-        tic2 = datetime.utcnow()
-        conn = boto3.client("s3")
-        conn = boto3.resource("s3", region_name="us-east-1")
-        conn.create_bucket(Bucket="bucket")
-
-        index_old = S3IndexStore(collection_name="index_old", bucket="bucket", key="task_id")
-        old_store = OpenDataStore(index=index_old, bucket="bucket", key="task_id", object_grouping=["task_id"])
-        old_store.connect()
-        old_store.update([{"task_id": "mp-1", "last_updated": tic}])
-        old_store.update([{"task_id": "mp-2", "last_updated": tic}])
-
-        index_new = S3IndexStore(collection_name="index_new", bucket="bucket", prefix="new", key="task_id")
-        new_store = OpenDataStore(
-            index=index_new, bucket="bucket", sub_dir="new", key="task_id", object_grouping=["task_id"]
+        pd.DataFrame(
+            [{"task_id": "mp-1", "data": {"foo": "asd"}, s3store_w_subdir.last_updated_field: datetime.utcnow()}]
         )
-        new_store.connect()
-        new_store.update([{"task_id": "mp-1", "last_updated": tic2}])
-        new_store.update([{"task_id": "mp-2", "last_updated": tic2}])
+    )
+    s3store_w_subdir.update(
+        pd.DataFrame(
+            [{"task_id": "mp-2", "data": {"foo": "asd"}, s3store_w_subdir.last_updated_field: datetime.utcnow()}]
+        )
+    )
 
-        assert len(old_store.newer_in(new_store)) == 2
-        assert len(new_store.newer_in(old_store)) == 0
-
-        assert len(old_store.newer_in(new_store.index)) == 2
-        assert len(new_store.newer_in(old_store.index)) == 0
-
-        assert len(old_store.newer_in(new_store, exhaustive=True)) == 2
-        assert len(new_store.newer_in(old_store, exhaustive=True)) == 0
-
-        with pytest.raises(AttributeError):
-            old_store.newer_in(new_store, criteria={"query": "task_id == 'mp-1'"})
+    assert objects_in_bucket("subdir1/data_foo=asd.jsonl.gz")
+    assert objects_in_bucket("subdir1/data_foo=sdf.jsonl.gz")
 
 
 def test_additional_metadata(s3store):
@@ -302,43 +508,5 @@ def test_additional_metadata(s3store):
 
     data = [{"task_id": f"mp-{i}", "a": i, s3store.last_updated_field: tic} for i in range(4)]
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(TypeError):
         s3store.update(data, key="a", additional_metadata="task_id")
-
-
-def test_get_session(s3store):
-    index = PandasMemoryStore(key="task_id")
-    store = OpenDataStore(
-        index=index,
-        bucket="bucket1",
-        key="task_id",
-        s3_profile={
-            "aws_access_key_id": "ACCESS_KEY",
-            "aws_secret_access_key": "SECRET_KEY",
-        },
-        object_grouping=["task_id"],
-    )
-    assert store._get_session().get_credentials().access_key == "ACCESS_KEY"
-    assert store._get_session().get_credentials().secret_key == "SECRET_KEY"
-
-
-def test_no_bucket():
-    with mock_s3():
-        conn = boto3.resource("s3", region_name="us-east-1")
-        conn.create_bucket(Bucket="bucket1")
-
-        index = PandasMemoryStore(key="task_id")
-        store = OpenDataStore(index=index, bucket="bucket2", key="task_id", object_grouping=["task_id"])
-        with pytest.raises(RuntimeError, match=r".*Bucket not present.*"):
-            store.connect()
-
-
-def test_pickle(s3store_w_subdir):
-    sobj = pickle.dumps(s3store_w_subdir.index)
-    dobj = pickle.loads(sobj)
-    assert hash(dobj) == hash(s3store_w_subdir.index)
-    assert dobj == s3store_w_subdir.index
-    sobj = pickle.dumps(s3store_w_subdir)
-    dobj = pickle.loads(sobj)
-    assert hash(dobj) == hash(s3store_w_subdir)
-    assert dobj == s3store_w_subdir


### PR DESCRIPTION
## Summary

During initial integration testing with the new builders we decided to make the OpenData stores fully geared to working with DataFrames and to not require maintaining compatibility with the Store interface.  This allowed us to simplify the code on both the store and builder side. This is the updated interface and code for the OpenData related stores.

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.