### PR TITLE
Back MemoryStore with a real MongoDB when available, fall back to mongomock-ng

### DIFF
--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -5,10 +5,12 @@ various utilities.
 """
 
 import warnings
+import weakref
 from collections.abc import Callable, Iterator
 from itertools import chain, groupby
 from pathlib import Path
 from typing import Any, Literal
+from uuid import uuid4
 
 import bson
 import mongomock_ng as mongomock
@@ -505,22 +507,125 @@ class MongoURIStore(MongoStore):
 
 class MemoryStore(MongoStore):
     """
-    An in-memory Store that functions similarly
-    to a MongoStore.
+    An in-memory Store that functions similarly to a MongoStore.
+
+    If a MongoDB server is reachable (by default on ``localhost:27017``), the
+    data is stored in a real, ephemeral MongoDB database for full MongoDB
+    compatibility and performance. That database is namespaced uniquely per
+    Store instance and is dropped automatically when the Store is garbage
+    collected or the interpreter exits, so the user never has to create or
+    clean up a database manually. If no server is reachable, the Store
+    transparently falls back to an in-process ``mongomock`` database, so it
+    works even with no MongoDB installed.
     """
 
-    def __init__(self, collection_name: str = "memory_db", **kwargs):
+    #: Set to True by connect() when a real MongoDB backend is in use. Defined
+    #: at class level so close() is safe on subclasses (e.g. MontyStore) that
+    #: do not call MemoryStore.__init__.
+    _using_real_mongo: bool = False
+    _finalizer = None
+
+    def __init__(
+        self,
+        collection_name: str = "memory_db",
+        host: str = "localhost",
+        port: int = 27017,
+        mongoclient_kwargs: dict | None = None,
+        server_selection_timeout_ms: int = 500,
+        **kwargs,
+    ):
         """
         Initializes the Memory Store.
 
         Args:
             collection_name: name for the collection in memory.
+            host: hostname to probe for a running MongoDB server to back the
+                Store with. The data is written to an ephemeral database that
+                is dropped when the Store is closed.
+            port: TCP port to probe for a running MongoDB server.
+            mongoclient_kwargs: Dict of extra kwargs to pass to MongoClient when
+                a real MongoDB backend is used.
+            server_selection_timeout_ms: how long, in milliseconds, to wait when
+                probing ``host:port`` for a MongoDB server before falling back
+                to an in-process ``mongomock`` database. Set to 0 (or less) to
+                skip the probe entirely and always use ``mongomock``.
         """
         self.collection_name = collection_name
+        self.host = host
+        self.port = port
+        self.mongoclient_kwargs = mongoclient_kwargs or {}
+        self.server_selection_timeout_ms = server_selection_timeout_ms
+        # unique, ephemeral database name so that multiple MemoryStore instances
+        # backed by the same real MongoDB server do not clobber one another
+        self._database = f"maggma_memory_{uuid4().hex}"
         self.default_sort = None
         self._coll = None
         self.kwargs = kwargs
         super(MongoStore, self).__init__(**kwargs)
+
+    def _get_memory_client(self) -> MongoClient:
+        """
+        Return a client backing the in-memory Store.
+
+        Attempts to connect to a real MongoDB server at ``host:port`` for full
+        MongoDB compatibility and performance. If none is reachable within
+        ``server_selection_timeout_ms``, falls back to an in-process
+        ``mongomock`` client so the Store works without a MongoDB server.
+        """
+        if self.server_selection_timeout_ms > 0:
+            mongoclient_kwargs = dict(self.mongoclient_kwargs)
+            mongoclient_kwargs.setdefault("serverSelectionTimeoutMS", self.server_selection_timeout_ms)
+            try:
+                client = MongoClient(host=self.host, port=self.port, **mongoclient_kwargs)
+                # force server selection to confirm a server is actually reachable
+                client.admin.command("ping")
+                self._using_real_mongo = True
+                # ensure the ephemeral database is dropped when this Store is
+                # garbage collected or the interpreter exits, so nothing is left
+                # behind on the server
+                if self._finalizer is None:
+                    self._finalizer = weakref.finalize(
+                        self,
+                        self._drop_ephemeral_database,
+                        self.host,
+                        self.port,
+                        self._database,
+                        dict(mongoclient_kwargs),
+                    )
+                self.logger.debug(f"{self.name} using real MongoDB backend at {self.host}:{self.port}")
+                return client
+            except Exception:
+                self.logger.debug(f"{self.name}: no MongoDB server reachable, falling back to mongomock")
+
+        self._using_real_mongo = False
+        return mongomock.MongoClient()  # type: ignore
+
+    @staticmethod
+    def _drop_ephemeral_database(host: str, port: int, database: str, mongoclient_kwargs: dict):
+        """Drop an ephemeral MongoDB database. Used as a weakref finalizer, so it
+        must not hold a reference to the Store."""
+        mongoclient_kwargs.setdefault("serverSelectionTimeoutMS", 500)
+        try:
+            client = MongoClient(host=host, port=port, **mongoclient_kwargs)
+            client.drop_database(database)
+            client.close()
+        except Exception:
+            pass
+
+    def _connect_collection(self, force_reset: bool = False):
+        """Establish (or re-establish) the underlying in-memory collection."""
+        if force_reset and self._coll is not None:
+            old_client = self._coll.database.client
+            # on a forced reset, discard the previous contents (matching the
+            # historical mongomock behavior of starting from a fresh client)
+            if getattr(self, "_using_real_mongo", False):
+                try:
+                    old_client.drop_database(self._database)
+                except Exception:
+                    pass
+            old_client.close()
+        client = self._get_memory_client()
+        self._coll = client[self._database][self.collection_name]  # type: ignore
 
     def connect(self, force_reset: bool = False):
         """
