### PR TITLE
fix: add __future__ annotations to azure store to fix TypeError when azure not installed

### DIFF
--- a/src/maggma/stores/azure.py
+++ b/src/maggma/stores/azure.py
@@ -2,17 +2,21 @@
 Advanced Stores for connecting to Microsoft Azure data.
 """
 
+from __future__ import annotations
+
 import importlib
 import os
 import threading
 import warnings
 import zlib
-from collections.abc import Iterator
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
 from hashlib import sha1
 from json import dumps
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 import msgpack  # type: ignore
 from monty.msgpack import default as monty_default


### PR DESCRIPTION
Fixes #1113

## Summary

- When azure-storage-blob is not installed, the fallback sets ContainerClient = None
- The new `X | None` union type hint syntax (introduced in #1111) then evaluates `None | None` at runtime, raising `TypeError: unsupported operand type(s) for |: NoneType and NoneType`
- Adding `from __future__ import annotations` makes all annotations lazy PEP 563 string literals that are never evaluated at runtime, fixing the error
- Also moved `collections.abc.Iterator` into a TYPE_CHECKING block as required by ruff (TCH003)

## Test plan

- [ ] Verify that importing maggma.stores.azure without zure-storage-blob installed no longer raises TypeError
- [ ] Existing azure store tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)