### PR TITLE
Tweak docstrings to fix rendered docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v0.0.280
     hooks:
       - id: ruff
-        args: [--fix, --show-fixes, --ignore, D]
+        args: [--fix, --show-fixes, --ignore, D, --extend-select, D411]
 
   - repo: https://github.com/psf/black
     rev: 23.7.0

--- a/src/maggma/api/API.py
+++ b/src/maggma/api/API.py
@@ -13,7 +13,7 @@ from maggma.api.resource import Resource
 
 class API(MSONable):
     """
-    Basic API manager to tie together various resources
+    Basic API manager to tie together various resources.
     """
 
     def __init__(
@@ -34,7 +34,7 @@ class API(MSONable):
             debug: turns debug on in FastAPI
             heartbeat_meta: dictionary of additional metadata to include in the heartbeat response
             description: description of the API to be used in the generated docs
-            tags_meta: descriptions of tags to be used in the generated docs
+            tags_meta: descriptions of tags to be used in the generated docs.
         """
         self.title = title
         self.version = version
@@ -50,7 +50,7 @@ class API(MSONable):
 
     def on_startup(self):
         """
-        Basic startup that runs the resource startup functions
+        Basic startup that runs the resource startup functions.
         """
         for resource_list in self.resources.values():
             for resource in resource_list:
@@ -59,7 +59,7 @@ class API(MSONable):
     @property
     def app(self):
         """
-        App server for the cluster manager
+        App server for the cluster manager.
         """
         app = FastAPI(
             title=self.title,
@@ -92,7 +92,7 @@ class API(MSONable):
 
         @app.get("/heartbeat", include_in_schema=False)
         def heartbeat():
-            """API Heartbeat for Load Balancing"""
+            """API Heartbeat for Load Balancing."""
 
             return {
                 "status": "OK",
@@ -103,14 +103,14 @@ class API(MSONable):
 
         @app.get("/", include_in_schema=False)
         def redirect_docs():
-            """Redirects the root end point to the docs"""
+            """Redirects the root end point to the docs."""
             return RedirectResponse(url=app.docs_url, status_code=301)
 
         return app
 
     def run(self, ip: str = "127.0.0.1", port: int = 8000, log_level: str = "info"):
         """
-        Runs the Cluster Manager locally
+        Runs the Cluster Manager locally.
 
         Args:
             ip: Local IP to listen on

--- a/src/maggma/api/__init__.py
+++ b/src/maggma/api/__init__.py
@@ -1,1 +1,1 @@
-""" Simple API Interface for Maggma """
+""" Simple API Interface for Maggma. """

--- a/src/maggma/api/models.py
+++ b/src/maggma/api/models.py
@@ -14,7 +14,7 @@ DataT = TypeVar("DataT")
 class Meta(BaseModel):
 
     """
-    Meta information for the MAPI Response
+    Meta information for the MAPI Response.
     """
 
     api_version: str = Field(
@@ -35,7 +35,7 @@ class Meta(BaseModel):
 
 class Error(BaseModel):
     """
-    Base Error model for General API
+    Base Error model for General API.
     """
 
     code: int = Field(..., description="The error code")
@@ -48,7 +48,7 @@ class Error(BaseModel):
 
 class Response(BaseModel, Generic[DataT]):
     """
-    A Generic API Response
+    A Generic API Response.
     """
 
     data: Optional[List[DataT]] = Field(None, description="List of returned data")
@@ -78,7 +78,7 @@ class Response(BaseModel, Generic[DataT]):
 class S3URLDoc(BaseModel):
 
     """
-    S3 pre-signed URL data returned by the S3 URL resource
+    S3 pre-signed URL data returned by the S3 URL resource.
     """
 
     url: str = Field(

--- a/src/maggma/api/query_operator/core.py
+++ b/src/maggma/api/query_operator/core.py
@@ -9,18 +9,18 @@ from maggma.api.utils import STORE_PARAMS
 class QueryOperator(MSONable, metaclass=ABCMeta):
     """
     Base Query Operator class for defining powerful query language
-    in the Materials API
+    in the Materials API.
     """
 
     @abstractmethod
     def query(self) -> STORE_PARAMS:
         """
-        The query function that does the work for this query operator
+        The query function that does the work for this query operator.
         """
 
     def meta(self) -> Dict:
         """
-        Returns meta data to return with the Response
+        Returns meta data to return with the Response.
 
         Args:
             store: the Maggma Store that the resource uses
@@ -30,7 +30,7 @@ class QueryOperator(MSONable, metaclass=ABCMeta):
 
     def post_process(self, docs: List[Dict], query: Dict) -> List[Dict]:
         """
-        An optional post-processing function for the data
+        An optional post-processing function for the data.
 
         Args:
             docs: the document results to post-process

--- a/src/maggma/api/query_operator/dynamic.py
+++ b/src/maggma/api/query_operator/dynamic.py
@@ -13,7 +13,7 @@ from maggma.utils import dynamic_import
 
 
 class DynamicQueryOperator(QueryOperator):
-    """Abstract Base class for dynamic query operators"""
+    """Abstract Base class for dynamic query operators."""
 
     def __init__(
         self,
@@ -75,7 +75,7 @@ class DynamicQueryOperator(QueryOperator):
         self.query = query  # type: ignore
 
     def query(self):
-        "Stub query function for abstract class"
+        "Stub query function for abstract class."
 
     @abstractmethod
     def field_to_operator(self, name: str, field: FieldInfo) -> List[Tuple[str, Any, Query, Callable[..., Dict]]]:
@@ -84,7 +84,7 @@ class DynamicQueryOperator(QueryOperator):
             - query param name,
             - query param type
             - FastAPI Query object,
-            - and callable to convert the value into a query dict
+            - and callable to convert the value into a query dict.
         """
 
     @classmethod
@@ -97,7 +97,7 @@ class DynamicQueryOperator(QueryOperator):
 
     def as_dict(self) -> Dict:
         """
-        Special as_dict implemented to convert pydantic models into strings
+        Special as_dict implemented to convert pydantic models into strings.
         """
         d = super().as_dict()  # Ensures sub-classes serialize correctly
         d["model"] = f"{self.model.__module__}.{self.model.__name__}"  # type: ignore
@@ -105,7 +105,7 @@ class DynamicQueryOperator(QueryOperator):
 
 
 class NumericQuery(DynamicQueryOperator):
-    "Query Operator to enable searching on numeric fields"
+    "Query Operator to enable searching on numeric fields."
 
     def field_to_operator(self, name: str, field: FieldInfo) -> List[Tuple[str, Any, Query, Callable[..., Dict]]]:
         """
@@ -113,7 +113,7 @@ class NumericQuery(DynamicQueryOperator):
         query_param name,
         default value,
         Query object,
-        and callable to convert it into a query dict
+        and callable to convert it into a query dict.
         """
 
         ops = []
@@ -190,7 +190,7 @@ class NumericQuery(DynamicQueryOperator):
 
 
 class StringQueryOperator(DynamicQueryOperator):
-    "Query Operator to enable searching on numeric fields"
+    "Query Operator to enable searching on numeric fields."
 
     def field_to_operator(self, name: str, field: FieldInfo) -> List[Tuple[str, Any, Query, Callable[..., Dict]]]:
         """
@@ -198,7 +198,7 @@ class StringQueryOperator(DynamicQueryOperator):
         query_param name,
         default value,
         Query object,
-        and callable to convert it into a query dict
+        and callable to convert it into a query dict.
         """
 
         ops = []

--- a/src/maggma/api/query_operator/pagination.py
+++ b/src/maggma/api/query_operator/pagination.py
@@ -7,13 +7,13 @@ from maggma.api.utils import STORE_PARAMS
 
 
 class PaginationQuery(QueryOperator):
-    """Query operators to provides Pagination"""
+    """Query operators to provides Pagination."""
 
     def __init__(self, default_limit: int = 100, max_limit: int = 1000):
         """
         Args:
             default_limit: the default number of documents to return
-            max_limit: max number of documents to return
+            max_limit: max number of documents to return.
         """
 
         self.default_limit = default_limit
@@ -39,7 +39,7 @@ class PaginationQuery(QueryOperator):
             ),
         ) -> STORE_PARAMS:
             """
-            Pagination parameters for the API Endpoint
+            Pagination parameters for the API Endpoint.
             """
 
             if _page is not None:
@@ -80,10 +80,10 @@ class PaginationQuery(QueryOperator):
         self.query = query  # type: ignore
 
     def query(self):
-        "Stub query function for abstract class"
+        "Stub query function for abstract class."
 
     def meta(self) -> Dict:
         """
-        Metadata for the pagination params
+        Metadata for the pagination params.
         """
         return {"max_limit": self.max_limit}

--- a/src/maggma/api/query_operator/sorting.py
+++ b/src/maggma/api/query_operator/sorting.py
@@ -8,7 +8,7 @@ from maggma.api.utils import STORE_PARAMS
 
 class SortQuery(QueryOperator):
     """
-    Method to generate the sorting portion of a query
+    Method to generate the sorting portion of a query.
     """
 
     def query(

--- a/src/maggma/api/query_operator/sparse_fields.py
+++ b/src/maggma/api/query_operator/sparse_fields.py
@@ -13,7 +13,7 @@ class SparseFieldsQuery(QueryOperator):
         """
         Args:
             model: PyDantic Model that represents the underlying data source
-            default_fields: default fields to return in the API response if no fields are explicitly requested
+            default_fields: default fields to return in the API response if no fields are explicitly requested.
         """
 
         self.model = model
@@ -32,7 +32,7 @@ class SparseFieldsQuery(QueryOperator):
             _all_fields: bool = Query(False, description="Include all fields."),
         ) -> STORE_PARAMS:
             """
-            Pagination parameters for the API Endpoint
+            Pagination parameters for the API Endpoint.
             """
 
             properties = _fields.split(",") if isinstance(_fields, str) else self.default_fields
@@ -44,17 +44,17 @@ class SparseFieldsQuery(QueryOperator):
         self.query = query  # type: ignore
 
     def query(self):
-        "Stub query function for abstract class"
+        "Stub query function for abstract class."
 
     def meta(self) -> Dict:
         """
-        Returns metadata for the Sparse field set
+        Returns metadata for the Sparse field set.
         """
         return {"default_fields": self.default_fields}
 
     def as_dict(self) -> Dict:
         """
-        Special as_dict implemented to convert pydantic models into strings
+        Special as_dict implemented to convert pydantic models into strings.
         """
 
         d = super().as_dict()  # Ensures sub-classes serialize correctly
@@ -64,7 +64,7 @@ class SparseFieldsQuery(QueryOperator):
     @classmethod
     def from_dict(cls, d):
         """
-        Special from_dict to autoload the pydantic model from the location string
+        Special from_dict to autoload the pydantic model from the location string.
         """
         model = d.get("model")
         if isinstance(model, str):

--- a/src/maggma/api/query_operator/submission.py
+++ b/src/maggma/api/query_operator/submission.py
@@ -9,7 +9,7 @@ from maggma.api.utils import STORE_PARAMS
 
 class SubmissionQuery(QueryOperator):
     """
-    Method to generate a query for submission data using status and datetime
+    Method to generate a query for submission data using status and datetime.
     """
 
     def __init__(self, status_enum):
@@ -40,4 +40,4 @@ class SubmissionQuery(QueryOperator):
         self.query = query
 
     def query(self):
-        "Stub query function for abstract class"
+        "Stub query function for abstract class."

--- a/src/maggma/api/resource/aggregation.py
+++ b/src/maggma/api/resource/aggregation.py
@@ -17,7 +17,7 @@ from maggma.core import Store
 
 class AggregationResource(Resource):
     """
-    Implements a REST Compatible Resource as a GET URL endpoint
+    Implements a REST Compatible Resource as a GET URL endpoint.
     """
 
     def __init__(
@@ -58,7 +58,7 @@ class AggregationResource(Resource):
     def prepare_endpoint(self):
         """
         Internal method to prepare the endpoint by setting up default handlers
-        for routes
+        for routes.
         """
 
         self.build_dynamic_model_search()

--- a/src/maggma/api/resource/core.py
+++ b/src/maggma/api/resource/core.py
@@ -13,7 +13,7 @@ from maggma.utils import dynamic_import
 
 class Resource(MSONable, metaclass=ABCMeta):
     """
-    Base class for a REST Compatible Resource
+    Base class for a REST Compatible Resource.
     """
 
     def __init__(
@@ -22,7 +22,7 @@ class Resource(MSONable, metaclass=ABCMeta):
     ):
         """
         Args:
-            model: the pydantic model this Resource represents
+            model: the pydantic model this Resource represents.
         """
         if not issubclass(model, BaseModel):
             raise ValueError("The resource model has to be a PyDantic Model")
@@ -36,7 +36,7 @@ class Resource(MSONable, metaclass=ABCMeta):
 
     def on_startup(self):
         """
-        Callback to perform some work on resource initialization
+        Callback to perform some work on resource initialization.
         """
 
     @abstractmethod
@@ -51,7 +51,7 @@ class Resource(MSONable, metaclass=ABCMeta):
         def redirect_unslashed():
             """
             Redirects unforward slashed url to resource
-            url with the forward slash
+            url with the forward slash.
             """
 
             url = self.router.url_path_for("/")
@@ -60,7 +60,7 @@ class Resource(MSONable, metaclass=ABCMeta):
     def run(self):  # pragma: no cover
         """
         Runs the Endpoint cluster locally
-        This is intended for testing not production
+        This is intended for testing not production.
         """
         import uvicorn
 
@@ -70,7 +70,7 @@ class Resource(MSONable, metaclass=ABCMeta):
 
     def as_dict(self) -> Dict:
         """
-        Special as_dict implemented to convert pydantic models into strings
+        Special as_dict implemented to convert pydantic models into strings.
         """
 
         d = super().as_dict()  # Ensures sub-classes serialize correctly
@@ -87,19 +87,19 @@ class Resource(MSONable, metaclass=ABCMeta):
 
 class HintScheme(MSONable, metaclass=ABCMeta):
     """
-    Base class for generic hint schemes generation
+    Base class for generic hint schemes generation.
     """
 
     @abstractmethod
     def generate_hints(self, query: STORE_PARAMS) -> STORE_PARAMS:
         """
-        This method takes in a MongoDB query and returns hints
+        This method takes in a MongoDB query and returns hints.
         """
 
 
 class HeaderProcessor(MSONable, metaclass=ABCMeta):
     """
-    Base class for generic header processing
+    Base class for generic header processing.
     """
 
     @abstractmethod
@@ -107,5 +107,5 @@ class HeaderProcessor(MSONable, metaclass=ABCMeta):
         """
         This method takes in a FastAPI Response object and processes a new header for it in-place.
         It can use data in the upstream request to generate the header.
-        (https://fastapi.tiangolo.com/advanced/response-headers/#use-a-response-parameter)
+        (https://fastapi.tiangolo.com/advanced/response-headers/#use-a-response-parameter).
         """

--- a/src/maggma/api/resource/post_resource.py
+++ b/src/maggma/api/resource/post_resource.py
@@ -17,7 +17,7 @@ from maggma.stores import S3Store
 
 class PostOnlyResource(Resource):
     """
-    Implements a REST Compatible Resource as a POST URL endpoint
+    Implements a REST Compatible Resource as a POST URL endpoint.
     """
 
     def __init__(
@@ -73,7 +73,7 @@ class PostOnlyResource(Resource):
     def prepare_endpoint(self):
         """
         Internal method to prepare the endpoint by setting up default handlers
-        for routes
+        for routes.
         """
 
         self.build_dynamic_model_search()

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -21,7 +21,7 @@ class ReadOnlyResource(Resource):
     """
     Implements a REST Compatible Resource as a GET URL endpoint
     This class provides a number of convenience features
-    including full pagination, field projection
+    including full pagination, field projection.
     """
 
     def __init__(
@@ -98,7 +98,7 @@ class ReadOnlyResource(Resource):
     def prepare_endpoint(self):
         """
         Internal method to prepare the endpoint by setting up default handlers
-        for routes
+        for routes.
         """
 
         if self.enable_get_by_key:

--- a/src/maggma/api/resource/s3_url.py
+++ b/src/maggma/api/resource/s3_url.py
@@ -54,7 +54,7 @@ class S3URLResource(Resource):
     def prepare_endpoint(self):
         """
         Internal method to prepare the endpoint by setting up default handlers
-        for routes
+        for routes.
         """
 
         self.build_get_by_key()

--- a/src/maggma/api/resource/submission.py
+++ b/src/maggma/api/resource/submission.py
@@ -116,7 +116,7 @@ class SubmissionResource(Resource):
     def prepare_endpoint(self):
         """
         Internal method to prepare the endpoint by setting up default handlers
-        for routes
+        for routes.
         """
 
         if self.enable_default_search:

--- a/src/maggma/api/resource/utils.py
+++ b/src/maggma/api/resource/utils.py
@@ -12,7 +12,7 @@ def attach_query_ops(
 ) -> Callable[[List[STORE_PARAMS]], Dict]:
     """
     Attach query operators to API compliant function
-    The function has to take a list of STORE_PARAMs as the only argument
+    The function has to take a list of STORE_PARAMs as the only argument.
 
     Args:
         function: the function to decorate
@@ -31,7 +31,7 @@ def attach_query_ops(
 
 def generate_query_pipeline(query: dict, store: Store):
     """
-    Generate the generic aggregation pipeline used in GET endpoint queries
+    Generate the generic aggregation pipeline used in GET endpoint queries.
 
     Args:
         query: Query parameters

--- a/src/maggma/api/utils.py
+++ b/src/maggma/api/utils.py
@@ -58,7 +58,7 @@ def merge_queries(queries: List[STORE_PARAMS]) -> STORE_PARAMS:
 
 def attach_signature(function: Callable, defaults: Dict, annotations: Dict):
     """
-    Attaches signature for defaults and annotations for parameters to function
+    Attaches signature for defaults and annotations for parameters to function.
 
     Args:
         function: callable function to attach the signature to
@@ -142,12 +142,12 @@ def api_sanitize(
 
 def allow_msonable_dict(monty_cls: Type[MSONable]):
     """
-    Patch Monty to allow for dict values for MSONable
+    Patch Monty to allow for dict values for MSONable.
     """
 
     def validate_monty(cls, v, _):
         """
-        Stub validator for MSONable as a dictionary only
+        Stub validator for MSONable as a dictionary only.
         """
         if isinstance(v, cls):
             return v

--- a/src/maggma/builders/group_builder.py
+++ b/src/maggma/builders/group_builder.py
@@ -1,5 +1,5 @@
 """
-Many-to-Many GroupBuilder
+Many-to-Many GroupBuilder.
 """
 import traceback
 from abc import ABCMeta, abstractmethod
@@ -50,7 +50,7 @@ class GroupBuilder(Builder, metaclass=ABCMeta):
             store_process_time: If True, add "_process_time" key to
                 document for profiling purposes
             retry_failed: If True, will retry building documents that
-                previously failed
+                previously failed.
         """
         self.source = source
         self.target = target
@@ -69,7 +69,7 @@ class GroupBuilder(Builder, metaclass=ABCMeta):
     def ensure_indexes(self):
         """
         Ensures indices on critical fields for GroupBuilder
-        which include the plural version of the target's key field
+        which include the plural version of the target's key field.
         """
         index_checks = [
             self.source.ensure_index(self.source.key),
@@ -92,7 +92,7 @@ class GroupBuilder(Builder, metaclass=ABCMeta):
     def prechunk(self, number_splits: int) -> Iterator[Dict]:
         """
         Generic prechunk for group builder to perform domain-decomposition
-        by the grouping keys
+        by the grouping keys.
         """
         self.ensure_indexes()
 
@@ -154,7 +154,7 @@ class GroupBuilder(Builder, metaclass=ABCMeta):
 
     def update_targets(self, items: List[Dict]):
         """
-        Generic update targets for Group Builder
+        Generic update targets for Group Builder.
         """
         target = self.target
         for item in items:
@@ -167,7 +167,7 @@ class GroupBuilder(Builder, metaclass=ABCMeta):
     @abstractmethod
     def unary_function(self, items: List[Dict]) -> Dict:
         """
-        Processing function for GroupBuilder
+        Processing function for GroupBuilder.
 
         Arguments:
             items: list of of documents with matching grouping keys
@@ -180,7 +180,7 @@ class GroupBuilder(Builder, metaclass=ABCMeta):
 
     def get_ids_to_process(self) -> Iterable:
         """
-        Gets the IDs that need to be processed
+        Gets the IDs that need to be processed.
         """
 
         query = self.query or {}
@@ -214,7 +214,7 @@ class GroupBuilder(Builder, metaclass=ABCMeta):
 
     def get_groups_from_keys(self, keys) -> Set[Tuple]:
         """
-        Get the groups by grouping_keys for these documents
+        Get the groups by grouping_keys for these documents.
         """
 
         grouping_keys = self.grouping_keys

--- a/src/maggma/builders/map_builder.py
+++ b/src/maggma/builders/map_builder.py
@@ -1,5 +1,5 @@
 """
-One-to-One Map Builder and a simple CopyBuilder implementation
+One-to-One Map Builder and a simple CopyBuilder implementation.
 """
 import traceback
 from abc import ABCMeta, abstractmethod
@@ -65,7 +65,7 @@ class MapBuilder(Builder, metaclass=ABCMeta):
 
     def ensure_indexes(self):
         """
-        Ensures indices on critical fields for MapBuilder
+        Ensures indices on critical fields for MapBuilder.
         """
         index_checks = [
             self.source.ensure_index(self.source.key),
@@ -87,7 +87,7 @@ class MapBuilder(Builder, metaclass=ABCMeta):
     def prechunk(self, number_splits: int) -> Iterator[Dict]:
         """
         Generic prechunk for map builder to perform domain-decomposition
-        by the key field
+        by the key field.
         """
         self.ensure_indexes()
         keys = self.target.newer_in(self.source, criteria=self.query, exhaustive=True)
@@ -99,7 +99,7 @@ class MapBuilder(Builder, metaclass=ABCMeta):
     def get_items(self):
         """
         Generic get items for Map Builder designed to perform
-        incremental building
+        incremental building.
         """
 
         self.logger.info(f"Starting {self.__class__.__name__} Builder")
@@ -136,7 +136,7 @@ class MapBuilder(Builder, metaclass=ABCMeta):
     def process_item(self, item: Dict):
         """
         Generic process items to process a dictionary using
-        a map function
+        a map function.
         """
 
         self.logger.debug(f"Processing: {item[self.source.key]}")
@@ -173,7 +173,7 @@ class MapBuilder(Builder, metaclass=ABCMeta):
 
     def update_targets(self, items: List[Dict]):
         """
-        Generic update targets for Map Builder
+        Generic update targets for Map Builder.
         """
         target = self.target
         for item in items:
@@ -186,7 +186,7 @@ class MapBuilder(Builder, metaclass=ABCMeta):
 
     def finalize(self):
         """
-        Finalize MapBuilder operations including removing orphaned documents
+        Finalize MapBuilder operations including removing orphaned documents.
         """
         if self.delete_orphans:
             source_keyvals = set(self.source.distinct(self.source.key))
@@ -214,7 +214,7 @@ class CopyBuilder(MapBuilder):
 
     def unary_function(self, item):
         """
-        Identity function for copy builder map operation
+        Identity function for copy builder map operation.
         """
         if "_id" in item:
             del item["_id"]

--- a/src/maggma/builders/projection_builder.py
+++ b/src/maggma/builders/projection_builder.py
@@ -102,7 +102,7 @@ class Projection_Builder(Builder):
 
     def ensure_indexes(self):
         """
-        Ensures key fields are indexed to improve querying efficiency
+        Ensures key fields are indexed to improve querying efficiency.
         """
         index_checks = [s.ensure_index(s.key) for s in self.sources]
 

--- a/src/maggma/cli/distributed.py
+++ b/src/maggma/cli/distributed.py
@@ -212,7 +212,7 @@ def handle_dead_workers(workers, socket):
 def worker(url: str, port: int, num_processes: int, no_bars: bool):
     """
     Simple distributed worker that connects to a manager asks for work and deploys
-    using multiprocessing
+    using multiprocessing.
     """
     identity = f"{randint(0, 0x10000):04X}-{randint(0, 0x10000):04X}"
     logger = getLogger(f"Worker {identity}")

--- a/src/maggma/cli/multiprocessing.py
+++ b/src/maggma/cli/multiprocessing.py
@@ -18,7 +18,7 @@ logger = getLogger("MultiProcessor")
 class BackPressure:
     """
     Wrapper for an iterator to provide
-    async access with backpressure
+    async access with backpressure.
     """
 
     def __init__(self, iterator, n):
@@ -38,7 +38,7 @@ class BackPressure:
 
     async def release(self, async_iterator):
         """
-        release iterator to pipeline the backpressure
+        release iterator to pipeline the backpressure.
         """
         async for item in async_iterator:
             try:
@@ -53,7 +53,7 @@ class AsyncUnorderedMap:
     """
     Async iterator that maps a function to an async iterator
     using an executor and returns items as they are done
-    This does not guarantee order
+    This does not guarantee order.
     """
 
     def __init__(self, func, async_iterator, executor):
@@ -105,7 +105,7 @@ class AsyncUnorderedMap:
 
 async def atqdm(async_iterator, *args, **kwargs):
     """
-    Wrapper around tqdm for async generators
+    Wrapper around tqdm for async generators.
     """
     _tqdm = tqdm(*args, **kwargs)
     async for item in async_iterator:
@@ -119,7 +119,7 @@ async def grouper(async_iterator, n: int):
     """
     Collect data into fixed-length chunks or blocks.
     >>> list(grouper(3, 'ABCDEFG'))
-    [['A', 'B', 'C'], ['D', 'E', 'F'], ['G']]
+    [['A', 'B', 'C'], ['D', 'E', 'F'], ['G']].
 
     Updated from:
     https://stackoverflow.com/questions/31164731/python-chunking-csv-file-multiproccessing/31170795#31170795

--- a/src/maggma/cli/rabbitmq.py
+++ b/src/maggma/cli/rabbitmq.py
@@ -223,7 +223,7 @@ def handle_dead_workers(connection, workers, channel, worker_queue):
 def worker(url: str, port: int, num_processes: int, no_bars: bool, queue_prefix: str):
     """
     Simple distributed worker that connects to a manager asks for work and deploys
-    using multiprocessing
+    using multiprocessing.
     """
     identity = f"{randint(0, 0x10000):04X}-{randint(0, 0x10000):04X}"
     logger = getLogger(f"Worker {identity}")

--- a/src/maggma/cli/serial.py
+++ b/src/maggma/cli/serial.py
@@ -12,7 +12,7 @@ from maggma.utils import grouper, primed
 
 def serial(builder: Builder, no_bars=False):
     """
-    Runs the builders using a single process
+    Runs the builders using a single process.
     """
 
     logger = logging.getLogger("SerialProcessor")

--- a/src/maggma/cli/source_loader.py
+++ b/src/maggma/cli/source_loader.py
@@ -21,7 +21,7 @@ _BASENAME = "maggma.cli.sources"
 
 class ScriptFinder(MetaPathFinder):
     """
-    Special Finder designed to find custom script builders
+    Special Finder designed to find custom script builders.
     """
 
     @classmethod
@@ -42,7 +42,7 @@ class ScriptFinder(MetaPathFinder):
 
 
 class NotebookLoader(Loader):
-    """Module Loader for Jupyter Notebooks or Source Files"""
+    """Module Loader for Jupyter Notebooks or Source Files."""
 
     def __init__(self, name=None, path=None):
         self.shell = InteractiveShell.instance()
@@ -82,7 +82,7 @@ def spec_from_source(file_path: str) -> ModuleSpec:
     """
     Returns a ModuleSpec from a filepath for importlib loading
     Specialized for loading python source files and notebooks into
-    a temporary maggma cli package to run as a builder
+    a temporary maggma cli package to run as a builder.
     """
     file_path_obj = Path(file_path).resolve().relative_to(Path(".").resolve())
     file_path_str = str(file_path_obj)
@@ -115,7 +115,7 @@ def spec_from_source(file_path: str) -> ModuleSpec:
 
 def load_builder_from_source(file_path: str) -> List[Builder]:
     """
-    Loads Maggma Builders from a Python source file
+    Loads Maggma Builders from a Python source file.
     """
     file_path = str(Path(file_path).resolve())
     spec = spec_from_source(file_path)
@@ -135,7 +135,7 @@ def find_matching_file(segments, curr_path="./"):
     """
     Finds file that has the right sequence of segments
     in the path relative to the current path
-    Requires all segments match the file path
+    Requires all segments match the file path.
     """
 
     # If we've gotten to the end of the segment match check to see if a file exists

--- a/src/maggma/cli/sources/__init__.py
+++ b/src/maggma/cli/sources/__init__.py
@@ -1,1 +1,1 @@
-""" Dummy module to allow for loading dynamic source files """
+""" Dummy module to allow for loading dynamic source files. """

--- a/src/maggma/core/__init__.py
+++ b/src/maggma/core/__init__.py
@@ -1,4 +1,4 @@
-""" Core specifications for Maggma """
+""" Core specifications for Maggma. """
 from maggma.core.builder import Builder
 from maggma.core.store import DateTimeFormat, Sort, Store, StoreError
 from maggma.core.validator import Validator

--- a/src/maggma/core/builder.py
+++ b/src/maggma/core/builder.py
@@ -83,6 +83,7 @@ class Builder(MSONable, metaclass=ABCMeta):
         """
         Process an item. There should be no database operations in this method.
         Default behavior is to return the item.
+
         Arguments:
             item:
 

--- a/src/maggma/core/builder.py
+++ b/src/maggma/core/builder.py
@@ -1,5 +1,5 @@
 """
-Module containing the core builder definition
+Module containing the core builder definition.
 """
 
 import logging
@@ -17,7 +17,7 @@ class Builder(MSONable, metaclass=ABCMeta):
     Base Builder class
     At minimum this class should implement:
     get_items - Get items from the sources
-    update_targets - Updates the sources with results
+    update_targets - Updates the sources with results.
 
     Multiprocessing and MPI processing can be used if all
     the data processing is  limited to process_items
@@ -56,7 +56,7 @@ class Builder(MSONable, metaclass=ABCMeta):
         Part of a domain-decomposition paradigm to allow the builder to operate on
         multiple nodes by dividing up the IO as well as the compute
         This function should return an iterator of dictionaries that can be distributed
-        to multiple instances of the builder to get/process/update on
+        to multiple instances of the builder to get/process/update on.
 
         Arguments:
             number_splits: The number of groups to split the documents to work on
@@ -119,7 +119,7 @@ class Builder(MSONable, metaclass=ABCMeta):
     def run(self, log_level=logging.DEBUG):
         """
         Run the builder serially
-        This is only intended for diagnostic purposes
+        This is only intended for diagnostic purposes.
         """
         # Set up logging
         root = logging.getLogger()

--- a/src/maggma/core/store.py
+++ b/src/maggma/core/store.py
@@ -1,5 +1,5 @@
 """
-Module containing the core Store definition
+Module containing the core Store definition.
 """
 
 import logging
@@ -17,14 +17,14 @@ from maggma.utils import LU_KEY_ISOFORMAT
 
 
 class Sort(Enum):
-    """Enumeration for sorting order"""
+    """Enumeration for sorting order."""
 
     Ascending = 1
     Descending = -1
 
 
 class DateTimeFormat(Enum):
-    """Datetime format in store document"""
+    """Datetime format in store document."""
 
     DateTime = "datetime"
     IsoFormat = "isoformat"
@@ -33,7 +33,7 @@ class DateTimeFormat(Enum):
 class Store(MSONable, metaclass=ABCMeta):
     """
     Abstract class for a data Store
-    Defines the interface for all data going in and out of a Builder
+    Defines the interface for all data going in and out of a Builder.
     """
 
     def __init__(
@@ -49,7 +49,7 @@ class Store(MSONable, metaclass=ABCMeta):
             last_updated_field: field for date/time stamping the data
             last_updated_type: the date/time format for the last_updated_field.
                                 Can be "datetime" or "isoformat"
-            validator: Validator to validate documents going into the store
+            validator: Validator to validate documents going into the store.
         """
         self.key = key
         self.last_updated_field = last_updated_field
@@ -64,19 +64,19 @@ class Store(MSONable, metaclass=ABCMeta):
     @abstractproperty
     def _collection(self):
         """
-        Returns a handle to the pymongo collection object
+        Returns a handle to the pymongo collection object.
         """
 
     @abstractproperty
     def name(self) -> str:
         """
-        Return a string representing this data source
+        Return a string representing this data source.
         """
 
     @abstractmethod
     def connect(self, force_reset: bool = False):
         """
-        Connect to the source data
+        Connect to the source data.
 
         Args:
             force_reset: whether to reset the connection or not
@@ -85,13 +85,13 @@ class Store(MSONable, metaclass=ABCMeta):
     @abstractmethod
     def close(self):
         """
-        Closes any connections
+        Closes any connections.
         """
 
     @abstractmethod
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -107,7 +107,7 @@ class Store(MSONable, metaclass=ABCMeta):
         limit: int = 0,
     ) -> Iterator[Dict]:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -121,7 +121,7 @@ class Store(MSONable, metaclass=ABCMeta):
     @abstractmethod
     def update(self, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None):
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -134,7 +134,7 @@ class Store(MSONable, metaclass=ABCMeta):
     @abstractmethod
     def ensure_index(self, key: str, unique: bool = False) -> bool:
         """
-        Tries to create an index and return true if it succeeded
+        Tries to create an index and return true if it succeeded.
 
         Args:
             key: single key to index
@@ -174,7 +174,7 @@ class Store(MSONable, metaclass=ABCMeta):
     @abstractmethod
     def remove_docs(self, criteria: Dict):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -187,7 +187,7 @@ class Store(MSONable, metaclass=ABCMeta):
         sort: Optional[Dict[str, Union[Sort, int]]] = None,
     ):
         """
-        Queries the Store for a single document
+        Queries the Store for a single document.
 
         Args:
             criteria: PyMongo filter for documents to search
@@ -199,7 +199,7 @@ class Store(MSONable, metaclass=ABCMeta):
 
     def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
         """
-        Get all distinct values for a field
+        Get all distinct values for a field.
 
         Args:
             field: the field(s) to get distinct values for
@@ -214,7 +214,7 @@ class Store(MSONable, metaclass=ABCMeta):
     def last_updated(self) -> datetime:
         """
         Provides the most recent last_updated date time stamp from
-        the documents in this Store
+        the documents in this Store.
         """
         doc = next(
             self.query(
@@ -295,7 +295,7 @@ class Store(MSONable, metaclass=ABCMeta):
     def updated_keys(self, target, criteria=None):
         """
         Returns keys for docs that are newer in the target store in comparison
-        with this store when comparing the last updated field (last_updated_field)
+        with this store when comparing the last updated field (last_updated_field).
 
         Args:
             target (Store): store to look for updated documents
@@ -329,7 +329,7 @@ class Store(MSONable, metaclass=ABCMeta):
 
 
 class StoreError(Exception):
-    """General Store-related error"""
+    """General Store-related error."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)

--- a/src/maggma/core/validator.py
+++ b/src/maggma/core/validator.py
@@ -20,7 +20,7 @@ class Validator(MSONable, metaclass=ABCMeta):
     @abstractmethod
     def is_valid(self, doc: Dict) -> bool:
         """
-        Determines if the document is valid
+        Determines if the document is valid.
 
         Args:
             doc: document to check
@@ -30,7 +30,7 @@ class Validator(MSONable, metaclass=ABCMeta):
     def validation_errors(self, doc: Dict) -> List[str]:
         """
         If document is not valid, provides a list of
-        strings to display for why validation has failed
+        strings to display for why validation has failed.
 
         Returns empty list if the document is valid
 

--- a/src/maggma/stores/__init__.py
+++ b/src/maggma/stores/__init__.py
@@ -1,4 +1,4 @@
-""" Root store module with easy imports for implemented Stores """
+""" Root store module with easy imports for implemented Stores. """
 from maggma.core import Store
 from maggma.stores.advanced_stores import AliasingStore, MongograntStore, SandboxStore, VaultStore
 from maggma.stores.aws import S3Store

--- a/src/maggma/stores/advanced_stores.py
+++ b/src/maggma/stores/advanced_stores.py
@@ -1,5 +1,5 @@
 """
-Advanced Stores for behavior outside normal access patterns
+Advanced Stores for behavior outside normal access patterns.
 """
 import json
 import os
@@ -85,20 +85,20 @@ class MongograntStore(MongoStore):
     @classmethod
     def from_db_file(cls, file):
         """
-        Raises ValueError since MongograntStores can't be initialized from a file
+        Raises ValueError since MongograntStores can't be initialized from a file.
         """
         raise ValueError("MongograntStore doesn't implement from_db_file")
 
     @classmethod
     def from_collection(cls, collection):
         """
-        Raises ValueError since MongograntStores can't be initialized from a PyMongo collection
+        Raises ValueError since MongograntStores can't be initialized from a PyMongo collection.
         """
         raise ValueError("MongograntStore doesn't implement from_collection")
 
     def __eq__(self, other: object) -> bool:
         """
-        Check equality for MongograntStore
+        Check equality for MongograntStore.
 
         Args:
             other: other MongograntStore to compare with
@@ -118,7 +118,7 @@ class MongograntStore(MongoStore):
 class VaultStore(MongoStore):
     """
     Extends MongoStore to read credentials out of Vault server
-    and uses these values to initialize MongoStore instance
+    and uses these values to initialize MongoStore instance.
     """
 
     @requires(hvac is not None, "hvac is required to use VaultStore")
@@ -126,7 +126,7 @@ class VaultStore(MongoStore):
         """
         Args:
             collection_name: name of mongo collection
-            vault_secret_path: path on vault server with mongo creds object
+            vault_secret_path: path on vault server with mongo creds object.
 
         Important:
             Environment variables that must be set prior to invocation
@@ -174,7 +174,7 @@ class VaultStore(MongoStore):
 
     def __eq__(self, other: object) -> bool:
         """
-        Check equality for VaultStore
+        Check equality for VaultStore.
 
         Args:
             other: other VaultStore to compare with
@@ -188,14 +188,14 @@ class VaultStore(MongoStore):
 
 class AliasingStore(Store):
     """
-    Special Store that aliases for the primary accessors
+    Special Store that aliases for the primary accessors.
     """
 
     def __init__(self, store: Store, aliases: Dict, **kwargs):
         """
         Args:
             store: the store to wrap around
-            aliases: dict of aliases of the form external key: internal key
+            aliases: dict of aliases of the form external key: internal key.
         """
         self.store = store
         # Given an external key tells what the internal key is
@@ -215,13 +215,13 @@ class AliasingStore(Store):
     @property
     def name(self) -> str:
         """
-        Return a string representing this data source
+        Return a string representing this data source.
         """
         return self.store.name
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -239,7 +239,7 @@ class AliasingStore(Store):
         limit: int = 0,
     ) -> Iterator[Dict]:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -264,7 +264,7 @@ class AliasingStore(Store):
 
     def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
         """
-        Get all distinct values for a field
+        Get all distinct values for a field.
 
         Args:
             field: the field(s) to get distinct values for
@@ -321,7 +321,7 @@ class AliasingStore(Store):
 
     def update(self, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None):
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -342,7 +342,7 @@ class AliasingStore(Store):
 
     def remove_docs(self, criteria: Dict):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -368,7 +368,7 @@ class AliasingStore(Store):
 
     def __eq__(self, other: object) -> bool:
         """
-        Check equality for AliasingStore
+        Check equality for AliasingStore.
 
         Args:
             other: other AliasingStore to compare with
@@ -382,7 +382,7 @@ class AliasingStore(Store):
 
 class SandboxStore(Store):
     """
-    Provides a sandboxed view to another store
+    Provides a sandboxed view to another store.
     """
 
     def __init__(self, store: Store, sandbox: str, exclusive: bool = False):
@@ -390,7 +390,7 @@ class SandboxStore(Store):
         Args:
             store: store to wrap sandboxing around
             sandbox: the corresponding sandbox
-            exclusive: whether to be exclusively in this sandbox or include global items
+            exclusive: whether to be exclusively in this sandbox or include global items.
         """
         self.store = store
         self.sandbox = sandbox
@@ -406,7 +406,7 @@ class SandboxStore(Store):
     def name(self) -> str:
         """
         Returns:
-            a string representing this data source
+            a string representing this data source.
         """
         return f"Sandbox[{self.store.name}][{self.sandbox}]"
 
@@ -414,7 +414,7 @@ class SandboxStore(Store):
     def sbx_criteria(self) -> Dict:
         """
         Returns:
-            the sandbox criteria dict used to filter the source store
+            the sandbox criteria dict used to filter the source store.
         """
         if self.exclusive:
             return {"sbxn": self.sandbox}
@@ -422,7 +422,7 @@ class SandboxStore(Store):
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -439,7 +439,7 @@ class SandboxStore(Store):
         limit: int = 0,
     ) -> Iterator[Dict]:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -483,7 +483,7 @@ class SandboxStore(Store):
 
     def update(self, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None):
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -502,7 +502,7 @@ class SandboxStore(Store):
 
     def remove_docs(self, criteria: Dict):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -526,7 +526,7 @@ class SandboxStore(Store):
 
     def __eq__(self, other: object) -> bool:
         """
-        Check equality for SandboxStore
+        Check equality for SandboxStore.
 
         Args:
             other: other SandboxStore to compare with

--- a/src/maggma/stores/aws.py
+++ b/src/maggma/stores/aws.py
@@ -398,7 +398,7 @@ class S3Store(Store):
         return resource, bucket
 
     def _get_full_key_path(self, id: str) -> str:
-        """Produces the full key path for S3 items
+        """Produces the full key path for S3 items.
 
         Args:
             id (str): The value of the key identifier.

--- a/src/maggma/stores/azure.py
+++ b/src/maggma/stores/azure.py
@@ -1,5 +1,5 @@
 """
-Advanced Stores for connecting to Microsoft Azure data
+Advanced Stores for connecting to Microsoft Azure data.
 """
 import os
 import threading
@@ -56,7 +56,7 @@ class AzureBlobStore(Store):
         **kwargs,
     ):
         """
-        Initializes an AzureBlob Store
+        Initializes an AzureBlob Store.
 
         Args:
             index: a store to use to index the Azure blob
@@ -122,13 +122,13 @@ class AzureBlobStore(Store):
     def name(self) -> str:
         """
         Returns:
-            a string representing this data source
+            a string representing this data source.
         """
         return f"container://{self.container_name}"
 
     def connect(self, *args, **kwargs):  # lgtm[py/conflicting-attributes]
         """
-        Connect to the source data
+        Connect to the source data.
         """
 
         service_client = self._get_service_client()
@@ -151,7 +151,7 @@ class AzureBlobStore(Store):
 
     def close(self):
         """
-        Closes any connections
+        Closes any connections.
         """
         self.index.close()
         self.service = None
@@ -161,7 +161,7 @@ class AzureBlobStore(Store):
     def _collection(self):
         """
         Returns:
-            a handle to the pymongo collection object
+            a handle to the pymongo collection object.
 
         Important:
             Not guaranteed to exist in the future
@@ -171,7 +171,7 @@ class AzureBlobStore(Store):
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -188,7 +188,7 @@ class AzureBlobStore(Store):
         limit: int = 0,
     ) -> Iterator[Dict]:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -241,7 +241,7 @@ class AzureBlobStore(Store):
 
     def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
         """
-        Get all distinct values for a field
+        Get all distinct values for a field.
 
         Args:
             field: the field(s) to get distinct values for
@@ -286,7 +286,7 @@ class AzureBlobStore(Store):
 
     def ensure_index(self, key: str, unique: bool = False) -> bool:
         """
-        Tries to create an index and return true if it succeeded
+        Tries to create an index and return true if it succeeded.
 
         Args:
             key: single key to index
@@ -304,7 +304,7 @@ class AzureBlobStore(Store):
         additional_metadata: Union[str, List[str], None] = None,
     ):
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -380,7 +380,7 @@ class AzureBlobStore(Store):
 
     def write_doc_to_blob(self, doc: Dict, search_keys: List[str]):
         """
-        Write the data to an Azure blob and return the metadata to be inserted into the index db
+        Write the data to an Azure blob and return the metadata to be inserted into the index db.
 
         Args:
             doc: the document
@@ -451,7 +451,7 @@ class AzureBlobStore(Store):
 
     def remove_docs(self, criteria: Dict, remove_blob_object: bool = False):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -500,7 +500,7 @@ class AzureBlobStore(Store):
         """
         Rebuilds the index Store from the data in Azure
         Relies on the index document being stores as the metadata for the file
-        This can help recover lost databases
+        This can help recover lost databases.
         """
 
         objects = self.container.list_blobs(name_starts_with=self.sub_dir)
@@ -524,7 +524,7 @@ class AzureBlobStore(Store):
         Read data from the index store and populate the metadata of the Azure Blob.
         Force all of the keys to be lower case to be Minio compatible
         Args:
-            index_query: query on the index store
+            index_query: query on the index store.
         """
         if self.container is None or self.service is None:
             raise RuntimeError("The store has not been connected")
@@ -545,7 +545,7 @@ class AzureBlobStore(Store):
     def __eq__(self, other: object) -> bool:
         """
         Check equality for AzureBlobStore
-        other: other AzureBlobStore to compare with
+        other: other AzureBlobStore to compare with.
         """
         if not isinstance(other, AzureBlobStore):
             return False

--- a/src/maggma/stores/azure.py
+++ b/src/maggma/stores/azure.py
@@ -523,6 +523,7 @@ class AzureBlobStore(Store):
         """
         Read data from the index store and populate the metadata of the Azure Blob.
         Force all of the keys to be lower case to be Minio compatible
+
         Args:
             index_query: query on the index store.
         """

--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -295,6 +295,7 @@ class JointStore(Store):
     def __eq__(self, other: object) -> bool:
         """
         Check equality for JointStore
+
         Args:
             other: other JointStore to compare with.
         """

--- a/src/maggma/stores/compound_stores.py
+++ b/src/maggma/stores/compound_stores.py
@@ -1,4 +1,4 @@
-""" Special stores that combine underlying Stores together """
+""" Special stores that combine underlying Stores together. """
 from datetime import datetime
 from itertools import groupby
 from typing import Dict, Iterator, List, Optional, Tuple, Union
@@ -40,7 +40,7 @@ class JointStore(Store):
             password: Password to connect with
             main: name for the main collection
                 if not specified this defaults to the first
-                in collection_names list
+                in collection_names list.
         """
         self.database = database
         self.collection_names = collection_names
@@ -59,14 +59,14 @@ class JointStore(Store):
     @property
     def name(self) -> str:
         """
-        Return a string representing this data source
+        Return a string representing this data source.
         """
         compound_name = ",".join(self.collection_names)
         return f"Compound[{self.host}/{self.database}][{compound_name}]"
 
     def connect(self, force_reset: bool = False):
         """
-        Connects the underlying Mongo database and all collection connections
+        Connects the underlying Mongo database and all collection connections.
 
         Args:
             force_reset: whether to reset the connection or not when the Store is
@@ -90,13 +90,13 @@ class JointStore(Store):
 
     def close(self):
         """
-        Closes underlying database connections
+        Closes underlying database connections.
         """
         self._collection.database.client.close()
 
     @property
     def _collection(self):
-        """Property referring to the root pymongo collection"""
+        """Property referring to the root pymongo collection."""
         if self._coll is None:
             raise StoreError("Must connect Mongo-like store before attempting to use it")
         return self._coll
@@ -104,7 +104,7 @@ class JointStore(Store):
     @property
     def nonmain_names(self) -> List:
         """
-        alll non-main collection names
+        alll non-main collection names.
         """
         return list(set(self.collection_names) - {self.main})
 
@@ -112,7 +112,7 @@ class JointStore(Store):
     def last_updated(self) -> datetime:
         """
         Special last_updated for this JointStore
-        that checks all underlying collections
+        that checks all underlying collections.
         """
         lus = []
         for cname in self.collection_names:
@@ -126,13 +126,13 @@ class JointStore(Store):
     def update(self, docs, update_lu=True, key=None, **kwargs):
         """
         Update documents into the underlying collections
-        Not Implemented for JointStore
+        Not Implemented for JointStore.
         """
         raise NotImplementedError("JointStore is a read-only store")
 
     def _get_store_by_name(self, name) -> MongoStore:
         """
-        Gets an underlying collection as a mongoStore
+        Gets an underlying collection as a mongoStore.
         """
         if name not in self.collection_names:
             raise ValueError("Asking for collection not referenced in this Store")
@@ -140,13 +140,13 @@ class JointStore(Store):
 
     def ensure_index(self, key, unique=False, **kwargs):
         """
-        Can't ensure index for JointStore
+        Can't ensure index for JointStore.
         """
         raise NotImplementedError("No ensure_index method for JointStore")
 
     def _get_pipeline(self, criteria=None, properties=None, skip=0, limit=0):
         """
-        Gets the aggregation pipeline for query and query_one
+        Gets the aggregation pipeline for query and query_one.
 
         Args:
             properties: properties to be returned
@@ -218,7 +218,7 @@ class JointStore(Store):
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -264,7 +264,7 @@ class JointStore(Store):
 
     def query_one(self, criteria=None, properties=None, **kwargs):
         """
-        Get one document
+        Get one document.
 
         Args:
             properties: properties to return in query
@@ -285,7 +285,7 @@ class JointStore(Store):
 
     def remove_docs(self, criteria: Dict):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -296,7 +296,7 @@ class JointStore(Store):
         """
         Check equality for JointStore
         Args:
-            other: other JointStore to compare with
+            other: other JointStore to compare with.
         """
         if not isinstance(other, JointStore):
             return False
@@ -313,12 +313,12 @@ class JointStore(Store):
 
 
 class ConcatStore(Store):
-    """Store concatting multiple stores"""
+    """Store concatting multiple stores."""
 
     def __init__(self, stores: List[Store], **kwargs):
         """
         Initialize a ConcatStore that concatenates multiple stores together
-        to appear as one store
+        to appear as one store.
 
         Args:
             stores: list of stores to concatenate together
@@ -330,14 +330,14 @@ class ConcatStore(Store):
     @property
     def name(self) -> str:
         """
-        A string representing this data source
+        A string representing this data source.
         """
         compound_name = ",".join([store.name for store in self.stores])
         return f"Concat[{compound_name}]"
 
     def connect(self, force_reset: bool = False):
         """
-        Connect all stores in this ConcatStore
+        Connect all stores in this ConcatStore.
 
         Args:
             force_reset: Whether to forcibly reset the connection for all stores
@@ -347,7 +347,7 @@ class ConcatStore(Store):
 
     def close(self):
         """
-        Close all connections in this ConcatStore
+        Close all connections in this ConcatStore.
         """
         for store in self.stores:
             store.close()
@@ -362,7 +362,7 @@ class ConcatStore(Store):
         Finds the most recent last_updated across all the stores.
         This might not be the most useful way to do this for this type of Store
         since it could very easily over-estimate the last_updated based on what stores
-        are used
+        are used.
         """
         lus = []
         for store in self.stores:
@@ -373,7 +373,7 @@ class ConcatStore(Store):
     def update(self, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None):
         """
         Update documents into the Store
-        Not implemented in ConcatStore
+        Not implemented in ConcatStore.
 
         Args:
             docs: the document or list of documents to update
@@ -386,7 +386,7 @@ class ConcatStore(Store):
 
     def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
         """
-        Get all distinct values for a field
+        Get all distinct values for a field.
 
         Args:
             field: the field(s) to get distinct values for
@@ -400,7 +400,7 @@ class ConcatStore(Store):
 
     def ensure_index(self, key: str, unique: bool = False) -> bool:
         """
-        Ensure an index is properly set. Returns whether all stores support this index or not
+        Ensure an index is properly set. Returns whether all stores support this index or not.
 
         Args:
             key: single key to index
@@ -413,7 +413,7 @@ class ConcatStore(Store):
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -431,7 +431,7 @@ class ConcatStore(Store):
         limit: int = 0,
     ) -> Iterator[Dict]:
         """
-        Queries across all Store for a set of documents
+        Queries across all Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -490,7 +490,7 @@ class ConcatStore(Store):
                 docs.extend(group)
 
         def key_set(d: Dict) -> Tuple:
-            "index function based on passed in keys"
+            "index function based on passed in keys."
             return tuple(d.get(k, None) for k in keys)
 
         sorted_docs = sorted(docs, key=key_set)
@@ -500,7 +500,7 @@ class ConcatStore(Store):
 
     def remove_docs(self, criteria: Dict):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -509,7 +509,7 @@ class ConcatStore(Store):
 
     def __eq__(self, other: object) -> bool:
         """
-        Check equality for ConcatStore
+        Check equality for ConcatStore.
 
         Args:
             other: other JointStore to compare with

--- a/src/maggma/stores/file_store.py
+++ b/src/maggma/stores/file_store.py
@@ -57,7 +57,8 @@ class FileStore(MemoryStore):
         **kwargs,
     ):
         """
-        Initializes a FileStore
+        Initializes a FileStore.
+
         Args:
             path: parent directory containing all files and subdirectories to process
             file_filters: List of fnmatch patterns defining the files to be tracked by
@@ -177,20 +178,20 @@ class FileStore(MemoryStore):
         Iterate through all files in the Store folder and populate
         the Store with dictionaries containing basic information about each file.
 
-        The keys of the documents added to the Store are
+        The keys of the documents added to the Store are:
 
-            name: str = File name
-            path: Path = Absolute path of this file
-            parent: str = Name of the parent directory (if any)
-            file_id: str = Unique identifier for this file, computed from the hash
-                        of its path relative to the base FileStore directory and
-                        the file creation time. The key of this field is 'file_id'
-                        by default but can be changed via the 'key' kwarg to
-                        FileStore.__init__().
-            size: int = Size of this file in bytes
-            last_updated: datetime = Time this file was last modified
-            hash: str = Hash of the file contents
-            orphan: bool = Whether this record is an orphan
+        - name: str = File name
+        - path: Path = Absolute path of this file
+        - parent: str = Name of the parent directory (if any)
+        - file_id: str = Unique identifier for this file, computed from the hash
+                    of its path relative to the base FileStore directory and
+                    the file creation time. The key of this field is 'file_id'
+                    by default but can be changed via the 'key' kwarg to
+                    `FileStore.__init__()`.
+        - size: int = Size of this file in bytes
+        - last_updated: datetime = Time this file was last modified
+        - hash: str = Hash of the file contents
+        - orphan: bool = Whether this record is an orphan
         """
         file_list = []
         # generate a list of files in subdirectories
@@ -214,18 +215,18 @@ class FileStore(MemoryStore):
         basic information about that file. The keys in the returned dict
         are:
 
-            name: str = File name
-            path: Path = Absolute path of this file
-            parent: str = Name of the parent directory (if any)
-            file_id: str = Unique identifier for this file, computed from the hash
-                        of its path relative to the base FileStore directory and
-                        the file creation time. The key of this field is 'file_id'
-                        by default but can be changed via the 'key' kwarg to
-                        FileStore.__init__().
-            size: int = Size of this file in bytes
-            last_updated: datetime = Time this file was last modified
-            hash: str = Hash of the file contents
-            orphan: bool = Whether this record is an orphan
+        - name: str = File name
+        - path: Path = Absolute path of this file
+        - parent: str = Name of the parent directory (if any)
+        - file_id: str = Unique identifier for this file, computed from the hash
+                    of its path relative to the base FileStore directory and
+                    the file creation time. The key of this field is 'file_id'
+                    by default but can be changed via the 'key' kwarg to
+                    FileStore.__init__().
+        - size: int = Size of this file in bytes
+        - last_updated: datetime = Time this file was last modified
+        - hash: str = Hash of the file contents
+        - orphan: bool = Whether this record is an orphan
         """
         # compute the file_id from the relative path
         relative_path = f.relative_to(self.path)

--- a/src/maggma/stores/file_store.py
+++ b/src/maggma/stores/file_store.py
@@ -119,7 +119,7 @@ class FileStore(MemoryStore):
     @property
     def name(self) -> str:
         """
-        Return a string representing this data source
+        Return a string representing this data source.
         """
         return f"file://{self.path}"
 
@@ -265,7 +265,7 @@ class FileStore(MemoryStore):
 
     def connect(self, force_reset: bool = False):
         """
-        Connect to the source data
+        Connect to the source data.
 
         Read all the files in the directory, create corresponding File
         items in the internal MemoryStore.
@@ -358,7 +358,7 @@ class FileStore(MemoryStore):
 
     def _filter_data(self, d):
         """
-        Remove any protected keys from a dictionary
+        Remove any protected keys from a dictionary.
 
         Args:
             d: Dictionary whose keys are to be filtered
@@ -376,7 +376,7 @@ class FileStore(MemoryStore):
         contents_size_limit: Optional[int] = 0,
     ) -> Iterator[Dict]:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -461,7 +461,7 @@ class FileStore(MemoryStore):
         contents_size_limit: Optional[int] = None,
     ):
         """
-        Queries the Store for a single document
+        Queries the Store for a single document.
 
         Args:
             criteria: PyMongo filter for documents to search

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -1,7 +1,7 @@
 """
 Module containing various definitions of Stores.
 Stores are a default access pattern to data and provide
-various utilities
+various utilities.
 """
 
 import copy
@@ -39,7 +39,7 @@ files_collection_fields = (
 
 class GridFSStore(Store):
     """
-    A Store for GridFS backend. Provides a common access method consistent with other stores
+    A Store for GridFS backend. Provides a common access method consistent with other stores.
     """
 
     def __init__(
@@ -100,7 +100,7 @@ class GridFSStore(Store):
     @classmethod
     def from_launchpad_file(cls, lp_file, collection_name, **kwargs):
         """
-        Convenience method to construct a GridFSStore from a launchpad file
+        Convenience method to construct a GridFSStore from a launchpad file.
 
         Note: A launchpad file is a special formatted yaml file used in fireworks
 
@@ -121,13 +121,13 @@ class GridFSStore(Store):
     @property
     def name(self) -> str:
         """
-        Return a string representing this data source
+        Return a string representing this data source.
         """
         return f"gridfs://{self.host}/{self.database}/{self.collection_name}"
 
     def connect(self, force_reset: bool = False):
         """
-        Connect to the source data
+        Connect to the source data.
 
         Args:
             force_reset: whether to reset the connection or not when the Store is
@@ -163,7 +163,7 @@ class GridFSStore(Store):
 
     @property
     def _collection(self):
-        """Property referring to underlying pymongo collection"""
+        """Property referring to underlying pymongo collection."""
         if self._coll is None:
             raise StoreError("Must connect Mongo-like store before attempting to use it")
         return self._coll
@@ -172,7 +172,7 @@ class GridFSStore(Store):
     def last_updated(self) -> datetime:
         """
         Provides the most recent last_updated date time stamp from
-        the documents in this Store
+        the documents in this Store.
         """
         return self._files_store.last_updated
 
@@ -195,7 +195,7 @@ class GridFSStore(Store):
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -274,7 +274,7 @@ class GridFSStore(Store):
     def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
         """
         Get all distinct values for a field. This function only operates
-        on the metadata in the files collection
+        on the metadata in the files collection.
 
         Args:
             field: the field(s) to get distinct values for
@@ -300,7 +300,7 @@ class GridFSStore(Store):
         """
         Simple grouping function that will group documents
         by keys. Will only work if the keys are included in the files
-        collection for GridFS
+        collection for GridFS.
 
         Args:
             keys: fields to group documents
@@ -333,7 +333,7 @@ class GridFSStore(Store):
         Currently operators on the GridFS files collection
         Args:
             key: single key to index
-            unique: Whether or not this index contains only unique keys
+            unique: Whether or not this index contains only unique keys.
 
         Returns:
             bool indicating if the index exists/was created
@@ -351,7 +351,7 @@ class GridFSStore(Store):
         additional_metadata: Union[str, List[str], None] = None,
     ):
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -402,7 +402,7 @@ class GridFSStore(Store):
 
     def remove_docs(self, criteria: Dict):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -423,7 +423,7 @@ class GridFSStore(Store):
     def __eq__(self, other: object) -> bool:
         """
         Check equality for GridFSStore
-        other: other GridFSStore to compare with
+        other: other GridFSStore to compare with.
         """
         if not isinstance(other, GridFSStore):
             return False
@@ -459,7 +459,7 @@ class GridFSURIStore(GridFSStore):
             collection_name: The collection name
             compression: compress the data as it goes into GridFS
             ensure_metadata: ensure returned documents have the metadata fields
-            searchable_fields: fields to keep in the index store
+            searchable_fields: fields to keep in the index store.
         """
 
         self.uri = uri
@@ -487,7 +487,7 @@ class GridFSURIStore(GridFSStore):
 
     def connect(self, force_reset: bool = False):
         """
-        Connect to the source data
+        Connect to the source data.
 
         Args:
             force_reset: whether to reset the connection or not when the Store is

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -452,7 +452,8 @@ class GridFSURIStore(GridFSStore):
         **kwargs,
     ):
         """
-        Initializes a GridFS Store for binary data
+        Initializes a GridFS Store for binary data.
+
         Args:
             uri: MongoDB+SRV URI
             database: database to connect to

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -180,6 +180,7 @@ class GridFSStore(Store):
     def transform_criteria(cls, criteria: Dict) -> Dict:
         """
         Allow client to not need to prepend 'metadata.' to query fields.
+
         Args:
             criteria: Query criteria
         """

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -706,6 +706,7 @@ class JSONStore(MemoryStore):
         """
         Helper method to read the contents of a JSON file and generate
         a list of docs.
+
         Args:
             path: Path to the JSON file to be read
         """

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -1,7 +1,7 @@
 """
 Module containing various definitions of Stores.
 Stores are a default access pattern to data and provide
-various utilities
+various utilities.
 """
 
 import warnings
@@ -41,7 +41,7 @@ except ImportError:
 
 class MongoStore(Store):
     """
-    A Store that connects to a Mongo collection
+    A Store that connects to a Mongo collection.
     """
 
     def __init__(
@@ -94,13 +94,13 @@ class MongoStore(Store):
     @property
     def name(self) -> str:
         """
-        Return a string representing this data source
+        Return a string representing this data source.
         """
         return f"mongo://{self.host}/{self.database}/{self.collection_name}"
 
     def connect(self, force_reset: bool = False):
         """
-        Connect to the source data
+        Connect to the source data.
 
         Args:
             force_reset: whether to reset the connection or not when the Store is
@@ -130,14 +130,14 @@ class MongoStore(Store):
             self._coll = db[self.collection_name]  # type: ignore
 
     def __hash__(self) -> int:
-        """Hash for MongoStore"""
+        """Hash for MongoStore."""
         return hash((self.database, self.collection_name, self.last_updated_field))
 
     @classmethod
     def from_db_file(cls, filename: str, **kwargs):
         """
         Convenience method to construct MongoStore from db_file
-        from old QueryEngine format
+        from old QueryEngine format.
         """
         kwargs = loadfn(filename)
         if "collection" in kwargs:
@@ -149,7 +149,7 @@ class MongoStore(Store):
     @classmethod
     def from_launchpad_file(cls, lp_file, collection_name, **kwargs):
         """
-        Convenience method to construct MongoStore from a launchpad file
+        Convenience method to construct MongoStore from a launchpad file.
 
         Note: A launchpad file is a special formatted yaml file used in fireworks
 
@@ -169,7 +169,7 @@ class MongoStore(Store):
 
     def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False) -> List:
         """
-        Get all distinct values for a field
+        Get all distinct values for a field.
 
         Args:
             field: the field(s) to get distinct values for
@@ -243,7 +243,7 @@ class MongoStore(Store):
         """
         Generates a MongoStore from a pymongo collection object
         This is not a fully safe operation as it gives dummy information to the MongoStore
-        As a result, this will not serialize and can not reset its connection
+        As a result, this will not serialize and can not reset its connection.
 
         Args:
             collection: the PyMongo collection to create a MongoStore around
@@ -258,7 +258,7 @@ class MongoStore(Store):
 
     @property
     def _collection(self):
-        """Property referring to underlying pymongo collection"""
+        """Property referring to underlying pymongo collection."""
         if self._coll is None:
             raise StoreError("Must connect Mongo-like store before attempting to use it")
         return self._coll
@@ -269,7 +269,7 @@ class MongoStore(Store):
         hint: Optional[Dict[str, Union[Sort, int]]] = None,
     ) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -303,7 +303,7 @@ class MongoStore(Store):
         **kwargs,
     ) -> Iterator[Dict]:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -351,7 +351,7 @@ class MongoStore(Store):
         Tries to create an index and return true if it succeeded
         Args:
             key: single key to index
-            unique: Whether or not this index contains only unique keys
+            unique: Whether or not this index contains only unique keys.
 
         Returns:
             bool indicating if the index exists/was created
@@ -368,7 +368,7 @@ class MongoStore(Store):
 
     def update(self, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None):
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -416,7 +416,7 @@ class MongoStore(Store):
 
     def remove_docs(self, criteria: Dict):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -424,7 +424,7 @@ class MongoStore(Store):
         self._collection.delete_many(filter=criteria)
 
     def close(self):
-        """Close up all collections"""
+        """Close up all collections."""
         self._collection.database.client.close()
         self._coll = None
         if self.ssh_tunnel is not None:
@@ -433,7 +433,7 @@ class MongoStore(Store):
     def __eq__(self, other: object) -> bool:
         """
         Check equality for MongoStore
-        other: other mongostore to compare with
+        other: other mongostore to compare with.
         """
         if not isinstance(other, MongoStore):
             return False
@@ -446,7 +446,7 @@ class MongoURIStore(MongoStore):
     """
     A Store that connects to a Mongo collection via a URI
     This is expected to be a special mongodb+srv:// URIs that include
-    client parameters via TXT records
+    client parameters via TXT records.
     """
 
     def __init__(
@@ -489,14 +489,14 @@ class MongoURIStore(MongoStore):
     @property
     def name(self) -> str:
         """
-        Return a string representing this data source
+        Return a string representing this data source.
         """
         # TODO: This is not very safe since it exposes the username/password info
         return self.uri
 
     def connect(self, force_reset: bool = False):
         """
-        Connect to the source data
+        Connect to the source data.
 
         Args:
             force_reset: whether to reset the connection or not when the Store is
@@ -511,14 +511,14 @@ class MongoURIStore(MongoStore):
 class MemoryStore(MongoStore):
     """
     An in-memory Store that functions similarly
-    to a MongoStore
+    to a MongoStore.
     """
 
     def __init__(self, collection_name: str = "memory_db", **kwargs):
         """
         Initializes the Memory Store
         Args:
-            collection_name: name for the collection in memory
+            collection_name: name for the collection in memory.
         """
         self.collection_name = collection_name
         self.default_sort = None
@@ -528,7 +528,7 @@ class MemoryStore(MongoStore):
 
     def connect(self, force_reset: bool = False):
         """
-        Connect to the source data
+        Connect to the source data.
 
         Args:
             force_reset: whether to reset the connection or not when the Store is
@@ -538,16 +538,16 @@ class MemoryStore(MongoStore):
             self._coll = mongomock.MongoClient().db[self.name]  # type: ignore
 
     def close(self):
-        """Close up all collections"""
+        """Close up all collections."""
         self._coll.database.client.close()
 
     @property
     def name(self):
-        """Name for the store"""
+        """Name for the store."""
         return f"mem://{self.collection_name}"
 
     def __hash__(self):
-        """Hash for the store"""
+        """Hash for the store."""
         return hash((self.name, self.last_updated_field))
 
     def groupby(
@@ -598,7 +598,7 @@ class MemoryStore(MongoStore):
     def __eq__(self, other: object) -> bool:
         """
         Check equality for MemoryStore
-        other: other MemoryStore to compare with
+        other: other MemoryStore to compare with.
         """
         if not isinstance(other, MemoryStore):
             return False
@@ -609,7 +609,7 @@ class MemoryStore(MongoStore):
 
 class JSONStore(MemoryStore):
     """
-    A Store for access to a single or multiple JSON files
+    A Store for access to a single or multiple JSON files.
     """
 
     def __init__(
@@ -671,7 +671,7 @@ class JSONStore(MemoryStore):
 
     def connect(self, force_reset: bool = False):
         """
-        Loads the files into the collection in memory
+        Loads the files into the collection in memory.
 
         Args:
             force_reset: whether to reset the connection or not. If False (default) and .connect()
@@ -776,7 +776,7 @@ class JSONStore(MemoryStore):
 
     def __eq__(self, other: object) -> bool:
         """
-        Check equality for JSONStore
+        Check equality for JSONStore.
 
         Args:
             other: other JSONStore to compare with
@@ -885,7 +885,7 @@ class MontyStore(MemoryStore):
         hint: Optional[Dict[str, Union[Sort, int]]] = None,
     ) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -348,7 +348,8 @@ class MongoStore(Store):
 
     def ensure_index(self, key: str, unique: Optional[bool] = False) -> bool:
         """
-        Tries to create an index and return true if it succeeded
+        Tries to create an index and return true if it succeeded.
+
         Args:
             key: single key to index
             unique: Whether or not this index contains only unique keys.
@@ -516,7 +517,8 @@ class MemoryStore(MongoStore):
 
     def __init__(self, collection_name: str = "memory_db", **kwargs):
         """
-        Initializes the Memory Store
+        Initializes the Memory Store.
+
         Args:
             collection_name: name for the collection in memory.
         """

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -45,7 +45,7 @@ class PandasMemoryStore:
         """
         Args:
             key: main key to index on
-            last_updated_field: field for date/time stamping the data
+            last_updated_field: field for date/time stamping the data.
         """
         self._data = None
         self.key = key
@@ -82,7 +82,7 @@ class PandasMemoryStore:
         criteria_fields: Union[List, None] = None,
     ) -> pd.DataFrame:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: if there's a `query` key, it's value will be used as the
@@ -160,7 +160,7 @@ class PandasMemoryStore:
 
     def count(self, criteria: Optional[Dict] = None, criteria_fields: Union[List, None] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Returns:
             int: the number of documents matching the query criteria
@@ -175,7 +175,7 @@ class PandasMemoryStore:
         self, field: str, criteria: Optional[Dict] = None, criteria_fields: Union[List, None] = None
     ) -> pd.Series:
         """
-        Get all distinct values for a field
+        Get all distinct values for a field.
 
         Args:
             field: the field(s) to get distinct values for
@@ -193,7 +193,7 @@ class PandasMemoryStore:
     def last_updated(self) -> datetime:
         """
         Provides the most recent last_updated date time stamp from
-        the documents in this Store
+        the documents in this Store.
         """
         if self._data is None:
             return datetime.min
@@ -280,7 +280,7 @@ class PandasMemoryStore:
 
     def update(self, docs: pd.DataFrame) -> pd.DataFrame:
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -300,13 +300,13 @@ class PandasMemoryStore:
         return key in self._data
 
     def __hash__(self):
-        """Hash for the store"""
+        """Hash for the store."""
         return hash((self.key, self.last_updated_field))
 
     def __eq__(self, other: object) -> bool:
         """
         Check equality for PandasMemoryStore
-        other: other PandasMemoryStore to compare with
+        other: other PandasMemoryStore to compare with.
         """
         if not isinstance(other, PandasMemoryStore):
             return False
@@ -332,7 +332,7 @@ class S3IndexStore(PandasMemoryStore):
         manifest_key: str = "manifest.jsonl",
         **kwargs,
     ):
-        """Initializes an S3IndexStore
+        """Initializes an S3IndexStore.
 
         Args:
             collection_name (str): name of the collection
@@ -467,7 +467,7 @@ class OpenDataStore(S3IndexStore):
         object_grouping: Optional[List[str]] = None,
         **kwargs,
     ):
-        """Initializes an OpenDataStore
+        """Initializes an OpenDataStore.
 
         Args:
             index (S3IndexStore): The store that'll be used as the index,
@@ -547,7 +547,7 @@ class OpenDataStore(S3IndexStore):
         criteria_fields: Union[List, None] = None,
     ) -> pd.DataFrame:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: if there's a `query` key, it's value will be used as the

--- a/src/maggma/stores/shared_stores.py
+++ b/src/maggma/stores/shared_stores.py
@@ -271,6 +271,7 @@ class MultiStore:
 
         Note: this is not a search for an instance of a store,
             but rather a search for a equivalent store
+
         Args:
             store: The store to find
 

--- a/src/maggma/stores/shared_stores.py
+++ b/src/maggma/stores/shared_stores.py
@@ -60,20 +60,20 @@ class StoreFacade(Store):
     @property
     def _collection(self):
         """
-        Returns a handle to the pymongo collection object
+        Returns a handle to the pymongo collection object.
         """
         return self.multistore.store_collection(self.store)
 
     @property
     def name(self) -> str:
         """
-        Return a string representing this data source
+        Return a string representing this data source.
         """
         return self.multistore.store_name(self.store)
 
     def connect(self, force_reset: bool = False):
         """
-        Connect to the source data
+        Connect to the source data.
 
         Args:
             force_reset: whether to reset the connection or not when the Store is
@@ -83,13 +83,13 @@ class StoreFacade(Store):
 
     def close(self):
         """
-        Closes any connections
+        Closes any connections.
         """
         self.multistore.close(self.store)
 
     def count(self, criteria: Optional[Dict] = None) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -105,7 +105,7 @@ class StoreFacade(Store):
         limit: int = 0,
     ) -> Iterator[Dict]:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -126,7 +126,7 @@ class StoreFacade(Store):
 
     def update(self, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None, **kwargs):
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -139,7 +139,7 @@ class StoreFacade(Store):
 
     def ensure_index(self, key: str, unique: bool = False, **kwargs) -> bool:
         """
-        Tries to create an index and return true if it succeeded
+        Tries to create an index and return true if it succeeded.
 
         Args:
             key: single key to index
@@ -182,7 +182,7 @@ class StoreFacade(Store):
 
     def remove_docs(self, criteria: Dict, **kwargs):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -197,7 +197,7 @@ class StoreFacade(Store):
         **kwargs,
     ):
         """
-        Queries the Store for a single document
+        Queries the Store for a single document.
 
         Args:
             criteria: PyMongo filter for documents to search
@@ -209,7 +209,7 @@ class StoreFacade(Store):
 
     def distinct(self, field: str, criteria: Optional[Dict] = None, all_exist: bool = False, **kwargs) -> List:
         """
-        Get all distinct values for a field
+        Get all distinct values for a field.
 
         Args:
             field: the field(s) to get distinct values for
@@ -257,7 +257,7 @@ class MultiStore:
 
     def __init__(self, **kwargs):
         """
-        Initializes a MultiStore
+        Initializes a MultiStore.
         """
         # Keep a list of stores, since there is no way to hash a store (to use a dict)
         self._stores = []
@@ -267,7 +267,7 @@ class MultiStore:
     def get_store_index(self, store: Store) -> Optional[int]:
         """
         Gets the index of the store in the list of stores.
-        If it doesn't exist, returns None
+        If it doesn't exist, returns None.
 
         Note: this is not a search for an instance of a store,
             but rather a search for a equivalent store
@@ -285,7 +285,7 @@ class MultiStore:
 
     def add_store(self, store: Store):
         """
-        Adds a store to the list of cached stores
+        Adds a store to the list of cached stores.
 
         Args:
             store: The store to cache
@@ -331,7 +331,7 @@ class MultiStore:
 
     def count_stores(self) -> int:
         """
-        Returns the number of stores in the multistore
+        Returns the number of stores in the multistore.
 
         Returns:
             int indicating the number of stores
@@ -349,7 +349,7 @@ class MultiStore:
 
     def connect(self, store, force_reset: bool = False):
         """
-        For a given store, connect to the source data
+        For a given store, connect to the source data.
 
         Args:
             store: the store to connect to the source data
@@ -362,7 +362,7 @@ class MultiStore:
 
     def close(self, store: Store):
         """
-        For a given store, close any connections
+        For a given store, close any connections.
 
         Args:
             store: the store to close connections to
@@ -373,7 +373,7 @@ class MultiStore:
 
     def connect_all(self, force_reset: bool = False):
         """
-        Connects to all stores
+        Connects to all stores.
 
         Args:
             force_reset: whether to reset the connection or not when the Store is
@@ -385,7 +385,7 @@ class MultiStore:
 
     def close_all(self):
         """
-        Closes all connections
+        Closes all connections.
         """
         with self._multistore_lock:
             for store in self._stores:
@@ -393,7 +393,7 @@ class MultiStore:
 
     def count(self, store: Store, criteria: Optional[Dict] = None, **kwargs) -> int:
         """
-        Counts the number of documents matching the query criteria
+        Counts the number of documents matching the query criteria.
 
         Args:
             criteria: PyMongo filter for documents to count in
@@ -412,7 +412,7 @@ class MultiStore:
         **kwargs,
     ) -> List[Dict]:
         """
-        Queries the Store for a set of documents
+        Queries the Store for a set of documents.
 
         Args:
             criteria: PyMongo filter for documents to search in
@@ -432,7 +432,7 @@ class MultiStore:
 
     def update(self, store: Store, docs: Union[List[Dict], Dict], key: Union[List, str, None] = None, **kwargs):
         """
