### PR TITLE
Enable `recursive_msonable` in `jsanitize` calls

### DIFF
--- a/src/maggma/cli/distributed.py
+++ b/src/maggma/cli/distributed.py
@@ -135,7 +135,7 @@ def manager(url: str, port: int, builders: List[Builder], num_chunks: int, num_w
                 if not chunk_dict["distributed"]:
                     temp_builder_dict = dict(**builder_dict)
                     temp_builder_dict.update(chunk_dict["chunk"])  # type: ignore
-                    temp_builder_dict = jsanitize(temp_builder_dict)
+                    temp_builder_dict = jsanitize(temp_builder_dict, recursive_msonable=True)
 
                     # Send work for available workers
                     for identity in workers:

--- a/src/maggma/cli/rabbitmq.py
+++ b/src/maggma/cli/rabbitmq.py
@@ -136,7 +136,7 @@ def manager(
                 if not chunk_dict["distributed"]:
                     temp_builder_dict = dict(**builder_dict)
                     temp_builder_dict.update(chunk_dict["chunk"])  # type: ignore
-                    temp_builder_dict = jsanitize(temp_builder_dict)
+                    temp_builder_dict = jsanitize(temp_builder_dict, recursive_msonable=True)
 
                     # Send work for available workers
                     for identity in workers:

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -388,7 +388,7 @@ class GridFSStore(Store):
                 if has(d, k)
             }
             metadata.update(search_doc)
-            data = json.dumps(jsanitize(d)).encode("UTF-8")
+            data = json.dumps(jsanitize(d, recursive_msonable=True)).encode("UTF-8")
             if self.compression:
                 data = zlib.compress(data)
                 metadata["compression"] = "zlib"

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -384,7 +384,7 @@ class MongoStore(Store):
         if not isinstance(docs, list):
             docs = [docs]
 
-        for d in (jsanitize(x, allow_bson=True) for x in docs):
+        for d in (jsanitize(x, allow_bson=True, recursive_msonable=True) for x in docs):
             # document-level validation is optional
             validates = True
             if self.validator:


### PR DESCRIPTION
## Summary

In several places throughout `maggma`, the `monty.json.jsanitize` function is called to (as the name suggests) sanitize the data prior to dumping it in the `Store`. This is all fine and dandy, but `MSONable` objects are (seemingly?) converted to `str`. With `recursive_msonable=True`, all `MSONable` objects are converted to JSONable dictionary form via `.as_dict()`.

@rkingsbury, @munrojm: I'm assuming there's something I'm missing here. Apologies because I don't have a MongoDB set up anymore so can't test directly, but surely we want `MSONable` objects to be represented in `.as_dict()` form in the data store, right? Is that happening some other way?