### PR TITLE
Let pip-compile own the lock files; run upgrade-dependencies quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,15 @@
 version: 2
 
-# Note: dependabot only supports daily/weekly/monthly intervals; there is no
-# quarterly option. Security updates are opened immediately regardless of
-# schedule and must be disabled separately in repo Settings > Security.
+# The Python (pip) lock files under requirements/ are generated and kept mutually
+# consistent by the pip-compile-based `upgrade-dependencies` workflow, so we do
+# NOT let Dependabot manage the pip ecosystem here: Dependabot bumps individual
+# pinned lines without a full resolver pass, which can produce internally
+# inconsistent lock files (e.g. pydantic pinned alongside a pydantic-core version
+# it does not allow). Only GitHub Actions are managed by Dependabot below.
+# Security updates are opened immediately regardless of schedule and must be
+# configured separately in repo Settings > Security.
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      day: "1"
-      time: "02:00"
-      timezone: "America/New_York"
-    open-pull-requests-limit: 2
-    groups:
-      major-updates:
-        update-types:
-          - "version-update:semver-major"
-      minor-and-patch-updates:
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -5,8 +5,8 @@ name: upgrade dependencies
 on:
   workflow_dispatch: # Allow running on-demand
   schedule:
-    # Runs every Monday at 8:00 UTC (4:00 Eastern)
-    - cron: '0 8 * * 1'
+    # Runs quarterly: at 8:00 UTC (4:00 Eastern) on the 1st of Jan, Apr, Jul, Oct
+    - cron: '0 8 1 1,4,7,10 *'
 
 jobs:
   upgrade:


### PR DESCRIPTION
## Summary

Follow-up to #1122, which had to be hand-fixed because Dependabot produced internally inconsistent pip lock files.

The `requirements/*.txt` lock files are already generated by the `upgrade-dependencies` workflow using `pip-compile --resolver=backtracking`, which keeps every pinned (direct **and** transitive) dependency mutually consistent. Dependabot's `pip` ecosystem manages the *same* files but bumps individual pinned lines **without** a full resolver pass, so it can emit locks that don't actually install — e.g. in #1122 it set `pydantic-core==2.47.0` next to `pydantic==2.13.4` (which pins `pydantic-core==2.46.4`), and `mpmath==1.4.1` next to `sympy==1.14.0` (needs `mpmath<1.4`), both `ResolutionImpossible`.

## Changes

- **`.github/dependabot.yml`** — remove the `pip` ecosystem block so Dependabot no longer edits the lock files; the pip-compile workflow is now the single source of truth. GitHub Actions updates are unchanged. (Security updates are unaffected — they're configured in repo Settings > Security, not here.)
- **`.github/workflows/upgrade-dependencies.yml`** — reduce the schedule from weekly (`0 8 * * 1`) to **quarterly** (`0 8 1 1,4,7,10 *`, i.e. 08:00 UTC on the 1st of Jan/Apr/Jul/Oct). The workflow can still be triggered on demand via `workflow_dispatch`.

Both files validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