-        Update documents into the Store
+        Update documents into the Store.
 
         Args:
             docs: the document or list of documents to update
@@ -446,7 +446,7 @@ class MultiStore:
 
     def ensure_index(self, store: Store, key: str, unique: bool = False, **kwargs) -> bool:
         """
-        Tries to create an index and return true if it succeeded
+        Tries to create an index and return true if it succeeded.
 
         Args:
             key: single key to index
@@ -492,7 +492,7 @@ class MultiStore:
 
     def remove_docs(self, store: Store, criteria: Dict, **kwargs):
         """
-        Remove docs matching the query dictionary
+        Remove docs matching the query dictionary.
 
         Args:
             criteria: query dictionary to match
@@ -509,7 +509,7 @@ class MultiStore:
         **kwargs,
     ):
         """
-        Queries the Store for a single document
+        Queries the Store for a single document.
 
         Args:
             criteria: PyMongo filter for documents to search
@@ -527,7 +527,7 @@ class MultiStore:
         self, store: Store, field: str, criteria: Optional[Dict] = None, all_exist: bool = False, **kwargs
     ) -> List:
         """
-        Get all distinct values for a field
+        Get all distinct values for a field.
 
         Args:
             field: the field(s) to get distinct values for
@@ -538,7 +538,7 @@ class MultiStore:
 
     def set_store_attribute(self, store: Store, name: str, value: Any):
         """
-        A method to set an attribute of a store
+        A method to set an attribute of a store.
 
         Args:
             name: The name of a function or attribute to access
@@ -550,7 +550,7 @@ class MultiStore:
 
     def call_attr(self, name: str, store: Store, **kwargs):
         """
