### PR TITLE
write all NaN and NaT Dataframe created values as null

### DIFF
--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -4,6 +4,7 @@ from io import BytesIO, StringIO
 from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import jsonlines
+import numpy as np
 import pandas as pd
 from boto3 import client as boto_client
 from botocore import UNSIGNED
@@ -625,6 +626,8 @@ class OpenDataStore(S3IndexStore):
         self.index.update(index)
 
     def _write_doc_to_s3(self, doc: pd.DataFrame, index: pd.DataFrame) -> None:
+        doc = doc.replace({pd.NaT: None}).replace({"NaT": None}).replace({np.NaN: None})
+
         string_io = StringIO()
         with jsonlines.Writer(string_io, dumps=json_util.dumps) as writer:
             for _, row in doc.iterrows():


### PR DESCRIPTION
## Summary

Some collections do not have the same set of fields present in all the documents. The underlying DataFrames implementation for OpenData store uses NaN and NaT to fill in missing values for these fields. This is incompatible with Mongo storage (no NaT) and our JSON serialization. This adds code to convert NaN and NaT values to None prior to writing the documents out to S3 in OpenDataStore.
 
## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.