### PR TITLE
clarify state of open data stores

### DIFF
--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -57,7 +57,7 @@ class PandasMemoryStore:
         self.logger = logging.getLogger(type(self).__name__)
         self.logger.addHandler(logging.NullHandler())
         self.logger.warning(
-            "Use all open data stores with caution. The stores are in a a deprecated, and in particular may be incompatible with numpy 2.0+."
+            "Use all open data stores with caution as they are deprecated and may be incompatible with numpy 2.0+."
         )
 
     @property

--- a/src/maggma/stores/open_data.py
+++ b/src/maggma/stores/open_data.py
@@ -1,4 +1,5 @@
 import gzip
+import logging
 import re
 from collections.abc import Generator
 from datetime import datetime
@@ -53,6 +54,11 @@ class PandasMemoryStore:
         self._data = None
         self.key = key
         self.last_updated_field = last_updated_field
+        self.logger = logging.getLogger(type(self).__name__)
+        self.logger.addHandler(logging.NullHandler())
+        self.logger.warning(
+            "Use all open data stores with caution. The stores are in a a deprecated, and in particular may be incompatible with numpy 2.0+."
+        )
 
     @property
     def index_data(self):

--- a/tests/stores/test_open_data.py
+++ b/tests/stores/test_open_data.py
@@ -390,6 +390,9 @@ def test_read_doc_from_s3():
         assert (df["task_id"] == "mp-2").any()
 
 
+@pytest.mark.xfail(
+    reason="Known issue, the store is in a deprecated state, and in particular may be incompatible with numpy 2.0+"
+)
 def test_update(s3store):
     assert len(s3store.index_data) == 2
     s3store.update(


### PR DESCRIPTION
addresses #995
 
## Summary

Major changes:

- issue warning about deprecated state of open data stores upon initialization of them
- xfail tests of open data stores that fail with numpy 2.x