@@ -531,11 +636,20 @@ class MemoryStore(MongoStore):
                 already connected.
         """
         if self._coll is None or force_reset:
-            self._coll = mongomock.MongoClient().db[self.name]  # type: ignore
+            self._connect_collection(force_reset=force_reset)
 
     def close(self):
-        """Close up all collections."""
-        self._coll.database.client.close()
+        """Close up all collections.
+
+        For an in-memory Store this is intentionally a no-op that leaves the
+        Store usable, matching the historical ``mongomock`` behavior (its
+        ``close()`` did nothing) that callers such as the builders rely on when
+        they query a Store after it has been closed. Resources are released and
+        any ephemeral MongoDB database backing the Store is dropped when the
+        Store is garbage collected or at interpreter exit (see
+        ``_drop_ephemeral_database``). Use ``force_reset=True`` on ``connect()``
+        to explicitly discard the contents and start fresh.
+        """
 
     @property
     def name(self):
@@ -682,7 +796,7 @@ class JSONStore(MemoryStore):
             on systems with slow storage when multiple connect / disconnects are performed.
         """
         if self._coll is None or force_reset:
-            self._coll = mongomock.MongoClient().db[self.name]  # type: ignore
+            self._connect_collection(force_reset=force_reset)
 
             # create the .json file if it does not exist
             if not self.read_only and not Path(self.paths[0]).exists():
@@ -876,6 +990,11 @@ class MontyStore(MemoryStore):
                 set_storage(self.database_path, storage=self.storage, **self.storage_kwargs)
             client = MontyClient(self.database_path, **self.client_kwargs)
             self._coll = client[self.database_name][self.collection_name]
+
+    def close(self):
+        """Close up the MontyDB client."""
+        if self._coll is not None:
+            self._coll.database.client.close()
 
     @property
     def name(self) -> str:

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -610,6 +610,9 @@ class MemoryStore(MongoStore):
             client.drop_database(database)
             client.close()
         except Exception:
+            # Best-effort cleanup: if the server is already gone or unreachable at
+            # finalization time there is nothing left to drop. Swallow the error so
+            # a finalizer/atexit hook never raises.
             pass
 
     def _connect_collection(self, force_reset: bool = False):
@@ -622,6 +625,9 @@ class MemoryStore(MongoStore):
                 try:
                     old_client.drop_database(self._database)
                 except Exception:
