### PR TITLE
update decorators for moto v5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ testing = [
             "pytest-asyncio",
             "pytest-xdist",
             "pre-commit",
-            "moto",
+            "moto>=5.0", # mock_s3 changed to mock_aws in v5
             "ruff",
             "responses<0.22.0",
             "types-pyYAML",

--- a/requirements/macos-latest_py3.10_extras.txt
+++ b/requirements/macos-latest_py3.10_extras.txt
@@ -226,7 +226,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==5.1
+moto==5.0.9
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/macos-latest_py3.10_extras.txt
+++ b/requirements/macos-latest_py3.10_extras.txt
@@ -226,7 +226,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.11
+moto==5.1
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/macos-latest_py3.11_extras.txt
+++ b/requirements/macos-latest_py3.11_extras.txt
@@ -221,7 +221,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.11
+moto==5.1
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/macos-latest_py3.11_extras.txt
+++ b/requirements/macos-latest_py3.11_extras.txt
@@ -221,7 +221,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==5.1
+moto==5.0.9
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/macos-latest_py3.12_extras.txt
+++ b/requirements/macos-latest_py3.12_extras.txt
@@ -221,7 +221,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.3
     # via maggma (setup.py)
-moto==4.2.11
+moto==5.1
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/macos-latest_py3.12_extras.txt
+++ b/requirements/macos-latest_py3.12_extras.txt
@@ -221,7 +221,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.3
     # via maggma (setup.py)
-moto==5.1
+moto==5.0.9
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/macos-latest_py3.9_extras.txt
+++ b/requirements/macos-latest_py3.9_extras.txt
@@ -231,7 +231,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.11
+moto==5.1
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/macos-latest_py3.9_extras.txt
+++ b/requirements/macos-latest_py3.9_extras.txt
@@ -231,7 +231,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==5.1
+moto==5.0.9
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/ubuntu-latest_py3.10_extras.txt
+++ b/requirements/ubuntu-latest_py3.10_extras.txt
@@ -226,7 +226,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==5.1
+moto==5.0.9
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/ubuntu-latest_py3.10_extras.txt
+++ b/requirements/ubuntu-latest_py3.10_extras.txt
@@ -226,7 +226,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.11
+moto==5.1
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/ubuntu-latest_py3.11_extras.txt
+++ b/requirements/ubuntu-latest_py3.11_extras.txt
@@ -221,7 +221,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.11
+moto==5.1
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/ubuntu-latest_py3.11_extras.txt
+++ b/requirements/ubuntu-latest_py3.11_extras.txt
@@ -221,7 +221,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==5.1
+moto==5.0.9
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/ubuntu-latest_py3.12_extras.txt
+++ b/requirements/ubuntu-latest_py3.12_extras.txt
@@ -221,7 +221,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.3
     # via maggma (setup.py)
-moto==4.2.11
+moto==5.1
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/ubuntu-latest_py3.12_extras.txt
+++ b/requirements/ubuntu-latest_py3.12_extras.txt
@@ -221,7 +221,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.3
     # via maggma (setup.py)
-moto==5.1
+moto==5.0.9
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/ubuntu-latest_py3.9_extras.txt
+++ b/requirements/ubuntu-latest_py3.9_extras.txt
@@ -231,7 +231,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==4.2.11
+moto==5.1
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/requirements/ubuntu-latest_py3.9_extras.txt
+++ b/requirements/ubuntu-latest_py3.9_extras.txt
@@ -231,7 +231,7 @@ monty==2023.11.3
     # via maggma (setup.py)
 montydb==2.5.2
     # via maggma (setup.py)
-moto==5.1
+moto==5.0.9
     # via maggma (setup.py)
 msal==1.26.0
     # via

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from moto import mock_s3
+from moto import mock_aws
 from sshtunnel import BaseSSHTunnelForwarderError
 
 from maggma.stores import MemoryStore, MongoStore, S3Store
@@ -32,7 +32,7 @@ def ssh_tunnel():
 
 @pytest.fixture()
 def s3store():
-    with mock_s3():
+    with mock_aws():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
@@ -64,7 +64,7 @@ def s3store():
 
 @pytest.fixture()
 def s3store_w_subdir():
-    with mock_s3():
+    with mock_aws():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
@@ -77,7 +77,7 @@ def s3store_w_subdir():
 
 @pytest.fixture()
 def s3store_multi():
-    with mock_s3():
+    with mock_aws():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
@@ -90,7 +90,7 @@ def s3store_multi():
 
 @pytest.fixture()
 def s3store_with_tunnel(ssh_tunnel):
-    with mock_s3():
+    with mock_aws():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
@@ -102,7 +102,7 @@ def s3store_with_tunnel(ssh_tunnel):
 
 
 def test_keys():
-    with mock_s3():
+    with mock_aws():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
         index = MemoryStore("index", key=1)
@@ -306,7 +306,7 @@ def test_searchable_fields(s3store):
 
 
 def test_newer_in(s3store):
-    with mock_s3():
+    with mock_aws():
         tic = datetime(2018, 4, 12, 16)
         tic2 = datetime.utcnow()
         conn = boto3.client("s3")
@@ -358,7 +358,7 @@ def test_get_session(s3store):
 
 
 def test_no_bucket():
-    with mock_s3():
+    with mock_aws():
         conn = boto3.resource("s3", region_name="us-east-1")
         conn.create_bucket(Bucket="bucket1")
 
@@ -431,7 +431,7 @@ def test_ssh_tunnel_2():
             return "ADDRESS", "PORT"
 
     def get_store():
-        with mock_s3():
+        with mock_aws():
             conn = boto3.resource("s3", region_name="us-east-1")
             conn.create_bucket(Bucket="bucket1")
 


### PR DESCRIPTION
moto v5 replaced all decorators including `mock_s3` with `mock_aws`. To keep tests working, this PR updates test code accordingly.