### PR TITLE
Handle store error during finalize

### DIFF
--- a/src/maggma/core/builder.py
+++ b/src/maggma/core/builder.py
@@ -9,7 +9,7 @@ from typing import Any, Union
 
 from monty.json import MontyDecoder, MSONable
 
-from maggma.core.store import Store
+from maggma.core.store import Store, StoreError
 from maggma.utils import TqdmLoggingHandler, grouper, tqdm
 
 
@@ -114,7 +114,7 @@ class Builder(MSONable, metaclass=ABCMeta):
         for store in self.sources + self.targets:
             try:
                 store.close()
-            except AttributeError:
+            except (AttributeError, StoreError):
                 continue
 
     def run(self, log_level=logging.DEBUG):


### PR DESCRIPTION
# Handle store Error during finalize

I assume the try/except in finalize is meant to handle situations where the store is already closed.
https://github.com/materialsproject/maggma/blob/f88951d09b22795fc4e69dc29a6e552b0ab4f676/src/maggma/core/builder.py#L109-L118

However, closing a store:
https://github.com/materialsproject/maggma/blob/f88951d09b22795fc4e69dc29a6e552b0ab4f676/src/maggma/stores/mongolike.py#L421-L426

can cause a StoreError if it's already closed.
https://github.com/materialsproject/maggma/blob/f88951d09b22795fc4e69dc29a6e552b0ab4f676/src/maggma/stores/mongolike.py#L254-L258