+                    # Best-effort discard of the previous contents; if the drop
+                    # fails the database will still be cleaned up by the finalizer
+                    # on garbage collection or interpreter exit.
                     pass
             old_client.close()
         client = self._get_memory_client()

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -541,7 +541,8 @@ class MemoryStore(MongoStore):
             collection_name: name for the collection in memory.
             host: hostname to probe for a running MongoDB server to back the
                 Store with. The data is written to an ephemeral database that
-                is dropped when the Store is closed.
+                is dropped when the Store is garbage collected or the
+                interpreter exits.
             port: TCP port to probe for a running MongoDB server.
             mongoclient_kwargs: Dict of extra kwargs to pass to MongoClient when
                 a real MongoDB backend is used.
@@ -559,6 +560,7 @@ class MemoryStore(MongoStore):
         # backed by the same real MongoDB server do not clobber one another
         self._database = f"maggma_memory_{uuid4().hex}"
         self.default_sort = None
+        self._client = None
         self._coll = None
         self.kwargs = kwargs
         super(MongoStore, self).__init__(**kwargs)
@@ -602,8 +604,10 @@ class MemoryStore(MongoStore):
 
     @staticmethod
     def _drop_ephemeral_database(host: str, port: int, database: str, mongoclient_kwargs: dict):
-        """Drop an ephemeral MongoDB database. Used as a weakref finalizer, so it
-        must not hold a reference to the Store."""
+        """Drop an ephemeral MongoDB database.
+
+        Used as a weakref finalizer, so it must not hold a reference to the Store.
+        """
         mongoclient_kwargs.setdefault("serverSelectionTimeoutMS", 500)
         try:
             client = MongoClient(host=host, port=port, **mongoclient_kwargs)
@@ -615,23 +619,33 @@ class MemoryStore(MongoStore):
             # a finalizer/atexit hook never raises.
             pass
 
-    def _connect_collection(self, force_reset: bool = False):
-        """Establish (or re-establish) the underlying in-memory collection."""
-        if force_reset and self._coll is not None:
-            old_client = self._coll.database.client
-            # on a forced reset, discard the previous contents (matching the
-            # historical mongomock behavior of starting from a fresh client)
-            if getattr(self, "_using_real_mongo", False):
+    def _reset_connection(self):
+        """Tear down the current connection and discard its contents."""
+        if getattr(self, "_using_real_mongo", False):
+            # discard the ephemeral database, even if we are currently
+            # disconnected (e.g. after close(), when self._client is None)
+            if self._client is not None:
                 try:
-                    old_client.drop_database(self._database)
+                    self._client.drop_database(self._database)
                 except Exception:
-                    # Best-effort discard of the previous contents; if the drop
-                    # fails the database will still be cleaned up by the finalizer
-                    # on garbage collection or interpreter exit.
+                    # Best-effort discard; the finalizer will still drop the
+                    # database on garbage collection or interpreter exit.
                     pass
-            old_client.close()
-        client = self._get_memory_client()
-        self._coll = client[self._database][self.collection_name]  # type: ignore
+            else:
+                self._drop_ephemeral_database(self.host, self.port, self._database, dict(self.mongoclient_kwargs))
+        if self._client is not None:
+            self._client.close()
+        self._client = None
+        self._coll = None
+
+    def _ensure_connected(self, force_reset: bool = False):
+        """Establish (or re-establish) the underlying in-memory collection."""
+        if force_reset:
+            self._reset_connection()
+        if self._coll is None:
+            if self._client is None:
+                self._client = self._get_memory_client()
+            self._coll = self._client[self._database][self.collection_name]  # type: ignore
 
     def connect(self, force_reset: bool = False):
         """
@@ -641,21 +655,29 @@ class MemoryStore(MongoStore):
             force_reset: whether to reset the connection or not when the Store is
                 already connected.
         """
-        if self._coll is None or force_reset:
-            self._connect_collection(force_reset=force_reset)
+        self._ensure_connected(force_reset=force_reset)
 
     def close(self):
