### PR TITLE
fixed other references to incorrect method name

### DIFF
--- a/docs/getting_started/simple_builder.md
+++ b/docs/getting_started/simple_builder.md
@@ -116,7 +116,7 @@ Our simple process item just has to multiply one field by `self.multiplier`:
 
 ``` python
 
-    def process_items(self, item : Dict) -> Dict:
+    def process_item(self, item : Dict) -> Dict:
         """
         Multiplies the "a" sub-document by self.multiplier
         """
@@ -183,7 +183,7 @@ class MultiplyBuilder(Builder):
         """
         docs = list(self.source.query())
 
-    def process_items(self, item : Dict) -> Dict:
+    def process_item(self, item : Dict) -> Dict:
         """
         Multiplies the "a" sub-document by self.multiplier
         """

--- a/docs/getting_started/simple_builder.md
+++ b/docs/getting_started/simple_builder.md
@@ -4,7 +4,7 @@
 
 A `Builder` is a class that inherits from `maggma.core.Builder` and implement 3 methods:
 
-* `get_items`:  This method should return some iterable of items to run through `process_items`
+* `get_items`:  This method should return some iterable of items to run through `process_item`
 * `process_item`: This method should take a single item, process it, and return the processed item
 * `update_targets`: This method should take a list of processed items and update the target stores.
 
@@ -141,8 +141,8 @@ Finally, we have to put the processed item in to the target store:
 
 
 !!! note
-    Note that whatever `process_items` returns, `update_targets` takes a `List` of these:
-    For instance, if `process_items` returns `str`, then `update_targets` would look like:
+    Note that whatever `process_item` returns, `update_targets` takes a `List` of these:
+    For instance, if `process_item` returns `str`, then `update_targets` would look like:
     ``` python
 
         def update_target(self,items: List[str]):


### PR DESCRIPTION
## Summary

I fixed the code examples in the quickstart docs

Major changes:

- fix: There was a typo in the quickstart docs for the Builder code that did not raise an error but also rendered the example incorrect. The example subclass of Builder implemented a method `.process_items` instead of the correct method `.process_item`, resulting in no processing being applied. Hopefully this can save others some headache when getting started :)

## Checklist

- [na] Google format doc strings added.
- [na] Code linted with `ruff`. (For guidance in fixing rule violates, see [rule list](https://beta.ruff.rs/docs/rules/))
- [na] Type annotations included. Check with `mypy`.
- [na] Tests added for new features/fixes.
- [ na] I have run the tests locally and they passed.
<!-- - [na] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) -->

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
