### PR TITLE
capability to configure query on request

### DIFF
--- a/src/maggma/api/resource/core.py
+++ b/src/maggma/api/resource/core.py
@@ -6,6 +6,7 @@ from monty.json import MontyDecoder, MSONable
 from pydantic import BaseModel
 from starlette.responses import RedirectResponse
 
+from maggma.api.query_operator import QueryOperator
 from maggma.api.utils import STORE_PARAMS, api_sanitize
 from maggma.utils import dynamic_import
 
@@ -105,4 +106,10 @@ class HeaderProcessor(MSONable, metaclass=ABCMeta):
         This method takes in a FastAPI Response object and processes a new header for it in-place.
         It can use data in the upstream request to generate the header.
         (https://fastapi.tiangolo.com/advanced/response-headers/#use-a-response-parameter).
+        """
+
+    @abstractmethod
+    def configure_query_on_request(self, request: Request, query_operator: QueryOperator) -> STORE_PARAMS:
+        """
+        This method takes in a FastAPI Request object and returns a query to be used in the store.
         """

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -201,8 +201,8 @@ class ReadOnlyResource(Resource):
 
             if self.query_to_configure_on_request is not None:
                 # give the key name "request", arbitrary choice, as only the value gets merged into the query
-                queries["request"] = self.header_processor.configure_query_from_request(
-                    request, self.query_to_configure_on_request
+                queries["groups"] = self.header_processor.configure_query_on_request(
+                    request=request, query_operator=self.query_to_configure_on_request
                 )
             # allowed query parameters
             query_params = [
@@ -217,7 +217,6 @@ class ReadOnlyResource(Resource):
                         detail="'limit' and 'skip' parameters have been renamed. "
                         "Please update your API client to the newest version.",
                     )
-
                 else:
                     raise HTTPException(
                         status_code=400,

--- a/src/maggma/api/resource/read_resource.py
+++ b/src/maggma/api/resource/read_resource.py
@@ -281,6 +281,12 @@ class ReadOnlyResource(Resource):
             if self.disable_validation:
                 response = Response(orjson.dumps(response, default=serialization_helper))  # type: ignore
 
+            if self.header_processor is not None:
+                if self.disable_validation:
+                    self.header_processor.process_header(response, request)
+                else:
+                    self.header_processor.process_header(temp_response, request)
+
             return response
 
         self.router.get(


### PR DESCRIPTION
## Summary

### Major changes:
- Added the capability in `ReadOnlyResource` for it to be able to configure query parameters based on the incoming request header.
- The added arg is `configure_query_on_request` which defaults to None. 
- The abstract method `configure_query_on_request` lives in the `HeaderProcessor` class, one would rewrite it in any custom header processor, e.g. in `emmet-api`     