-        """Close up all collections.
+        """Close the Store's connection.
 
-        For an in-memory Store this is intentionally a no-op that leaves the
-        Store usable, matching the historical ``mongomock`` behavior (its
-        ``close()`` did nothing) that callers such as the builders rely on when
-        they query a Store after it has been closed. Resources are released and
-        any ephemeral MongoDB database backing the Store is dropped when the
-        Store is garbage collected or at interpreter exit (see
-        ``_drop_ephemeral_database``). Use ``force_reset=True`` on ``connect()``
-        to explicitly discard the contents and start fresh.
+        After ``close()`` the Store must be reconnected with ``connect()`` before
+        it can be queried again; querying a closed Store raises a ``StoreError``.
+        The Store's data is preserved across a ``close()``/``connect()`` cycle:
+        with a real MongoDB backend it lives in the ephemeral database on the
+        server (dropped only when the Store is garbage collected or at
+        interpreter exit, see ``_drop_ephemeral_database``); with the
+        ``mongomock`` backend it lives in the in-process client, which is kept
+        alive for this reason. Use ``connect(force_reset=True)`` to discard the
+        contents and start fresh.
         """
+        if getattr(self, "_using_real_mongo", False) and self._client is not None:
+            # data persists in the ephemeral database on the server, so we can
+            # release the client connection now and reconnect later on demand
+            self._client.close()
+            self._client = None
+        # for the mongomock backend the data lives in the in-process client;
+        # keep it alive and simply mark the Store as needing a reconnect
+        self._coll = None
 
     @property
     def name(self):
@@ -802,7 +824,7 @@ class JSONStore(MemoryStore):
             on systems with slow storage when multiple connect / disconnects are performed.
         """
         if self._coll is None or force_reset:
-            self._connect_collection(force_reset=force_reset)
+            self._ensure_connected(force_reset=force_reset)
 
             # create the .json file if it does not exist
             if not self.read_only and not Path(self.paths[0]).exists():
@@ -998,9 +1020,10 @@ class MontyStore(MemoryStore):
             self._coll = client[self.database_name][self.collection_name]
 
     def close(self):
-        """Close up the MontyDB client."""
+        """Close up the MontyDB client. The Store must be reconnected before use."""
         if self._coll is not None:
             self._coll.database.client.close()
+            self._coll = None
 
     @property
     def name(self) -> str:

--- a/src/maggma/stores/mongolike.py
+++ b/src/maggma/stores/mongolike.py
@@ -509,14 +509,14 @@ class MemoryStore(MongoStore):
     """
     An in-memory Store that functions similarly to a MongoStore.
 
-    If a MongoDB server is reachable (by default on ``localhost:27017``), the
-    data is stored in a real, ephemeral MongoDB database for full MongoDB
-    compatibility and performance. That database is namespaced uniquely per
-    Store instance and is dropped automatically when the Store is garbage
-    collected or the interpreter exits, so the user never has to create or
-    clean up a database manually. If no server is reachable, the Store
-    transparently falls back to an in-process ``mongomock`` database, so it
-    works even with no MongoDB installed.
+    By default (``port=None``) the data is held in an in-process ``mongomock``
+    database, so the Store works with no MongoDB server installed. As an opt-in,
+    if a ``port`` is supplied the Store instead uses a real MongoDB server at
+    ``host:port`` (e.g. a local ``mongod``) for full MongoDB compatibility and
+    performance. In that case the data is written to an ephemeral database that
+    is namespaced uniquely per Store instance and dropped automatically when the
+    Store is garbage collected or the interpreter exits, so the user never has to
+    create or clean up a database manually.
     """
 
     #: Set to True by connect() when a real MongoDB backend is in use. Defined
@@ -529,7 +529,7 @@ class MemoryStore(MongoStore):
         self,
         collection_name: str = "memory_db",
         host: str = "localhost",
-        port: int = 27017,
+        port: int | None = None,
         mongoclient_kwargs: dict | None = None,
         server_selection_timeout_ms: int = 500,
         **kwargs,
