### PR TITLE
Fix GridFSURIStore and increase testing

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -460,7 +460,9 @@ class MongoURIStore(MongoStore):
                 ensure determinacy in query results.
         """
         self.uri = uri
-        self.ssh_tunnel = ssh_tunnel
+        if ssh_tunnel:
+            raise ValueError(f"At the moment ssh_tunnel is not supported for {self.__class__.__name__}")
+        self.ssh_tunnel = None
         self.default_sort = default_sort
         self.safe_update = safe_update
         self.mongoclient_kwargs = mongoclient_kwargs or {}

--- a/tests/stores/test_gridfs.py
+++ b/tests/stores/test_gridfs.py
@@ -20,9 +20,20 @@ def mongostore():
     store._collection.drop()
 
 
-@pytest.fixture()
-def gridfsstore():
-    store = GridFSStore("maggma_test", "test", key="task_id")
+@pytest.fixture(params=["std", "uri"])
+def gridfsstore(request):
+    """
+    Fixture providing both a standard GridFSStore and a GridFSURIStore.
+    """
+    store_type = request.param
+    if store_type == "std":
+        store = GridFSStore("maggma_test", "test", key="task_id")
+    elif store_type == "uri":
+        store = GridFSURIStore(
+            uri="mongodb://localhost:27017", database="maggma_test", collection_name="test", key="task_id"
+        )
+    else:
+        raise ValueError(f"Unknown store_type {store_type}")
     store.connect()
     yield store
     store._files_collection.drop()
@@ -243,6 +254,7 @@ def test_gridfs_uri():
     is_name = store.name is uri
     # This is try and keep the secret safe
     assert is_name
+    store.close()
 
 
 def test_gridfs_uri_dbname_parse():


### PR DESCRIPTION
While testing GridFSURIStore I discovered that there are several potential sources of errors due to the fact that it uses methods of the baseclass (GridFSStore), even if some attributes are not defined. Also there are no safeguard for accessing the `_files_store` attribute in case the store is not connected. 

This PR addresses these issues and modifies the gridfs tests so that all the tests are executed on both the `GridFSStore` and `GridFSURIStore`. This should hopefully reduce the chances of regression.

Also I noted that the `ssh_tunnel` is not taken into account in either of the "URI" stores. I kept the argument in the `__init__` to maintain the same API as the base classes, but it explicitly raises if passed.