-        This class will actually call an attribute/method on the class instance
+        This class will actually call an attribute/method on the class instance.
 
         Args:
             name: The name of a function or attribute to access
@@ -596,7 +596,7 @@ class MultiStoreManager(BaseManager):
     def setup(cls, multistore):
         """
         Args:
-            multistore: A multistore to share between processes
+            multistore: A multistore to share between processes.
 
         Returns:
             A manager

--- a/src/maggma/stores/ssh_tunnel.py
+++ b/src/maggma/stores/ssh_tunnel.py
@@ -30,7 +30,7 @@ class SSHTunnel(MSONable):
             password: optional password for the ssh tunnel server; If a private_key is
                 supplied this password is assumed to be the private key password
             private_key: ssh private key to authenticate to the tunnel server
-            kwargs: any extra args passed to the SSHTunnelForwarder
+            kwargs: any extra args passed to the SSHTunnelForwarder.
         """
 
         self.tunnel_server_address = tunnel_server_address

--- a/src/maggma/utils.py
+++ b/src/maggma/utils.py
@@ -1,5 +1,5 @@
 """
-Utilities to help with maggma functions
+Utilities to help with maggma functions.
 """
 import itertools
 import logging
@@ -24,7 +24,7 @@ from tqdm.auto import tqdm
 
 def primed(iterable: Iterable) -> Iterable:
     """Preprimes an iterator so the first value is calculated immediately
-    but not returned until the first iteration
+    but not returned until the first iteration.
     """
     itr = iter(iterable)
     try:
@@ -36,18 +36,18 @@ def primed(iterable: Iterable) -> Iterable:
 
 class TqdmLoggingHandler(logging.Handler):
     """
-    Helper to enable routing tqdm progress around logging
+    Helper to enable routing tqdm progress around logging.
     """
 
     def __init__(self, level=logging.NOTSET):
         """
-        Initialize the Tqdm handler
+        Initialize the Tqdm handler.
         """
         super().__init__(level)
 
     def emit(self, record):
         """
-        Emit a record via Tqdm screen
+        Emit a record via Tqdm screen.
         """
         try:
             msg = self.format(record)
@@ -60,7 +60,7 @@ class TqdmLoggingHandler(logging.Handler):
 
 
 def confirm_field_index(collection: Collection, field: str) -> bool:
-    """Confirm index on store for at least one of fields
+    """Confirm index on store for at least one of fields.
 
     One can't simply ensure an index exists via
     `store.collection.create_index` because a Builder must assume
@@ -105,7 +105,7 @@ LU_KEY_ISOFORMAT = (to_dt, to_isoformat_ceil_ms)
 
 def recursive_update(d: Dict, u: Dict):
     """
-    Recursive updates d with values from u
+    Recursive updates d with values from u.
 
     Args:
         d (dict): dict to update
@@ -126,7 +126,7 @@ def grouper(iterable: Iterable, n: int) -> Iterable:
     """
     Collect data into fixed-length chunks or blocks.
     >>> list(grouper(3, 'ABCDEFG'))