@@ -539,17 +539,17 @@ class MemoryStore(MongoStore):
 
         Args:
             collection_name: name for the collection in memory.
-            host: hostname to probe for a running MongoDB server to back the
-                Store with. The data is written to an ephemeral database that
-                is dropped when the Store is garbage collected or the
-                interpreter exits.
-            port: TCP port to probe for a running MongoDB server.
+            host: hostname of the MongoDB server to use when ``port`` is supplied.
+            port: TCP port of a MongoDB server to back the Store with. If None
+                (the default), the Store uses an in-process ``mongomock``
+                database and no server is required. If a port is supplied (e.g.
+                ``port=27017`` for a local ``mongod``), the Store uses that real
+                MongoDB server, writing to an ephemeral database that is dropped
+                when the Store is garbage collected or the interpreter exits.
             mongoclient_kwargs: Dict of extra kwargs to pass to MongoClient when
                 a real MongoDB backend is used.
-            server_selection_timeout_ms: how long, in milliseconds, to wait when
-                probing ``host:port`` for a MongoDB server before falling back
-                to an in-process ``mongomock`` database. Set to 0 (or less) to
-                skip the probe entirely and always use ``mongomock``.
+            server_selection_timeout_ms: serverSelectionTimeoutMS to use for the
+                real MongoDB client. Only relevant when ``port`` is supplied.
         """
         self.collection_name = collection_name
         self.host = host
@@ -569,38 +569,34 @@ class MemoryStore(MongoStore):
         """
         Return a client backing the in-memory Store.
 
