### PR TITLE
Default `auth_source` to `None` instead of `self.database`

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -61,7 +61,7 @@ class MongoStore(Store):
             username: Username for the collection
             password: Password to connect with
             safe_update: fail gracefully on DocumentTooLarge errors on update
-            auth_source: The database to authenticate on. Defaults to the database name.
+            auth_source: The database to authenticate on. Defaults to None.
             default_sort: Default sort field and direction to use when querying. Can be used to
                 ensure determinacy in query results.
         """
@@ -76,9 +76,6 @@ class MongoStore(Store):
         self.default_sort = default_sort
         self._coll = None  # type: ignore
         self.kwargs = kwargs
-
-        if auth_source is None:
-            auth_source = self.database
         self.auth_source = auth_source
         self.mongoclient_kwargs = mongoclient_kwargs or {}
 


### PR DESCRIPTION
using the database as the default `authSource` breaks [`jobflow-remote`](https://github.com/Matgenix/jobflow-remote) (running on AWS) from talking to a remote database. this PR changes the default to `None`, allowing `MongoClient` to use it's own default

i think this change is strictly speaking breaking but i suspect few users are relying on the current behavior since it's common practice to specify the `authSource` manually if it's not `admin`, which is the `MongoClient` default ([docs](https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient))

> authSource: The database to authenticate on. Defaults to the database specified in the URI, if provided, or to “admin”.

---

the error message is not helpful which is why it took me a while to troubleshoot this. commenting out the lines in my local code which are removed by this PR resolved this error

```py
db_ids = submit_flow(
    flow, worker="aws-slurm", project=proj_name, resources=resources
)
>>> ---> 74     db_ids = submit_flow(
     75         flow, worker="aws-slurm", project=proj_name, resources=resources
     76     )

File /scratch/janosh/.venv/py312/lib/python3.12/site-packages/jobflow_remote/jobs/submit.py:79, in submit_flow(flow, worker, project, exec_config, resources, allow_external_references)
     73         raise ConfigError(
     74             f"Additional stores {missing_stores!r} are not configured for this project."
     75         )
     77 jc = proj_obj.get_job_controller()
---> 79 return jc.add_flow(
     80     flow=flow,
     81     worker=worker,
     82     exec_config=exec_config,
...
    245 elif code == 43:
    246     raise CursorNotFound(errmsg, code, response, max_wire_version)
--> 248 raise OperationFailure(errmsg, code, response, max_wire_version)

OperationFailure: Authentication failed., full error: {'ok': 0.0, 'errmsg': 'Authentication failed.', 'code': 18, 'codeName': 'AuthenticationFailed'}
```