-    [['A', 'B', 'C'], ['D', 'E', 'F'], ['G']]
+    [['A', 'B', 'C'], ['D', 'E', 'F'], ['G']].
 
     Updated from:
     https://stackoverflow.com/questions/31164731/python-chunking-csv-file-multiproccessing/31170795#31170795
@@ -137,7 +137,7 @@ def grouper(iterable: Iterable, n: int) -> Iterable:
 
 def lazy_substitute(d: Dict, aliases: Dict):
     """
-    Simple top level substitute that doesn't dive into mongo like strings
+    Simple top level substitute that doesn't dive into mongo like strings.
     """
     for alias, key in aliases.items():
         if key in d:
@@ -148,7 +148,7 @@ def lazy_substitute(d: Dict, aliases: Dict):
 def substitute(d: Dict, aliases: Dict):
     """
     Substitutes keys in dictionary
-    Accepts multilevel mongo like keys
+    Accepts multilevel mongo like keys.
     """
     for alias, key in aliases.items():
         if has(d, key):
@@ -158,7 +158,7 @@ def substitute(d: Dict, aliases: Dict):
 
 def unset(d: Dict, key: str):
     """
-    Unsets a key
+    Unsets a key.
     """
     _unset(d, key)
     path = to_path(key)
@@ -170,7 +170,7 @@ def unset(d: Dict, key: str):
 class Timeout:
     """
     Context manager that provides context.
-    implementation courtesy of https://stackoverflow.com/a/22348885/637562
+    implementation courtesy of https://stackoverflow.com/a/22348885/637562.
     """
 
     def __init__(self, seconds=14, error_message=""):