-        Attempts to connect to a real MongoDB server at ``host:port`` for full
-        MongoDB compatibility and performance. If none is reachable within
-        ``server_selection_timeout_ms``, falls back to an in-process
-        ``mongomock`` client so the Store works without a MongoDB server.
+        Uses a real MongoDB server at ``host:port`` when a ``port`` was supplied
+        (opt-in, for full MongoDB compatibility and performance), otherwise an
+        in-process ``mongomock`` client so the Store works without a server.
         """
-        if self.server_selection_timeout_ms > 0:
-            mongoclient_kwargs = dict(self.mongoclient_kwargs)
-            mongoclient_kwargs.setdefault("serverSelectionTimeoutMS", self.server_selection_timeout_ms)
-            try:
-                client = MongoClient(host=self.host, port=self.port, **mongoclient_kwargs)
-                # force server selection to confirm a server is actually reachable
-                client.admin.command("ping")
-                self._using_real_mongo = True
-                # ensure the ephemeral database is dropped when this Store is
-                # garbage collected or the interpreter exits, so nothing is left
-                # behind on the server
-                if self._finalizer is None:
-                    self._finalizer = weakref.finalize(
-                        self,
-                        self._drop_ephemeral_database,
-                        self.host,
-                        self.port,
-                        self._database,
-                        dict(mongoclient_kwargs),
-                    )
-                self.logger.debug(f"{self.name} using real MongoDB backend at {self.host}:{self.port}")
-                return client
-            except Exception:
-                self.logger.debug(f"{self.name}: no MongoDB server reachable, falling back to mongomock")
+        if self.port is None:
+            # default: no port supplied -> in-process mongomock backend
+            self._using_real_mongo = False
+            return mongomock.MongoClient()  # type: ignore
 
-        self._using_real_mongo = False
-        return mongomock.MongoClient()  # type: ignore
+        # a port was supplied -> use a real MongoDB server at host:port
+        mongoclient_kwargs = dict(self.mongoclient_kwargs)
+        if self.server_selection_timeout_ms > 0:
+            mongoclient_kwargs.setdefault("serverSelectionTimeoutMS", self.server_selection_timeout_ms)
+        client = MongoClient(host=self.host, port=self.port, **mongoclient_kwargs)
+        self._using_real_mongo = True
+        # ensure the ephemeral database is dropped when this Store is garbage
+        # collected or the interpreter exits, so nothing is left behind on the server
+        if self._finalizer is None:
+            self._finalizer = weakref.finalize(
+                self,
+                self._drop_ephemeral_database,
+                self.host,
+                self.port,
+                self._database,
+                dict(mongoclient_kwargs),
+            )
+        self.logger.debug(f"{self.name} using real MongoDB backend at {self.host}:{self.port}")
+        return client
 
     @staticmethod
     def _drop_ephemeral_database(host: str, port: int, database: str, mongoclient_kwargs: dict):

--- a/tests/builders/test_copy_builder.py
+++ b/tests/builders/test_copy_builder.py
@@ -114,6 +114,7 @@ def test_query(source, target, old_docs, new_docs):
     source.update(old_docs)
     source.update(new_docs)
     builder.run()
+    target.connect()
     all_docs = list(target.query(criteria={}))
     assert len(all_docs) == 14
     assert min([d["k"] for d in all_docs]) == 6
@@ -129,6 +130,7 @@ def test_delete_orphans(source, target, old_docs, new_docs):
     source._collection.delete_many(deletion_criteria)
     builder.run()
 
+    target.connect()
     assert target._collection.count_documents(deletion_criteria) == 0
     assert target.query_one(criteria={"k": 5})["v"] == "new"
     assert target.query_one(criteria={"k": 10})["v"] == "old"

--- a/tests/builders/test_projection_builder.py
+++ b/tests/builders/test_projection_builder.py
@@ -104,6 +104,7 @@ def test_update_targets(source1, source2, target):
 def test_run(source1, source2, target):
     builder = Projection_Builder(source_stores=[source1, source2], target_store=target)
     builder.run()
+    target.connect()
     assert len(list(target.query())) == 15
     assert target.query_one(criteria={"k": 0})["a"] == "a"
     assert target.query_one(criteria={"k": 0})["d"] == "d"
@@ -119,4 +120,5 @@ def test_query(source1, source2, target):
         query_by_key=[0, 1, 2, 3, 4],
     )
     builder.run()
+    target.connect()
     assert len(list(target.query())) == 5

--- a/tests/stores/test_aws.py
+++ b/tests/stores/test_aws.py
@@ -6,6 +6,7 @@ import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
 
+from maggma.core import StoreError
 from maggma.stores import MemoryStore, MongoStore, S3Store
 from maggma.stores.ssh_tunnel import SSHTunnel
 
@@ -232,7 +233,9 @@ def test_remove(s3store):
 def test_close(s3store):
     list(s3store.query())
     s3store.close()
-    with pytest.raises(AttributeError):
+    # querying a closed store raises: the index (a MemoryStore) is genuinely
+    # closed, so it raises a StoreError before the S3 access is reached
+    with pytest.raises(StoreError):
         list(s3store.query())
 
 

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -248,11 +248,51 @@ def test_mongostore_newer_in(mongostore):
 
 
 # Memory store tests
-def test_memory_store_connect():
-    memorystore = MemoryStore()
+def test_memory_store_connect_mongomock_fallback():
+    # server_selection_timeout_ms=0 skips the probe and forces the mongomock backend
+    memorystore = MemoryStore(server_selection_timeout_ms=0)
     assert memorystore._coll is None
     memorystore.connect()
+    assert memorystore._using_real_mongo is False
     assert isinstance(memorystore._collection, mongomock_ng.collection.Collection)
+
+
+def test_memory_store_connect_unreachable_falls_back():
+    # an unreachable server should fall back to mongomock rather than raise
+    memorystore = MemoryStore(port=1, server_selection_timeout_ms=50)
+    memorystore.connect()
+    assert memorystore._using_real_mongo is False
+    assert isinstance(memorystore._collection, mongomock_ng.collection.Collection)
+
+
+def test_memory_store_uses_real_mongo_when_available():
+    # a real MongoDB server is available in CI; when present it should be used
+    try:
+        pymongo.MongoClient(serverSelectionTimeoutMS=500).admin.command("ping")
+    except Exception:
+        pytest.skip("no MongoDB server reachable on localhost:27017")
+
+    memorystore = MemoryStore()
+    memorystore.connect()
+    assert memorystore._using_real_mongo is True
+    assert isinstance(memorystore._collection, pymongo.collection.Collection)
+
+    # the ephemeral database exists while connected
+    verify_client = pymongo.MongoClient(serverSelectionTimeoutMS=500)
+    memorystore.update({"task_id": 1, "val": 2})
+    assert memorystore._database in verify_client.list_database_names()
+
+    # data survives close() (the Store remains usable), matching the historical
+    # in-memory behavior relied upon by builders
+    memorystore.close()
+    memorystore.connect()
+    assert memorystore.count() == 1
+
+    # the ephemeral database is dropped when the Store is finalized
+    database_name = memorystore._database
+    memorystore._finalizer()
+    assert database_name not in verify_client.list_database_names()
+    verify_client.close()
 
 
 def test_groupby(memorystore):
@@ -522,8 +562,11 @@ def test_jsonstore_orjson_options(test_dir):
     class SubFloat(float):
         pass
 
+    # Force the mongomock backend (server_selection_timeout_ms=0): a real MongoDB
+    # backend coerces the SubFloat subclass to a plain float on write/read, so the
+    # serialization_default option this test exercises would never be triggered.
     with ScratchDir("."):
-        jsonstore = JSONStore("d.json", read_only=False)
+        jsonstore = JSONStore("d.json", read_only=False, server_selection_timeout_ms=0)
         jsonstore.connect()
         with pytest.raises(orjson.JSONEncodeError):
             jsonstore.update({"wrong_field": SubFloat(1.1), "task_id": 3})
@@ -534,6 +577,7 @@ def test_jsonstore_orjson_options(test_dir):
             read_only=False,
             serialization_option=None,
             serialization_default=lambda x: "test",
+            server_selection_timeout_ms=0,
         )
         jsonstore.connect()
         jsonstore.update({"wrong_field": SubFloat(1.1), "task_id": 3})

--- a/tests/stores/test_mongolike.py
+++ b/tests/stores/test_mongolike.py
@@ -248,31 +248,26 @@ def test_mongostore_newer_in(mongostore):
 
 
 # Memory store tests
-def test_memory_store_connect_mongomock_fallback():
-    # server_selection_timeout_ms=0 skips the probe and forces the mongomock backend
-    memorystore = MemoryStore(server_selection_timeout_ms=0)
+def test_memory_store_connect_default_mongomock():
+    # by default (no port supplied) the Store uses the in-process mongomock
+    # backend. Note this runs in CI with a MongoDB server available, so it also
+    # confirms the real-mongo backend is strictly opt-in (the default does not
+    # touch a running server).
+    memorystore = MemoryStore()
     assert memorystore._coll is None
     memorystore.connect()
     assert memorystore._using_real_mongo is False
     assert isinstance(memorystore._collection, mongomock_ng.collection.Collection)
 
 
-def test_memory_store_connect_unreachable_falls_back():
-    # an unreachable server should fall back to mongomock rather than raise
-    memorystore = MemoryStore(port=1, server_selection_timeout_ms=50)
-    memorystore.connect()
-    assert memorystore._using_real_mongo is False
-    assert isinstance(memorystore._collection, mongomock_ng.collection.Collection)
-
-
-def test_memory_store_uses_real_mongo_when_available():
-    # a real MongoDB server is available in CI; when present it should be used
+def test_memory_store_uses_real_mongo_when_port_supplied():
+    # supplying a port opts in to a real MongoDB backend
     try:
         pymongo.MongoClient(serverSelectionTimeoutMS=500).admin.command("ping")
     except Exception:
         pytest.skip("no MongoDB server reachable on localhost:27017")
 
-    memorystore = MemoryStore()
+    memorystore = MemoryStore(port=27017)
     memorystore.connect()
     assert memorystore._using_real_mongo is True
     assert isinstance(memorystore._collection, pymongo.collection.Collection)
@@ -562,11 +557,12 @@ def test_jsonstore_orjson_options(test_dir):
     class SubFloat(float):
         pass
 
-    # Force the mongomock backend (server_selection_timeout_ms=0): a real MongoDB
-    # backend coerces the SubFloat subclass to a plain float on write/read, so the
-    # serialization_default option this test exercises would never be triggered.
+    # JSONStore uses the default mongomock backend (no port), which preserves the
+    # SubFloat subclass so orjson raises. A real MongoDB backend would instead
+    # coerce it to a plain float, and the serialization_default option this test
+    # exercises would never be triggered.
     with ScratchDir("."):
-        jsonstore = JSONStore("d.json", read_only=False, server_selection_timeout_ms=0)
+        jsonstore = JSONStore("d.json", read_only=False)
         jsonstore.connect()
         with pytest.raises(orjson.JSONEncodeError):
             jsonstore.update({"wrong_field": SubFloat(1.1), "task_id": 3})
@@ -577,7 +573,6 @@ def test_jsonstore_orjson_options(test_dir):
             read_only=False,
             serialization_option=None,
             serialization_default=lambda x: "test",
-            server_selection_timeout_ms=0,
         )
         jsonstore.connect()
         jsonstore.update({"wrong_field": SubFloat(1.1), "task_id": 3})


### PR DESCRIPTION
## Summary

Building on #1115 (mongomock → mongomock-ng), this lets `MemoryStore` **opt in** to a real, ephemeral MongoDB backend when one is available, while keeping the in-process `mongomock` backend as the default — with no manual database setup either way.

Motivation (see #830, #788): mongomock is a reimplementation and doesn't cover every MongoDB feature. When a real `mongod` is available, opting in gives exact MongoDB semantics and better performance, while the default keeps working out-of-the-box with no server installed.

## Behavior

`MemoryStore` takes an optional `port`:

- **`port=None` (default)** → data is held in an in-process `mongomock` database. No server is required or contacted, even if one happens to be listening on localhost. This is the historical behavior.
- **`port=<int>` (e.g. `port=27017`)** → the Store uses a real MongoDB server at `host:port`, writing to a database named `maggma_memory_<uuid>`, unique per store instance so instances never collide. That database is dropped automatically (via a `weakref.finalize`) when the store is garbage collected or the interpreter exits, so nothing is left behind and the user never creates or cleans up a database manually.

Other new, backward-compatible kwargs: `host` (used only when a port is supplied), `mongoclient_kwargs`, `server_selection_timeout_ms` (the real client's timeout). Existing `MemoryStore("name")` usage is unchanged and still uses mongomock.

## close() semantics

`MemoryStore.close()` is a genuine close: after it, the store must be reconnected with `connect()` before it can be queried again (querying a closed store raises `StoreError`). Data is preserved across a `close()`/`connect()` cycle — the real-MongoDB backend keeps it in the ephemeral server-side database, and the mongomock backend keeps its in-process client alive — while `connect(force_reset=True)` discards the contents and starts fresh.

The build pipeline already only queries stores before closing them: `Builder.run()` and the `serial`/`multiprocessing` runners all do `connect → get_items → update_targets → finalize()`, and `MapBuilder.finalize()` queries before `super().finalize()`. A couple of builder **tests** previously queried the target after `run()` had closed it; they now reconnect first (matching the existing pattern in `test_copy_builder.test_run`).

## Other notes

- `JSONStore` and `FileStore` inherit the behavior through the shared connection helper (and use the default mongomock backend); `MontyStore` keeps its own `close()`.
- The `test_jsonstore_orjson_options` test relies on the mongomock backend, since a real MongoDB coerces the custom `float` subclass before write and the `serialization_default` option under test would never trigger (this is the backend-dependent case discussed in #846).

## Testing

- `tests/stores/test_mongolike.py`, `tests/stores/test_file_store.py`, `tests/stores/test_aws.py`, `tests/builders` with a real `mongod` running: **74 passed**, 9 skipped, 1 xfailed, with **no leftover `maggma_memory_*` databases**. (The default-mongomock test runs with a server present and confirms the real backend is strictly opt-in.)
- Verified the port-supplied backend: querying a closed store raises, reconnect restores the data, and the ephemeral database is dropped by the finalizer; and that `as_dict`/`from_dict`, `MontyDecoder`, and `deepcopy` roundtrips still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
