### PR TITLE
Adding Dask support to mrun

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     extras_require={
         "vault": ["hvac>=0.9.5"],
         "memray": ["memray>=1.7.0"],
-        "dask": ["dask>=2024.1.1", "distributed>=2024.1.1", "bokeh!=3.0.*,>=2.4.2", "aysncssh>=2.14.2"],
+        "dask": ["dask>=2024.1.1", "distributed>=2024.1.1", "bokeh!=3.0.*,>=2.4.2", "asyncssh>=2.14.2"],
         "montydb": ["montydb>=2.3.12"],
         "notebook_runner": ["IPython>=8.11", "nbformat>=5.0", "regex>=2020.6"],
         "azure": ["azure-storage-blob>=12.16.0", "azure-identity>=1.12.0"],

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     extras_require={
         "vault": ["hvac>=0.9.5"],
         "memray": ["memray>=1.7.0"],
+        "dask": ["dask>=2024.1.1", "distributed>=2024.1.1", "bokeh!=3.0.*,>=2.4.2", "aysncssh>=2.14.2"],
         "montydb": ["montydb>=2.3.12"],
         "notebook_runner": ["IPython>=8.11", "nbformat>=5.0", "regex>=2020.6"],
         "azure": ["azure-storage-blob>=12.16.0", "azure-identity>=1.12.0"],

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -113,10 +113,13 @@ class BrokerExcepton(Exception):
 )
 @click.option(
     "--memory-limit",
-    default=None,
-    type=str,
-    help="""Amount of memory ('512MB', '4GB', etc.) to be allocated to each worker (process) for Dask.
-        Default is no limit""",
+    default="auto",
+    show_default=True,
+    help="""Bytes of memory that the worker can use.
+    This can be an integer (bytes),
+    float (fraction of total system memory),
+    string (like '5GB' or '5000M'),
+    'auto', or 0, for no memory management""",
 )
 @click.option(
     "--scheduler-address",

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -98,7 +98,6 @@ class BrokerExcepton(Exception):
 )
 @click.option(
     "--dask-workers",
-    "dask_workers",
     default=1,
     type=int,
     help="""Number of 'workers' to start. If using a distributed cluster,
@@ -106,7 +105,6 @@ class BrokerExcepton(Exception):
 )
 @click.option(
     "--memory-limit",
-    "memory_limit",
     default=None,
     type=str,
     help="""Amount of memory ('512MB', '4GB', etc.) to be allocated to each worker (process) for Dask.
@@ -114,21 +112,18 @@ class BrokerExcepton(Exception):
 )
 @click.option(
     "--scheduler-address",
-    "scheduler_address",
     type=str,
     default="127.0.0.1",
     help="Address for Dask scheduler",
 )
 @click.option(
     "--scheduler-port",
-    "scheduler_port",
     default=8786,
     type=int,
     help="Port for the Dask scheduler to communicate with workers over",
 )
 @click.option(
     "--hosts",
-    "hosts",
     default=None,
     type=click.Path(exists=True),
     help="""Path to file containing addresses of host machines for creating a Dask SSHcluster.

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -105,7 +105,7 @@ class BrokerExcepton(Exception):
 )
 @click.option(
     "--dask-threads",
-    default=0,
+    default=None,
     type=int,
     help="""Number of threads per worker process.
     Defaults to number of cores divided by the number of

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -134,6 +134,7 @@ class BrokerExcepton(Exception):
     type=int,
     help="Port for the Dask scheduler to communicate with workers over",
 )
+@click.option("--dashboard-port", "dashboard_port", default=8787, type=int, help="")
 @click.option(
     "--hosts",
     default=None,

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -173,12 +173,14 @@ def run(
     num_processes,
     rabbitmq,
     dask,
-    processes,
+    dashboard_port,
+    dask_threads,
     dask_workers,
+    hostfile,
     memory_limit,
+    processes,
     scheduler_address,
     scheduler_port,
-    hostfile,
     queue_prefix,
     memray,
     memray_dir,
@@ -286,12 +288,15 @@ def run(
                 worker(url=url, port=port, num_processes=num_processes, no_bars=no_bars)
     elif dask:
         dask_executor(
+            builders=builder_objects,
+            dashboard_port=dashboard_port,
+            dask_threads=dask_threads,
+            dask_workers=dask_workers,
+            hostfile=hostfile,
+            memory_limit=memory_limit,
+            processes=-processes,
             scheduler_address=scheduler_address,
             scheduler_port=scheduler_port,
-            dask_hosts=hosts,
-            builders=builder_objects,
-            dask_workers=dask_workers,
-            processes=-processes,
         )
     else:
         if num_processes == 1:

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -136,11 +136,10 @@ class BrokerExcepton(Exception):
 )
 @click.option("--dashboard-port", "dashboard_port", default=8787, type=int, help="")
 @click.option(
-    "--hosts",
+    "--hostfile",
     default=None,
     type=click.Path(exists=True),
-    help="""Path to file containing addresses of host machines for creating a Dask SSHcluster.
-    A Dask LocalCluster will be created if no 'hosts' are provided""",
+    help="Textfile with hostnames/IP addresses for creating Dask SSHCluster",
 )
 @click.option(
     "-m",
@@ -179,7 +178,7 @@ def run(
     memory_limit,
     scheduler_address,
     scheduler_port,
-    hosts,
+    hostfile,
     queue_prefix,
     memray,
     memray_dir,

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -121,6 +121,8 @@ class BrokerExcepton(Exception):
     string (like '5GB' or '5000M'),
     'auto', or 0, for no memory management""",
 )
+@click.option("--perf-report", default=False, is_flag=True, help="Turn on to save diagnostic report for Dask dashboard")
+@click.option("--report-name", default="dask_report.html", help="File name for Dask diagnostic report")
 @click.option(
     "--scheduler-address",
     type=str,
@@ -179,6 +181,8 @@ def run(
     hostfile,
     memory_limit,
     processes,
+    perf_report,
+    report_name,
     scheduler_address,
     scheduler_port,
     queue_prefix,
@@ -295,6 +299,8 @@ def run(
             hostfile=hostfile,
             memory_limit=memory_limit,
             processes=-processes,
+            perf_report=perf_report,
+            report_name=report_name,
             scheduler_address=scheduler_address,
             scheduler_port=scheduler_port,
         )

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -114,7 +114,8 @@ class BrokerExcepton(Exception):
     "--scheduler-address",
     type=str,
     default="127.0.0.1",
-    help="Address for Dask scheduler",
+    help="""Address for Dask scheduler. If a host file is provided,
+    the first entry in the file will be used for the scheduler""",
 )
 @click.option(
     "--scheduler-port",

--- a/src/maggma/cli/__init__.py
+++ b/src/maggma/cli/__init__.py
@@ -104,6 +104,14 @@ class BrokerExcepton(Exception):
     this will set the number of workers, or processes, per Dask Worker""",
 )
 @click.option(
+    "--dask-threads",
+    default=0,
+    type=int,
+    help="""Number of threads per worker process.
+    Defaults to number of cores divided by the number of
+    processes per host.""",
+)
+@click.option(
     "--memory-limit",
     default=None,
     type=str,

--- a/src/maggma/cli/dask_executor.py
+++ b/src/maggma/cli/dask_executor.py
@@ -78,7 +78,7 @@ def dask_executor(
 
 def setup_dask(
     dashboard_port: int,
-    hostnames: Union(List[str], None),
+    hostnames: Union[List[str], None],
     memory_limit,
     n_workers: int,
     nthreads: int,

--- a/src/maggma/cli/dask_executor.py
+++ b/src/maggma/cli/dask_executor.py
@@ -9,7 +9,7 @@ from maggma.core import Builder
 
 try:
     import dask
-    from dask.distributed import LocalCluster, SSHCluster
+    from dask.distributed import LocalCluster, SSHCluster, performance_report
 except ImportError:
     raise ImportError("Both dask and distributed are required to use Dask as a broker")
 
@@ -24,6 +24,8 @@ def dask_executor(
     dask_workers: int,
     memory_limit,
     processes: bool,
+    perf_report: bool,
+    report_name: str,
     scheduler_address: str,
     scheduler_port: int,
 ):
@@ -32,19 +34,19 @@ def dask_executor(
     that will be submitted to a Dask scheduler for distributed processing
     on a Dask cluster.
     """
-    logger = getLogger("Scheduler")
+    scheduler_logger = getLogger("Scheduler")
 
     if hostfile:
         with open(hostfile) as file:
             hostnames = file.read().split()
 
-        logger.info(
+        scheduler_logger.info(
             f"""Starting distributed Dask cluster, with scheduler at {hostnames[0]}:{scheduler_port},
             and workers at: {hostnames[1:]}:{scheduler_port}..."""
         )
     else:
         hostnames = None
-        logger.info(f"Starting Dask LocalCluster with scheduler at: {scheduler_address}:{scheduler_port}...")
+        scheduler_logger.info(f"Starting Dask LocalCluster with scheduler at: {scheduler_address}:{scheduler_port}...")
 
     client = setup_dask(
         dashboard_port=dashboard_port,
@@ -57,29 +59,13 @@ def dask_executor(
         scheduler_port=scheduler_port,
     )
 
-    logger.info(f"Dask dashboard available at: {client.dashboard_link}")
+    scheduler_logger.info(f"Dask dashboard available at: {client.dashboard_link}")
 
-    for builder in builders:
-        builder_name = builder.__class__.__name__
-        logger.info(f"Working on {builder_name}")
-        builder.connect()
-        items = builder.get_items()
-
-        task_graph = []
-        for idx, chunk in enumerate(items):
-            chunk_token = dask.base.tokenize(idx)
-            docs = dask.delayed(builder.get_processed_docs)(
-                chunk, dask_key_name=f"{builder_name}.get_processed_docs-" + chunk_token
-            )
-            built_docs = dask.delayed(builder.process_item)(
-                docs, dask_key_name=f"{builder_name}.process_item-" + chunk_token
-            )
-            update_store = dask.delayed(builder.update_targets)(
-                built_docs, dask_key_name=f"{builder_name}.update_targets-" + chunk_token
-            )
-            task_graph.append(update_store)
-
-        dask.compute(*task_graph)
+    if perf_report:
+        with performance_report(report_name):
+            run_builders(builders, scheduler_logger)
+    else:
+        run_builders(builders, scheduler_logger)
 
     client.shutdown()
 
@@ -118,3 +104,29 @@ def setup_dask(
     logger.info(f"Cluster started with config: {cluster}")
 
     return cluster.get_client()
+
+
+def run_builders(builders, logger):
+    for builder in builders:
+        builder_name = builder.__class__.__name__
+        logger.info(f"Working on {builder_name}")
+
+        builder.connect()
+        items = builder.get_items()
+
+        task_graph = []
+
+        for idx, chunk in enumerate(items):
+            chunk_token = dask.base.tokenize(idx)
+            docs = dask.delayed(builder.get_processed_docs)(
+                chunk, dask_key_name=f"{builder_name}.get_processed_docs-" + chunk_token
+            )
+            built_docs = dask.delayed(builder.process_item)(
+                docs, dask_key_name=f"{builder_name}.process_item-" + chunk_token
+            )
+            update_store = dask.delayed(builder.update_targets)(
+                built_docs, dask_key_name=f"{builder_name}.update_targets-" + chunk_token
+            )
+            task_graph.append(update_store)
+
+        dask.compute(*task_graph)

--- a/src/maggma/cli/dask_executor.py
+++ b/src/maggma/cli/dask_executor.py
@@ -88,7 +88,7 @@ def setup_dask(
 ):
     logger = getLogger("Cluster")
 
-    logger.info("Starting clutser...")
+    logger.info("Starting cluster...")
 
     if hostnames:
         cluster = SSHCluster(

--- a/src/maggma/cli/dask_executor.py
+++ b/src/maggma/cli/dask_executor.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env/python
+# coding utf-8
+
+from logging import getLogger
+from typing import List
+
+from maggma.cli.settings import CLISettings
+from maggma.core import Builder
+
+try:
+    import dask
+    from dask.distributed import LocalCluster, SSHCluster
+except ImportError:
+    raise ImportError("Both dask and distributed are required to use Dask as a broker")
+
+settings = CLISettings()
+
+
+def dask_executor(
+    scheduler_address: str,
+    scheduler_port: int,
+    dask_hosts: str,
+    builders: List[Builder],
+    dask_workers: int,
+    processes: bool,
+):
+    """
+    Dask executor for processing builders. Constructs Dask task graphs
+    that will be submitted to a Dask scheduler for distributed processing
+    on a Dask cluster.
+    """
+    logger = getLogger("Scheduler")
+
+    if dask_hosts:
+        with open(dask_hosts) as file:
+            dask_hosts = file.read().split()
+
+        logger.info(
+            f"""Starting distributed Dask cluster, with scheduler at {dask_hosts[0]}:{scheduler_port},
+            and workers at: {dask_hosts[1:]}:{scheduler_port}..."""
+        )
+    else:
+        logger.info(f"Starting Dask LocalCluster with scheduler at: {scheduler_address}:{scheduler_port}...")
+
+    client = setup_dask(
+        address=scheduler_address, port=scheduler_port, hosts=dask_hosts, n_workers=dask_workers, processes=processes
+    )
+
+    logger.info(f"Dask dashboard available at: {client.dashboard_link}")
+
+    for builder in builders:
+        logger.info(f"Working on {builder.__class__.__name__}")
+        builder.connect()
+        items = builder.get_items()
+
+        task_graph = []
+        for chunk in items:
+            docs = dask.delayed(builder.get_processed_docs)(chunk)
+            built_docs = dask.delayed(builder.process_item)(docs)
+            update_store = dask.delayed(builder.update_targets)(built_docs)
+            task_graph.append(update_store)
+
+        dask.compute(*task_graph)
+
+    client.shutdown()
+
+
+def setup_dask(address: str, port: int, hosts: List[str], n_workers: int, processes: bool):
+    logger = getLogger("Cluster")
+
+    logger.info("Starting clutser...")
+
+    if hosts:
+        cluster = SSHCluster(hosts=hosts, scheduler_port=port, n_workers=n_workers)
+    else:
+        cluster = LocalCluster(host=address, scheduler_port=port, n_workers=n_workers, processes=processes)
+
+    logger.info(f"Cluster started with config: {cluster}")
+
+    return cluster.get_client()


### PR DESCRIPTION
## Summary

Major changes:

added a Dask work broker for use with mrun

## Todos

- [ ] test run a builder on a distributed cluster
- [ ] add documentation for the differences needed to write Dask-compatible builders

## Checklist

- [ ] Google format doc strings added.
- [ ] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] I have run the tests locally and they passed.