@@ -187,13 +187,13 @@ class Timeout:
 
     def handle_timeout(self, signum, frame):
         """
-        Raises an error on timeout
+        Raises an error on timeout.
         """
         raise TimeoutError(self.error_message)
 
     def __enter__(self):
         """
-        Enter context with timeout
+        Enter context with timeout.
         """
         if self.seconds:
             signal.signal(signal.SIGALRM, self.handle_timeout)
@@ -201,7 +201,7 @@ class Timeout:
 
     def __exit__(self, type, value, traceback):
         """
-        Exit context with timeout
+        Exit context with timeout.
         """
         if self.seconds:
             signal.alarm(0)
@@ -209,7 +209,7 @@ class Timeout:
 
 def dynamic_import(abs_module_path: str, class_name: Optional[str] = None):
     """
-    Dynamic class importer from: https://www.bnmetrics.com/blog/dynamic-import-in-python3
+    Dynamic class importer from: https://www.bnmetrics.com/blog/dynamic-import-in-python3.
     """
 
     if class_name is None:
@@ -223,12 +223,12 @@ def dynamic_import(abs_module_path: str, class_name: Optional[str] = None):
 class ReportingHandler(logging.Handler):
     """
     Helper to route reporting messages
-    This uses the NOTSET level to send reporting messages
+    This uses the NOTSET level to send reporting messages.
     """
 
     def __init__(self, reporting_store):
         """
-        Initialize the Reporting Logger
+        Initialize the Reporting Logger.
         """
         super().__init__(logging.NOTSET)
         self.reporting_store = reporting_store
