### PR TITLE
Set explicit mode in zopen to address monty FutureWarning

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -711,7 +711,7 @@ class JSONStore(MemoryStore):
         Args:
             path: Path to the JSON file to be read
         """
-        with zopen(path) as f:
+        with zopen(path, "r") as f:
             data = f.read()
             data = data.decode() if isinstance(data, bytes) else data
             objects = bson.json_util.loads(data) if "$oid" in data else orjson.loads(data)


### PR DESCRIPTION
Explicitly sets `mode='r'` in `zopen` to avoid the following:

```
/home/ryan/miniforge3/envs/feynman/lib/python3.12/site-packages/maggma/stores/mongolike.py:712: FutureWarning: We strongly discourage using a default `mode`, it would beset to `r` now but would not be allowed after 2025-06-01
  with zopen(path) as f:
```
