### PR TITLE
Adding store support for tasks stored in open data

### DIFF
--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -784,3 +784,6 @@ class TasksOpenDataStore(OpenDataStore):
         val = re.search(rf"{col}=(.+)\.jsonl\.gz", key).group(1)
         doc[col] = val
         return self._gather_indexable_data(doc)
+
+    def update(self, docs: pd.DataFrame) -> pd.DataFrame:
+        raise NotImplementedError("update is not supported for this store")

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -777,7 +777,6 @@ class TasksOpenDataStore(OpenDataStore):
         super().__init__(**kwargs)
 
     def _index_for_doc_from_s3(self, key: str) -> pd.DataFrame:
-        print(f"indexing doc with id: {key}")
         doc = self._read_doc_from_s3(key)
         # create an entry for the trailing object grouping field
         col = self.object_grouping[-1]

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -613,7 +613,7 @@ class OpenDataStore(S3IndexStore):
         return f"{self.prefix}{id}{self.object_file_extension}"
 
     def _gather_indexable_data(self, df: pd.DataFrame) -> pd.DataFrame:
-        return df[self.searchable_fields]
+        return self._json_normalize_and_filter(df)
 
     def _json_normalize_and_filter(self, docs: pd.DataFrame) -> pd.DataFrame:
         dfs = []
@@ -689,7 +689,7 @@ class OpenDataStore(S3IndexStore):
         for page in page_iterator:
             for file in page["Contents"]:
                 key = file["Key"]
-                if key != self.index._get_manifest_full_key_path():
+                if key != self.index._get_manifest_full_key_path() and key.endswith(self.object_file_extension):
                     all_index_docs.append(self._index_for_doc_from_s3(key))
         ret = pd.concat(all_index_docs, ignore_index=True)
         self.index.set_index_data(ret)

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -1,7 +1,7 @@
 import gzip
+import re
 from datetime import datetime
 from io import BytesIO, StringIO
-import re
 from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import jsonlines

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -280,7 +280,9 @@ def s3store():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
-        store = OpenDataStore(collection_name="index", bucket="bucket1", key="task_id", object_grouping=["task_id"])
+        store = OpenDataStore(
+            collection_name="index", bucket="bucket1", key="task_id", object_grouping=["group_level_two", "task_id"]
+        )
         store.connect()
 
         store.update(
@@ -290,11 +292,13 @@ def s3store():
                         "task_id": "mp-1",
                         "data": "asd",
                         store.last_updated_field: datetime.utcnow(),
+                        "group": {"level_two": 4},
                     },
                     {
                         "task_id": "mp-3",
                         "data": "sdf",
                         store.last_updated_field: datetime.utcnow(),
+                        "group": {"level_two": 4},
                     },
                 ]
             )
@@ -394,6 +398,7 @@ def test_update(s3store):
                 {
                     "task_id": "mp-199999",
                     "data": "asd",
+                    "group": {"level_two": 4},
                     s3store.last_updated_field: datetime.utcnow(),
                 }
             ]
@@ -409,6 +414,7 @@ def test_update(s3store):
                 {
                     "task_id": "mp-199999",
                     "data": "foo",
+                    "group": {"level_two": 4},
                     s3store.last_updated_field: datetime.utcnow(),
                 }
             ]
@@ -417,11 +423,12 @@ def test_update(s3store):
     assert len(s3store.index_data) == 3
     assert len(s3store.index_data.query("task_id == 'mp-199999'")) == 1
 
-    mp4 = [{"task_id": "mp-4", "data": "asd", s3store.last_updated_field: datetime.utcnow()}]
+    mp4 = [{"task_id": "mp-4", "data": "asd", "group": {"level_two": 4}, s3store.last_updated_field: datetime.utcnow()}]
     s3store.update(pd.DataFrame(mp4))
     assert len(s3store.index_data) == 4
-    assert s3store._get_full_key_path(pd.DataFrame(mp4)) == "task_id=mp-4.jsonl.gz"
-    s3store.s3_client.head_object(Bucket=s3store.bucket, Key=s3store._get_full_key_path(pd.DataFrame(mp4)))
+    mp4_index = [{"task_id": "mp-4", "group_level_two": 4, s3store.last_updated_field: datetime.utcnow()}]
+    assert s3store._get_full_key_path(pd.DataFrame(mp4_index)) == "group_level_two=4/task_id=mp-4.jsonl.gz"
+    s3store.s3_client.head_object(Bucket=s3store.bucket, Key=s3store._get_full_key_path(pd.DataFrame(mp4_index)))
 
 
 def test_query(s3store):
@@ -455,17 +462,35 @@ def test_query(s3store):
 
 
 def test_rebuild_index_from_s3_data(s3store):
-    data = [{"task_id": "mp-2", "data": "asd", s3store.last_updated_field: datetime.utcnow()}]
+    data = [
+        {"task_id": "mp-2", "data": "asd", s3store.last_updated_field: datetime.utcnow(), "group": {"level_two": 4}}
+    ]
     client = boto3.client("s3", region_name="us-east-1")
     string_io = StringIO()
     with jsonlines.Writer(string_io, dumps=json_util.dumps) as writer:
         for _, row in pd.DataFrame(data).iterrows():
             writer.write(row.to_dict())
 
+    data = [
+        {"task_id": "mp-99", "data": "asd", s3store.last_updated_field: datetime.utcnow(), "group": {"level_two": 4}}
+    ]
+    client = boto3.client("s3", region_name="us-east-1")
+    string_io2 = StringIO()
+    with jsonlines.Writer(string_io2, dumps=json_util.dumps) as writer:
+        for _, row in pd.DataFrame(data).iterrows():
+            writer.write(row.to_dict())
+
     client.put_object(
         Bucket="bucket1",
         Body=BytesIO(gzip.compress(string_io.getvalue().encode("utf-8"))),
-        Key="task_id=mp-2.jsonl.gz",
+        Key="group_level_two=4/task_id=mp-2.jsonl.gz",
+    )
+
+    # creating file that should not be indexed to test that it gets skipped
+    client.put_object(
+        Bucket="bucket1",
+        Body=BytesIO(gzip.compress(string_io2.getvalue().encode("utf-8"))),
+        Key="task_id=mp-99.gz",
     )
 
     assert len(s3store.index.index_data) == 2
@@ -473,16 +498,18 @@ def test_rebuild_index_from_s3_data(s3store):
     assert len(index_docs) == 3
     assert len(s3store.index.index_data) == 3
     for key in index_docs.columns:
-        assert key == "task_id" or key == "last_updated"
+        assert key == "task_id" or key == "last_updated" or key == "group_level_two"
 
 
 def test_rebuild_index_from_data(s3store):
-    data = [{"task_id": "mp-2", "data": "asd", s3store.last_updated_field: datetime.utcnow()}]
+    data = [
+        {"task_id": "mp-2", "data": "asd", s3store.last_updated_field: datetime.utcnow(), "group": {"level_two": 4}}
+    ]
     index_docs = s3store.rebuild_index_from_data(pd.DataFrame(data))
     assert len(index_docs) == 1
     assert len(s3store.index.index_data) == 1
     for key in index_docs.columns:
-        assert key == "task_id" or key == "last_updated"
+        assert key == "task_id" or key == "last_updated" or key == "group_level_two"
 
 
 def test_count_subdir(s3store_w_subdir):


### PR DESCRIPTION
## Summary

Major changes:

- added TasksOpenDataStore
- fixed bugs in building index from S3 data for OpenDataStore when index contained nested object information

## Checklist

- [x] Google format doc strings added.
- [x] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] I have run the tests locally and they passed.