@@ -239,7 +239,7 @@ class ReportingHandler(logging.Handler):
 
     def emit(self, record):
         """
-        Emit a record via Tqdm screen
+        Emit a record via Tqdm screen.
         """
         if "maggma" in record.__dict__:
             maggma_record = record.maggma

--- a/src/maggma/validators.py
+++ b/src/maggma/validators.py
@@ -31,7 +31,7 @@ class JSONSchemaValidator(Validator):
             is found and raise a ValueError, if False will continue
             build but log an error message. In both cases, invalid
             documents will not be stored.
-            schema: A Python dict representation of a JSON
+            schema: A Python dict representation of a JSON.
         """
         self._schema = schema
         self._strict = strict
@@ -78,7 +78,7 @@ class JSONSchemaValidator(Validator):
     def validation_errors(self, doc: Dict) -> List[str]:
         """
         If document is not valid, provides a list of
-        strings to display for why validation has failed
+        strings to display for why validation has failed.
 
         Returns empty list if the document is valid
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -77,6 +77,7 @@ def test_msonable(owner_store, pet_store):
 def search_helper(payload, base: str = "/?", debug=True) -> Tuple[Response, Any]:
     """
     Helper function to directly query search endpoints
+
     Args:
         store: store f
         base: base of the query, default to /query?

--- a/tests/api/test_read_resource.py
+++ b/tests/api/test_read_resource.py
@@ -110,7 +110,8 @@ def test_problem_hint_scheme(owner_store):
 
 def search_helper(payload, base: str = "/?", debug=True) -> Response:
     """
-    Helper function to directly query search endpoints
+    Helper function to directly query search endpoints.
+
     Args:
         store: store f
         base: base of the query, default to /query?


### PR DESCRIPTION
In a similar vein to https://github.com/materialsproject/api/pull/863, this PR makes several docstring fixes that are otherwise breaking the rendered mkdocs, making it quite hard for users to use the API without digging into the code.

- [x] Enable D411 ruff rule in pre-commit to ensure that sections are properly demarcated
- [x] Fix D415 missing punctuation at end of summary so that docstring formats get properly detected
- [x] Manually fix some broken docstrings in cases where indented code was erroneously treated as code snippets


Example from deployed docs:

![2024-02-18-121757_705x632_scrot](https://github.com/materialsproject/maggma/assets/7916000/e2ed335e-7817-4a9f-b4aa-2e2dcf925858)

Which will now look like:


![2024-02-18-121734_781x657_scrot](https://github.com/materialsproject/maggma/assets/7916000/cade95f6-e13e-4d96-a0f3-3ada0c827d02)

There are still hundreds of pydocstyle warnings but I think this at least fixes the ones that mkdocs(trings) will care about.
