### PR TITLE
Add support for ruamel.yaml 0.18+ by replacing deprecated `.safe_load()` function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "setuptools",
-        "ruamel.yaml<0.18",
+        "ruamel.yaml>=0.18",
         "pydantic>=2.0",
         "pydantic-settings>=2.0.3",
         "pymongo>=4.2.0",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "setuptools",
-        "ruamel.yaml>=0.18",
+        "ruamel.yaml>=0.17",
         "pydantic>=2.0",
         "pydantic-settings>=2.0.3",
         "pymongo>=4.2.0",

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -107,7 +107,7 @@ class GridFSStore(Store):
         Returns:
         """
         with open(lp_file) as f:
-            yaml = YAML(typ='safe', pure=True)
+            yaml = YAML(typ="safe", pure=True)
             lp_creds = yaml.load(f.read())
 
         db_creds = lp_creds.copy()

--- a/src/maggma/stores/gridfs.py
+++ b/src/maggma/stores/gridfs.py
@@ -15,7 +15,7 @@ from monty.json import jsanitize
 from pydash import get, has
 from pymongo import MongoClient, uri_parser
 from pymongo.errors import ConfigurationError
-from ruamel import yaml
+from ruamel.yaml import YAML
 
 from maggma.core import Sort, Store, StoreError
 from maggma.stores.mongolike import MongoStore
@@ -107,7 +107,8 @@ class GridFSStore(Store):
         Returns:
         """
         with open(lp_file) as f:
-            lp_creds = yaml.safe_load(f.read())
+            yaml = YAML(typ='safe', pure=True)
+            lp_creds = yaml.load(f.read())
 
         db_creds = lp_creds.copy()
         db_creds["database"] = db_creds["name"]

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -8,7 +8,7 @@ import warnings
 from itertools import chain, groupby
 from pathlib import Path
 
-from ruamel import yaml
+from ruamel.yaml import YAML
 
 from maggma.stores.ssh_tunnel import SSHTunnel
 
@@ -156,7 +156,8 @@ class MongoStore(Store):
         Returns:
         """
         with open(lp_file) as f:
-            lp_creds = yaml.safe_load(f.read())
+            yaml = YAML(typ='safe', pure=True)
+            lp_creds = yaml.load(f.read())
 
         db_creds = lp_creds.copy()
         db_creds["database"] = db_creds["name"]

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -156,7 +156,7 @@ class MongoStore(Store):
         Returns:
         """
         with open(lp_file) as f:
-            yaml = YAML(typ='safe', pure=True)
+            yaml = YAML(typ="safe", pure=True)
             lp_creds = yaml.load(f.read())
 
         db_creds = lp_creds.copy()


### PR DESCRIPTION
## Summary

Closes #938.

This PR ensures maggma works with ruamel.yaml >= 0.18.0+ where the `.safe_load()` method was removed. The functionality is retained; the function is just called differently. The method was deprecated in 0.17.0 (2021-03-06) and removed in 0.18.0 (2023-10-23), so we have had ample time. 😅 

I think this should be good to go, @rkingsbury!